### PR TITLE
feat: add type exports for client side use

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,7 @@
 import SupabaseClient from './SupabaseClient'
-import { SupabaseClientOptions } from './lib/types'
+import { SupabaseClientOptions, SupabaseRealtimePayload } from './lib/types'
+export * from '@supabase/gotrue-js'
+export * from '@supabase/realtime-js'
 
 /**
  * Creates a new Supabase Client.
@@ -12,4 +14,4 @@ const createClient = (
   return new SupabaseClient(supabaseUrl, supabaseKey, options)
 }
 
-export { createClient }
+export { createClient, SupabaseClient, SupabaseClientOptions, SupabaseRealtimePayload }


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature: #97 

## What is the current behavior?

The library does not export all types needed for use in client side TypeScript projects.

## What is the new behavior?

Export the additional types for use in client side projects.

## Additional context

Note: This PR cannot be merged until the gotrue-js PR is merged: https://github.com/supabase/gotrue-js/pull/29
