### PR TITLE
fix: Ordering by data in JSON columns.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,6 +2,10 @@
 
 Releases are handled by Semantic release. This document is for forcing and documenting any non-code changes.
 
+## 1.0.4
+
+- Upgrades postgrest-js dependency to fix ordering for JSON columns. (https://github.com/supabase/postgrest-js/pull/132)
+
 ## 1.0.2
 
 - Fixes link in readme for NPM.

--- a/package-lock.json
+++ b/package-lock.json
@@ -688,9 +688,9 @@
       }
     },
     "@supabase/postgrest-js": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-0.21.1.tgz",
-      "integrity": "sha512-KHM+cDaxI5iIXl8uXQPsxjRqZHRnltav4Yq8juehn3wkXxsZS01LT6E3zdGn401a/yZgiJJWAp0m31BAql27vg==",
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-0.21.2.tgz",
+      "integrity": "sha512-ww7aa4GHu788T2QxZlLiRfi+MHJ+EXbNurzTgaG/3nWmOEEy/gmNTLwgyHUAO92MRE2IrLiZyln3QJDZwGQwrw==",
       "requires": {
         "cross-fetch": "^3.0.6"
       }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@supabase/gotrue-js": "^1.7.1",
-    "@supabase/postgrest-js": "^0.21.1",
+    "@supabase/postgrest-js": "^0.21.2",
     "@supabase/realtime-js": "^1.0.6"
   },
   "devDependencies": {


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Bump postgrest-js dependency to pull in the order by JSON column data fix (https://github.com/supabase/postgrest-js/pull/132).
