### PR TITLE
Add `"sideEffects": false` to pkg.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "main": "dist/main/index.js",
   "module": "dist/module/index.js",
   "types": "dist/main/index.d.ts",
+  "sideEffects": false,
   "repository": "supabase/supabase-js",
   "scripts": {
     "clean": "rimraf dist docs",


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature/fix

## What is the current behavior?

The package is not currently marked as side effect free so tree-shaking will be limited.

## What is the new behavior?

Tree-shaking can be done properly.

---

I didn't see anything that has side effects in the package, but if you know any then this should not be done