### PR TITLE
fix: change default limits for listing objects to 100

### DIFF
--- a/src/lib/storage/StorageFileApi.ts
+++ b/src/lib/storage/StorageFileApi.ts
@@ -1,9 +1,9 @@
 import { get, post, remove } from './fetch'
 import { isBrowser } from './helpers'
-import { FileObject, FileOptions, Metadata, SearchOptions } from './types'
+import { FileObject, FileOptions, SearchOptions } from './types'
 
 const DEFAULT_SEARCH_OPTIONS = {
-  limit: 0,
+  limit: 100,
   offset: 0,
   sortBy: {
     column: 'name',


### PR DESCRIPTION
this mirrors the default limit in the backend

Fixes issue reported at https://github.com/supabase/supabase/discussions/996