### PR TITLE
refactor: reducing the complexity of the SupabaseRealtimeClient and SupabaseClient classes

### DIFF
--- a/src/lib/SupabaseRealtimeClient.ts
+++ b/src/lib/SupabaseRealtimeClient.ts
@@ -15,19 +15,12 @@ export class SupabaseRealtimeClient {
       old: {},
     }
 
-    switch (payload.type) {
-      case 'INSERT':
-        records.new = Transformers.convertChangeData(payload.columns, payload.record)
-        break
+    if (payload.type === 'INSERT' || payload.type === 'UPDATE') {
+      records.new = Transformers.convertChangeData(payload.columns, payload.record)
+    }
 
-      case 'UPDATE':
-        records.new = Transformers.convertChangeData(payload.columns, payload.record)
-        records.old = Transformers.convertChangeData(payload.columns, payload.old_record)
-        break
-
-      case 'DELETE':
-        records.old = Transformers.convertChangeData(payload.columns, payload.old_record)
-        break
+    if (payload.type === 'UPDATE' || payload.type === 'DELETE') {
+      records.old = Transformers.convertChangeData(payload.columns, payload.old_record)
     }
 
     return records


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR will help us to reduce the complexity of the SupabaseRealtimeClient and SupabaseClient classes splitting our current code.

## What is the current behavior?

- SupabaseRealtimeClient -> getPayloadRecords method complexity is 10.
- SupabaseClient class complexity is 11.
  - SupabaseClient -> removeSubscription method complexity is 11.

## What is the new behavior?

SupabaseRealtimeClient -> getPayloadRecords method complexity will be 7.
- SupabaseClient class complexity will be 10.
  - SupabaseClient -> removeSubscription method complexity is 10.

## Additional context
