### PR TITLE
Added storage policies to readme.md of next-storage example app

### DIFF
--- a/example/next-storage/README.md
+++ b/example/next-storage/README.md
@@ -31,4 +31,10 @@ begin;
 commit;
 
 alter publication supabase_realtime add table profiles;
+
+-- Set up Storage!
+insert into storage.buckets (id, name) values ('avatars', 'avatars');
+create policy "Avatar images are publicly accessible." on storage.objects for select using (true);
+create policy "Inserted avatar file name starts with the user's id." on storage.objects for insert with check (auth.uid()::text = substring(name, 1, 36));
+create policy "Updated avatar file name starts with the user's id." on storage.objects for update with check (auth.uid()::text = substring(name, 1, 36));
 ```

--- a/example/next-storage/components/Account.tsx
+++ b/example/next-storage/components/Account.tsx
@@ -42,7 +42,7 @@ export default function Account({ session }: { session: AuthSession }) {
       }
 
       let { error: updateError } = await supabase.from('profiles').upsert({
-        id: user.id,
+        id: user!.id,
         avatar_url: filePath,
       })
 
@@ -73,7 +73,7 @@ export default function Account({ session }: { session: AuthSession }) {
       let { data, error } = await supabase
         .from('profiles')
         .select(`username, website, avatar_url`)
-        .eq('id', user.id)
+        .eq('id', user!.id)
         .single()
 
       if (error) {
@@ -94,7 +94,7 @@ export default function Account({ session }: { session: AuthSession }) {
       const user = supabase.auth.user()
 
       const updates = {
-        id: user.id,
+        id: user!.id,
         username,
         website,
         updated_at: new Date(),

--- a/example/next-storage/package.json
+++ b/example/next-storage/package.json
@@ -14,6 +14,7 @@
     "react-dom": "17.0.1"
   },
   "devDependencies": {
-    "@types/react": "^17.0.3"
+    "@types/react": "^17.0.3",
+    "typescript": "^4.2.3"
   }
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Added sample storage policies to the next-storage example app's readme.md

## What is the current behavior?

There are no example policies to get started with. 

## What is the new behavior?

There are SQLs that users can run to get up and running with Supabase Storage!

## Additional context

I added typescript dependencies to the project, because it was missing, but let me know if this was unnecessary. 
