### PR TITLE
Add additional steps to setup storage example

### DIFF
--- a/example/next-storage/README.md
+++ b/example/next-storage/README.md
@@ -2,6 +2,10 @@
 
 - Create a file `.env.local`
 - Add a `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_KEY`
+- Visit the project Supabase dashboard, Storage section
+  - Create a bucket named `avatars`
+  - Create a policy to make objects readable by everyone
+  - Create a policy to make objects writable by everyone
 - Run `npm run dev`
 
 ## Database schema


### PR DESCRIPTION
## What kind of change does this PR introduce?

I add a new step in the `next-storage` example readme to let users know they need to create a storage bucket and set the correct policies before they can run the example.
