### PR TITLE
Added 'User' to the exports

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import SupabaseClient from './SupabaseClient'
 import { SupabaseClientOptions, SupabaseRealtimePayload } from './lib/types'
+import { User } from '@supabase/gotrue-js'
 export * from '@supabase/gotrue-js'
 export * from '@supabase/realtime-js'
 
@@ -14,4 +15,4 @@ const createClient = (
   return new SupabaseClient(supabaseUrl, supabaseKey, options)
 }
 
-export { createClient, SupabaseClient, SupabaseClientOptions, SupabaseRealtimePayload }
+export { createClient, SupabaseClient, SupabaseClientOptions, SupabaseRealtimePayload, User }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import SupabaseClient from './SupabaseClient'
 import { SupabaseClientOptions, SupabaseRealtimePayload } from './lib/types'
-import { User } from '@supabase/gotrue-js'
+import { User as AuthUser } from '@supabase/gotrue-js'
 export * from '@supabase/gotrue-js'
 export * from '@supabase/realtime-js'
 
@@ -15,4 +15,4 @@ const createClient = (
   return new SupabaseClient(supabaseUrl, supabaseKey, options)
 }
 
-export { createClient, SupabaseClient, SupabaseClientOptions, SupabaseRealtimePayload, User }
+export { createClient, SupabaseClient, SupabaseClientOptions, SupabaseRealtimePayload, AuthUser }


### PR DESCRIPTION
## What kind of change does this PR introduce?

In order to get the `User` type, I had to do a import like this

```
import { User } from '@supabase/gotrue-js/dist/main/lib/types'
```
so I thought it would be better to export `User` from supabase-js


## What is the current behavior?

`User` is not exported within supabase-js

## What is the new behavior?

`User` is exported as `AuthUser`. Developers should be able to import the `AuthUser` type like this:

```
import { AuthUser } from "supabase-js";
```