### PR TITLE
refactor: SupabaseStorageClient

### DIFF
--- a/example/next-storage/components/Account.tsx
+++ b/example/next-storage/components/Account.tsx
@@ -39,9 +39,11 @@ export default function Account({
       const file = event.target.files[0]
       const fileExt = file.name.split('.').pop()
       const fileName = `${session?.user.id}${Math.random()}.${fileExt}`
-      const filePath = `${DEFAULT_AVATARS_BUCKET}/${fileName}`
+      const filePath = `${fileName}`
 
-      let { error: uploadError } = await supabase.storage.uploadFile(filePath, file)
+      let { error: uploadError } = await supabase.storage
+        .from(DEFAULT_AVATARS_BUCKET)
+        .uploadFile(filePath, file)
 
       if (uploadError) {
         throw uploadError

--- a/example/next-storage/components/Account.tsx
+++ b/example/next-storage/components/Account.tsx
@@ -43,7 +43,7 @@ export default function Account({
 
       let { error: uploadError } = await supabase.storage
         .from(DEFAULT_AVATARS_BUCKET)
-        .uploadFile(filePath, file)
+        .upload(filePath, file)
 
       if (uploadError) {
         throw uploadError

--- a/example/next-storage/components/Avatar.tsx
+++ b/example/next-storage/components/Avatar.tsx
@@ -11,7 +11,7 @@ export default function Avatar({ url, size }: { url: string | null; size: number
 
   async function downloadImage(path: string) {
     try {
-      const { data, error } = await supabase.storage.from(DEFAULT_AVATARS_BUCKET).downloadFile(path)
+      const { data, error } = await supabase.storage.from(DEFAULT_AVATARS_BUCKET).download(path)
       if (error) {
         throw error
       }

--- a/example/next-storage/components/Avatar.tsx
+++ b/example/next-storage/components/Avatar.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { supabase } from '../lib/api'
+import { DEFAULT_AVATARS_BUCKET } from '../lib/constants'
 
 export default function Avatar({ url, size }: { url: string | null; size: number }) {
   const [avatarUrl, setAvatarUrl] = useState<string | null>(null)
@@ -10,7 +11,7 @@ export default function Avatar({ url, size }: { url: string | null; size: number
 
   async function downloadImage(path: string) {
     try {
-      const { data, error } = await supabase.storage.downloadFile(path)
+      const { data, error } = await supabase.storage.from(DEFAULT_AVATARS_BUCKET).downloadFile(path)
       if (error) {
         throw error
       }

--- a/src/SupabaseClient.ts
+++ b/src/SupabaseClient.ts
@@ -71,7 +71,7 @@ export default class SupabaseClient {
    * Supabase Storage allows you to manage user-generated content, such as photos or videos.
    */
   get storage() {
-    return this._initStorageClient()
+    return new SupabaseStorageClient(this.storageUrl, this._getAuthHeaders())
   }
 
   /**
@@ -165,10 +165,6 @@ export default class SupabaseClient {
       headers: this._getAuthHeaders(),
       schema: this.schema,
     })
-  }
-
-  private _initStorageClient() {
-    return new SupabaseStorageClient(this.storageUrl, this._getAuthHeaders())
   }
 
   private _getAuthHeaders(): { [key: string]: string } {

--- a/src/lib/SupabaseStorageClient.ts
+++ b/src/lib/SupabaseStorageClient.ts
@@ -1,7 +1,66 @@
-import { StorageApi } from './storage'
+import { FileOptions, StorageApi } from './storage'
 
-export class SupabaseStorageClient extends StorageApi {
+export class SupabaseStorageClient {
+  protected url: string
+  protected headers: { [key: string]: string }
+  protected api: StorageApi
+
   constructor(url: string, headers: { [key: string]: string } = {}) {
-    super(url, headers)
+    this.url = url
+    this.headers = headers
+
+    this.api = new StorageApi(url, headers)
+  }
+
+  /**
+   * Perform file operation in a bucket.
+   *
+   * @param id The bucket id to operate on.
+   */
+  from(id: string): SupabaseStorageClient {
+    this.api = new StorageApi(this.url, this.headers, id)
+    return this
+  }
+
+  /**
+   * Uploads a file to an existing bucket.
+   *
+   * @param path The file path including the path and file name. For example `folder/image.png`.
+   * @param file The File object to be stored in the bucket.
+   * @param fileOptions HTTP headers. For example `cacheControl`
+   */
+  uploadFile(path: string, file: File, fileOptions?: FileOptions) {
+    return this.api.uploadFile(path, file, fileOptions)
+  }
+
+  /**
+   * Replaces an existing file at the specified path with a new one.
+   *
+   * @param path The file path including the path and file name. For example `folder/image.png`.
+   * @param file The file object to be stored in the bucket.
+   * @param fileOptions HTTP headers. For example `cacheControl`
+   */
+  updateFile(path: string, file: File, fileOptions?: FileOptions) {
+    return this.api.updateFile(path, file, fileOptions)
+  }
+
+  /**
+   * Moves an existing file, optionally renaming it at the same time.
+   *
+   * @param bucketId The bucket which contains the file.
+   * @param fromPath The original file path, including the current file name. For example `folder/image.png`.
+   * @param toPath The new file path, including the new file name. For example `folder/image-copy.png`.
+   */
+  moveFile(fromPath: string, toPath: string) {
+    return this.api.moveFile(fromPath, toPath)
+  }
+
+  /**
+   * Downloads a file.
+   *
+   * @param path The file path to be downloaded, including the path and file name. For example `folder/image.png`.
+   */
+  downloadFile(path: string) {
+    return this.api.downloadFile(path)
   }
 }

--- a/src/lib/SupabaseStorageClient.ts
+++ b/src/lib/SupabaseStorageClient.ts
@@ -1,4 +1,4 @@
-import { FileOptions, StorageBucketApi, StorageFileApi } from './storage'
+import { StorageBucketApi, StorageFileApi } from './storage'
 
 export class SupabaseStorageClient extends StorageBucketApi {
   constructor(url: string, headers: { [key: string]: string } = {}) {

--- a/src/lib/SupabaseStorageClient.ts
+++ b/src/lib/SupabaseStorageClient.ts
@@ -1,15 +1,8 @@
-import { FileOptions, StorageApi } from './storage'
+import { FileOptions, StorageBucketApi, StorageFileApi } from './storage'
 
-export class SupabaseStorageClient {
-  protected url: string
-  protected headers: { [key: string]: string }
-  protected api: StorageApi
-
+export class SupabaseStorageClient extends StorageBucketApi {
   constructor(url: string, headers: { [key: string]: string } = {}) {
-    this.url = url
-    this.headers = headers
-
-    this.api = new StorageApi(url, headers)
+    super(url, headers)
   }
 
   /**
@@ -17,50 +10,7 @@ export class SupabaseStorageClient {
    *
    * @param id The bucket id to operate on.
    */
-  from(id: string): SupabaseStorageClient {
-    this.api = new StorageApi(this.url, this.headers, id)
-    return this
-  }
-
-  /**
-   * Uploads a file to an existing bucket.
-   *
-   * @param path The file path including the path and file name. For example `folder/image.png`.
-   * @param file The File object to be stored in the bucket.
-   * @param fileOptions HTTP headers. For example `cacheControl`
-   */
-  uploadFile(path: string, file: File, fileOptions?: FileOptions) {
-    return this.api.uploadFile(path, file, fileOptions)
-  }
-
-  /**
-   * Replaces an existing file at the specified path with a new one.
-   *
-   * @param path The file path including the path and file name. For example `folder/image.png`.
-   * @param file The file object to be stored in the bucket.
-   * @param fileOptions HTTP headers. For example `cacheControl`
-   */
-  updateFile(path: string, file: File, fileOptions?: FileOptions) {
-    return this.api.updateFile(path, file, fileOptions)
-  }
-
-  /**
-   * Moves an existing file, optionally renaming it at the same time.
-   *
-   * @param bucketId The bucket which contains the file.
-   * @param fromPath The original file path, including the current file name. For example `folder/image.png`.
-   * @param toPath The new file path, including the new file name. For example `folder/image-copy.png`.
-   */
-  moveFile(fromPath: string, toPath: string) {
-    return this.api.moveFile(fromPath, toPath)
-  }
-
-  /**
-   * Downloads a file.
-   *
-   * @param path The file path to be downloaded, including the path and file name. For example `folder/image.png`.
-   */
-  downloadFile(path: string) {
-    return this.api.downloadFile(path)
+  from(id: string): StorageFileApi {
+    return new StorageFileApi(this.url, this.headers, id)
   }
 }

--- a/src/lib/storage/StorageBucketApi.ts
+++ b/src/lib/storage/StorageBucketApi.ts
@@ -1,0 +1,85 @@
+import { get, post, remove } from './fetch'
+import { Bucket } from './types'
+
+export class StorageBucketApi {
+  protected url: string
+  protected headers: { [key: string]: string }
+
+  constructor(url: string, headers: { [key: string]: string } = {}) {
+    this.url = url
+    this.headers = headers
+  }
+
+  /**
+   * Retrieves the details of all Storage buckets within an existing product.
+   */
+  async listBuckets(): Promise<{ data: Bucket[] | null; error: Error | null }> {
+    try {
+      const data = await get(`${this.url}/bucket`, { headers: this.headers })
+      return { data, error: null }
+    } catch (error) {
+      return { data: null, error }
+    }
+  }
+
+  /**
+   * Retrieves the details of an existing Storage bucket.
+   *
+   * @param id The unique identifier of the bucket you would like to retrieve.
+   */
+  async getBucket(id: string): Promise<{ data: Bucket | null; error: Error | null }> {
+    try {
+      const data = await get(`${this.url}/bucket/${id}`, { headers: this.headers })
+      return { data, error: null }
+    } catch (error) {
+      return { data: null, error }
+    }
+  }
+
+  /**
+   * Retrieves the details of an existing Storage bucket.
+   *
+   * @param id A unique identifier for the bucket you are creating.
+   */
+  async createBucket(id: string): Promise<{ data: Bucket | null; error: Error | null }> {
+    try {
+      const data = await post(`${this.url}/bucket`, { id, name: id }, { headers: this.headers })
+      return { data, error: null }
+    } catch (error) {
+      return { data: null, error }
+    }
+  }
+
+  /**
+   * Removes all objects inside a single bucket.
+   *
+   * @param id The unique identifier of the bucket you would like to empty.
+   */
+  async emptyBucket(
+    id: string
+  ): Promise<{ data: { message: string } | null; error: Error | null }> {
+    try {
+      const data = await post(`${this.url}/bucket/${id}/empty`, {}, { headers: this.headers })
+      return { data, error: null }
+    } catch (error) {
+      return { data: null, error }
+    }
+  }
+
+  /**
+   * Deletes an existing bucket. A bucket can't be deleted with existing objects inside it.
+   * You must first `empty()` the bucket.
+   *
+   * @param id The unique identifier of the bucket you would like to delete.
+   */
+  async deleteBucket(
+    id: string
+  ): Promise<{ data: { message: string } | null; error: Error | null }> {
+    try {
+      const data = await remove(`${this.url}/bucket/${id}`, {}, { headers: this.headers })
+      return { data, error: null }
+    } catch (error) {
+      return { data: null, error }
+    }
+  }
+}

--- a/src/lib/storage/StorageFileApi.ts
+++ b/src/lib/storage/StorageFileApi.ts
@@ -1,6 +1,6 @@
-import { get, post, put, remove } from './fetch'
+import { get, post, remove } from './fetch'
 import { isBrowser } from './helpers'
-import { Bucket, FileObject, FileOptions, Metadata, SearchOptions } from './types'
+import { FileObject, FileOptions, Metadata, SearchOptions } from './types'
 
 const DEFAULT_SEARCH_OPTIONS = {
   limit: 0,
@@ -15,7 +15,7 @@ const DEFAULT_FILE_OPTIONS: FileOptions = {
   cacheControl: '3600',
 }
 
-export class StorageApi {
+export class StorageFileApi {
   protected url: string
   protected headers: { [key: string]: string }
   protected bucketId?: string
@@ -24,79 +24,6 @@ export class StorageApi {
     this.url = url
     this.headers = headers
     this.bucketId = bucketId
-  }
-
-  /**
-   * Retrieves the details of all Storage buckets within an existing product.
-   */
-  async listBuckets(): Promise<{ data: Bucket[] | null; error: Error | null }> {
-    try {
-      const data = await get(`${this.url}/bucket`, { headers: this.headers })
-      return { data, error: null }
-    } catch (error) {
-      return { data: null, error }
-    }
-  }
-
-  /**
-   * Retrieves the details of an existing Storage bucket.
-   *
-   * @param id The unique identifier of the bucket you would like to retrieve.
-   */
-  async getBucket(id: string): Promise<{ data: Bucket | null; error: Error | null }> {
-    try {
-      const data = await get(`${this.url}/bucket/${id}`, { headers: this.headers })
-      return { data, error: null }
-    } catch (error) {
-      return { data: null, error }
-    }
-  }
-
-  /**
-   * Retrieves the details of an existing Storage bucket.
-   *
-   * @param id A unique identifier for the bucket you are creating.
-   */
-  async createBucket(id: string): Promise<{ data: Bucket | null; error: Error | null }> {
-    try {
-      const data = await post(`${this.url}/bucket`, { id, name: id }, { headers: this.headers })
-      return { data, error: null }
-    } catch (error) {
-      return { data: null, error }
-    }
-  }
-
-  /**
-   * Removes all objects inside a single bucket.
-   *
-   * @param id The unique identifier of the bucket you would like to empty.
-   */
-  async emptyBucket(
-    id: string
-  ): Promise<{ data: { message: string } | null; error: Error | null }> {
-    try {
-      const data = await post(`${this.url}/bucket/${id}/empty`, {}, { headers: this.headers })
-      return { data, error: null }
-    } catch (error) {
-      return { data: null, error }
-    }
-  }
-
-  /**
-   * Deletes an existing bucket. A bucket can't be deleted with existing objects inside it.
-   * You must first `empty()` the bucket.
-   *
-   * @param id The unique identifier of the bucket you would like to delete.
-   */
-  async deleteBucket(
-    id: string
-  ): Promise<{ data: { message: string } | null; error: Error | null }> {
-    try {
-      const data = await remove(`${this.url}/bucket/${id}`, {}, { headers: this.headers })
-      return { data, error: null }
-    } catch (error) {
-      return { data: null, error }
-    }
   }
 
   /**

--- a/src/lib/storage/StorageFileApi.ts
+++ b/src/lib/storage/StorageFileApi.ts
@@ -241,6 +241,6 @@ export class StorageFileApi {
   }
 
   _getFinalPath(path: string) {
-    return `${this.bucketId}\\${path}`
+    return `${this.bucketId}/${path}`
   }
 }

--- a/src/lib/storage/StorageFileApi.ts
+++ b/src/lib/storage/StorageFileApi.ts
@@ -33,7 +33,7 @@ export class StorageFileApi {
    * @param file The File object to be stored in the bucket.
    * @param fileOptions HTTP headers. For example `cacheControl`
    */
-  async uploadFile(
+  async upload(
     path: string,
     file: File,
     fileOptions?: FileOptions
@@ -73,7 +73,7 @@ export class StorageFileApi {
    * @param file The file object to be stored in the bucket.
    * @param fileOptions HTTP headers. For example `cacheControl`
    */
-  async updateFile(
+  async update(
     path: string,
     file: File,
     fileOptions?: FileOptions
@@ -112,7 +112,7 @@ export class StorageFileApi {
    * @param fromPath The original file path, including the current file name. For example `folder/image.png`.
    * @param toPath The new file path, including the new file name. For example `folder/image-copy.png`.
    */
-  async moveFile(
+  async move(
     fromPath: string,
     toPath: string
   ): Promise<{ data: { message: string } | null; error: Error | null }> {
@@ -158,7 +158,7 @@ export class StorageFileApi {
    *
    * @param path The file path to be downloaded, including the path and file name. For example `folder/image.png`.
    */
-  async downloadFile(path: string): Promise<{ data: Blob | null; error: Error | null }> {
+  async download(path: string): Promise<{ data: Blob | null; error: Error | null }> {
     try {
       const _path = this._getFinalPath(path)
       const res = await get(`${this.url}/object/${_path}`, {
@@ -173,28 +173,11 @@ export class StorageFileApi {
   }
 
   /**
-   * Deletes a file.
-   *
-   * @param path The file path to be deleted, including the path and file name. For example `folder/image.png`.
-   */
-  async deleteFile(
-    path: string
-  ): Promise<{ data: { message: string } | null; error: Error | null }> {
-    try {
-      const _path = this._getFinalPath(path)
-      const data = await remove(`${this.url}/object/${_path}`, {}, { headers: this.headers })
-      return { data, error: null }
-    } catch (error) {
-      return { data: null, error }
-    }
-  }
-
-  /**
-   * Deletes multiple files within the same bucket
+   * Deletes files within the same bucket
    *
    * @param paths An array of files to be deletes, including the path and file name. For example [`folder/image.png`].
    */
-  async deleteFiles(paths: string[]): Promise<{ data: FileObject[] | null; error: Error | null }> {
+  async remove(paths: string[]): Promise<{ data: FileObject[] | null; error: Error | null }> {
     try {
       const data = await remove(
         `${this.url}/object/${this.bucketId}`,
@@ -242,7 +225,7 @@ export class StorageFileApi {
    * @param path The folder path.
    * @param options Search options, including `limit`, `offset`, and `sortBy`.
    */
-  async listFiles(
+  async list(
     path?: string,
     options?: SearchOptions
   ): Promise<{ data: FileObject[] | null; error: Error | null }> {

--- a/src/lib/storage/StorageFileApi.ts
+++ b/src/lib/storage/StorageFileApi.ts
@@ -181,7 +181,8 @@ export class StorageFileApi {
     path: string
   ): Promise<{ data: { message: string } | null; error: Error | null }> {
     try {
-      const data = await remove(`${this.url}/object/${path}`, {}, { headers: this.headers })
+      const _path = this._getFinalPath(path)
+      const data = await remove(`${this.url}/object/${_path}`, {}, { headers: this.headers })
       return { data, error: null }
     } catch (error) {
       return { data: null, error }
@@ -191,16 +192,12 @@ export class StorageFileApi {
   /**
    * Deletes multiple files within the same bucket
    *
-   * @param bucketId The bucket which contains the files.
    * @param paths An array of files to be deletes, including the path and file name. For example [`folder/image.png`].
    */
-  async deleteFiles(
-    bucketId: string,
-    paths: string[]
-  ): Promise<{ data: FileObject[] | null; error: Error | null }> {
+  async deleteFiles(paths: string[]): Promise<{ data: FileObject[] | null; error: Error | null }> {
     try {
       const data = await remove(
-        `${this.url}/object/${bucketId}`,
+        `${this.url}/object/${this.bucketId}`,
         { prefixes: paths },
         { headers: this.headers }
       )
@@ -242,18 +239,16 @@ export class StorageFileApi {
 
   /**
    * Lists all the files within a bucket.
-   * @param bucketId The bucket which contains the files.
    * @param path The folder path.
    * @param options Search options, including `limit`, `offset`, and `sortBy`.
    */
   async listFiles(
-    bucketId: string,
     path?: string,
     options?: SearchOptions
   ): Promise<{ data: FileObject[] | null; error: Error | null }> {
     try {
       const body = { ...DEFAULT_SEARCH_OPTIONS, ...options, prefix: path || '' }
-      const data = await post(`${this.url}/object/list/${bucketId}`, body, {
+      const data = await post(`${this.url}/object/list/${this.bucketId}`, body, {
         headers: this.headers,
       })
       return { data, error: null }

--- a/src/lib/storage/index.ts
+++ b/src/lib/storage/index.ts
@@ -1,2 +1,3 @@
-export * from './StorageApi'
+export * from './StorageBucketApi'
+export * from './StorageFileApi'
 export * from './types'

--- a/test/storageApi.test.ts
+++ b/test/storageApi.test.ts
@@ -1,10 +1,10 @@
-import { StorageApi } from '../src/lib/storage'
+import { StorageBucketApi } from '../src/lib/storage'
 
 // TODO: need to setup storage-api server for this test
 const URL = 'http://0.0.0.0:5000'
 const KEY = 'some.fake.key'
 
-const storage = new StorageApi(URL, { Authorization: `Bearer ${KEY}` })
+const storage = new StorageBucketApi(URL, { Authorization: `Bearer ${KEY}` })
 const newBucketName = `my-new-bucket-${Date.now()}`
 let createdBucketId = ''
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Separating `StorageBucketApi` and `StorageFileApi`, so that we can call storage api with this syntax

```
supabase.storage.from('avatars').downloadFile('avatar1.png')
```

