### PR TITLE
chore: update postgrest-js to include next major version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -688,9 +688,9 @@
       }
     },
     "@supabase/postgrest-js": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-0.25.0.tgz",
-      "integrity": "sha512-oYD/YruiUZxzzDkwSVQNmNqIDykZTp4jlG577qcpltAmKY6G3g2sFPES4Ig6Z4DYFgfyg7JleozjiaBu4ZcpqQ==",
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-0.26.1.tgz",
+      "integrity": "sha512-fD7K6S2bl8JkYqeeZ0hWBWaCz61ktqz2MA4jiugT9FiKITaMgnjekHUwA29KbPsiRRft0HW/bNDRPxrGy+3UNw==",
       "requires": {
         "cross-fetch": "^3.0.6"
       }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@supabase/gotrue-js": "^1.12.0",
-    "@supabase/postgrest-js": "^0.25.0",
+    "@supabase/postgrest-js": "^0.26.1",
     "@supabase/realtime-js": "^1.0.6"
   },
   "devDependencies": {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Update postgrest-js lib to the latest major version.

## Additional context

Included releases:
https://github.com/supabase/postgrest-js/releases/tag/v0.26.1
https://github.com/supabase/postgrest-js/releases/tag/v0.26.0

