### PR TITLE
feat: add EventTypes as a Type

### DIFF
--- a/src/lib/SupabaseQueryBuilder.ts
+++ b/src/lib/SupabaseQueryBuilder.ts
@@ -1,7 +1,7 @@
 import { PostgrestQueryBuilder } from '@supabase/postgrest-js'
 import { SupabaseRealtimeClient } from './SupabaseRealtimeClient'
 import { RealtimeClient } from '@supabase/realtime-js'
-import { SupabaseRealtimePayload } from './types'
+import { SupabaseEventTypes, SupabaseRealtimePayload } from './types'
 
 export class SupabaseQueryBuilder<T> extends PostgrestQueryBuilder<T> {
   private _subscription: SupabaseRealtimeClient
@@ -33,7 +33,7 @@ export class SupabaseQueryBuilder<T> extends PostgrestQueryBuilder<T> {
    * @param callback A callback that will handle the payload that is sent whenever your database changes.
    */
   on(
-    event: 'INSERT' | 'UPDATE' | 'DELETE' | '*',
+    event: SupabaseEventTypes,
     callback: (payload: SupabaseRealtimePayload<T>) => void
   ): SupabaseRealtimeClient {
     if (!this._realtime.isConnected()) {

--- a/src/lib/SupabaseRealtimeClient.ts
+++ b/src/lib/SupabaseRealtimeClient.ts
@@ -1,5 +1,5 @@
 import { RealtimeSubscription, RealtimeClient, Transformers } from '@supabase/realtime-js'
-import { SupabaseRealtimePayload } from './types'
+import { SupabaseEventTypes, SupabaseRealtimePayload } from './types'
 
 export class SupabaseRealtimeClient {
   subscription: RealtimeSubscription
@@ -15,7 +15,7 @@ export class SupabaseRealtimeClient {
    * @param event The event
    * @param callback A callback function that is called whenever the event occurs.
    */
-  on(event: 'INSERT' | 'UPDATE' | 'DELETE' | '*', callback: Function) {
+  on(event: SupabaseEventTypes, callback: Function) {
     this.subscription.on(event, (payload: any) => {
       let enrichedPayload: SupabaseRealtimePayload<any> = {
         schema: payload.schema,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -35,3 +35,5 @@ export type SupabaseRealtimePayload<T> = {
   /** The previous record. Present for 'UPDATE' and 'DELETE' events. */
   old: T
 }
+
+export type SupabaseEventTypes = 'INSERT' | 'UPDATE' | 'DELETE' | '*'


### PR DESCRIPTION
## What kind of change does this PR introduce?

Add a new Type to avoid use duplicated code.

## What is the current behavior?

We're duplicating code for lack of specific data type.

## What is the new behavior?

Creating this new type, we can remove the duplicated code using the new created type.

## Additional context

JS is amazing, isn't?
