### PR TITLE
feat: updates createSignedURL to return full URL

### DIFF
--- a/src/lib/storage/StorageFileApi.ts
+++ b/src/lib/storage/StorageFileApi.ts
@@ -145,8 +145,7 @@ export class StorageFileApi {
         { expiresIn },
         { headers: this.headers }
       )
-      const signedUrl = `${this.url}${data.signedUrl}`
-      data = { ...data, signedUrl }
+      data = { signedURL: `${this.url}${data.signedURL}` }
       return { data, error: null }
     } catch (error) {
       return { data: null, error }


### PR DESCRIPTION
fixes https://github.com/supabase/supabase-js/issues/148

Previous return value for `createSignedURL`
```
{
  "data": {
    "signedURL": "/object/sign/test/test.png?token=blahblahblah",
    "signedUrl": "https://example.supabase.co/storage/v1undefined",
    "error": null
  }
}
```

New return value
```
{
  "data": {
    "signedURL": "https://example.supabase.co/storage/v1/object/sign/test/test.png?token=blahblahblah",
    "error": null
  }
}
```