### PR TITLE
Integrate AbortController signals to storage fetch methods for APIs

### DIFF
--- a/src/lib/storage/StorageFileApi.ts
+++ b/src/lib/storage/StorageFileApi.ts
@@ -223,6 +223,7 @@ export class StorageFileApi {
    * Lists all the files within a bucket.
    * @param path The folder path.
    * @param options Search options, including `limit`, `offset`, and `sortBy`.
+   * @param parameters Fetch parameters, currently only supports `signal`, which is an AbortController's signal
    */
   async list(
     path?: string,

--- a/src/lib/storage/StorageFileApi.ts
+++ b/src/lib/storage/StorageFileApi.ts
@@ -226,13 +226,17 @@ export class StorageFileApi {
    */
   async list(
     path?: string,
-    options?: SearchOptions
+    options?: SearchOptions,
+    signal?: AbortSignal
   ): Promise<{ data: FileObject[] | null; error: Error | null }> {
     try {
       const body = { ...DEFAULT_SEARCH_OPTIONS, ...options, prefix: path || '' }
-      const data = await post(`${this.url}/object/list/${this.bucketId}`, body, {
-        headers: this.headers,
-      })
+      const data = await post(
+        `${this.url}/object/list/${this.bucketId}`,
+        body,
+        { headers: this.headers },
+        signal
+      )
       return { data, error: null }
     } catch (error) {
       return { data: null, error }

--- a/src/lib/storage/StorageFileApi.ts
+++ b/src/lib/storage/StorageFileApi.ts
@@ -1,4 +1,4 @@
-import { get, post, remove } from './fetch'
+import { FetchParameters, get, post, remove } from './fetch'
 import { isBrowser } from './helpers'
 import { FileObject, FileOptions, SearchOptions } from './types'
 
@@ -227,7 +227,7 @@ export class StorageFileApi {
   async list(
     path?: string,
     options?: SearchOptions,
-    signal?: AbortSignal
+    parameters?: FetchParameters
   ): Promise<{ data: FileObject[] | null; error: Error | null }> {
     try {
       const body = { ...DEFAULT_SEARCH_OPTIONS, ...options, prefix: path || '' }
@@ -235,7 +235,7 @@ export class StorageFileApi {
         `${this.url}/object/list/${this.bucketId}`,
         body,
         { headers: this.headers },
-        signal
+        parameters
       )
       return { data, error: null }
     } catch (error) {

--- a/src/lib/storage/fetch.ts
+++ b/src/lib/storage/fetch.ts
@@ -7,6 +7,10 @@ export interface FetchOptions {
   noResolveJson?: boolean
 }
 
+export interface FetchParameters {
+  signal?: AbortSignal
+}
+
 export type RequestMethodType = 'GET' | 'POST' | 'PUT' | 'DELETE'
 
 const _getErrorMessage = (err: any): string =>
@@ -27,7 +31,7 @@ const handleError = (error: any, reject: any) => {
 const _getRequestParams = (
   method: RequestMethodType,
   options?: FetchOptions,
-  signal?: AbortSignal,
+  parameters?: FetchParameters,
   body?: object
 ) => {
   const params: { [k: string]: any } = { method, headers: options?.headers || {} }
@@ -39,22 +43,18 @@ const _getRequestParams = (
   params.headers = { 'Content-Type': 'application/json', ...options?.headers }
   params.body = JSON.stringify(body)
 
-  if (signal) {
-    params.signal = signal
-  }
-
-  return params
+  return { ...params, ...parameters }
 }
 
 async function _handleRequest(
   method: RequestMethodType,
   url: string,
   options?: FetchOptions,
-  signal?: AbortSignal,
+  parameters?: FetchParameters,
   body?: object
 ): Promise<any> {
   return new Promise((resolve, reject) => {
-    fetch(url, _getRequestParams(method, options, signal, body))
+    fetch(url, _getRequestParams(method, options, parameters, body))
       .then((result) => {
         if (!result.ok) throw result
         if (options?.noResolveJson) return resolve(result)
@@ -65,33 +65,37 @@ async function _handleRequest(
   })
 }
 
-export async function get(url: string, options?: FetchOptions, signal?: AbortSignal): Promise<any> {
-  return _handleRequest('GET', url, options, signal)
+export async function get(
+  url: string,
+  options?: FetchOptions,
+  parameters?: FetchParameters
+): Promise<any> {
+  return _handleRequest('GET', url, options, parameters)
 }
 
 export async function post(
   url: string,
   body: object,
   options?: FetchOptions,
-  signal?: AbortSignal
+  parameters?: FetchParameters
 ): Promise<any> {
-  return _handleRequest('POST', url, options, signal, body)
+  return _handleRequest('POST', url, options, parameters, body)
 }
 
 export async function put(
   url: string,
   body: object,
   options?: FetchOptions,
-  signal?: AbortSignal
+  parameters?: FetchParameters
 ): Promise<any> {
-  return _handleRequest('PUT', url, options, signal, body)
+  return _handleRequest('PUT', url, options, parameters, body)
 }
 
 export async function remove(
   url: string,
   body: object,
   options?: FetchOptions,
-  signal?: AbortSignal
+  parameters?: FetchParameters
 ): Promise<any> {
-  return _handleRequest('DELETE', url, options, signal, body)
+  return _handleRequest('DELETE', url, options, parameters, body)
 }

--- a/src/lib/storage/fetch.ts
+++ b/src/lib/storage/fetch.ts
@@ -24,7 +24,12 @@ const handleError = (error: any, reject: any) => {
   })
 }
 
-const _getRequestParams = (method: RequestMethodType, options?: FetchOptions, body?: object) => {
+const _getRequestParams = (
+  method: RequestMethodType,
+  options?: FetchOptions,
+  signal?: AbortSignal,
+  body?: object
+) => {
   const params: { [k: string]: any } = { method, headers: options?.headers || {} }
 
   if (method === 'GET') {
@@ -34,6 +39,10 @@ const _getRequestParams = (method: RequestMethodType, options?: FetchOptions, bo
   params.headers = { 'Content-Type': 'application/json', ...options?.headers }
   params.body = JSON.stringify(body)
 
+  if (signal) {
+    params.signal = signal
+  }
+
   return params
 }
 
@@ -41,10 +50,11 @@ async function _handleRequest(
   method: RequestMethodType,
   url: string,
   options?: FetchOptions,
+  signal?: AbortSignal,
   body?: object
 ): Promise<any> {
   return new Promise((resolve, reject) => {
-    fetch(url, _getRequestParams(method, options, body))
+    fetch(url, _getRequestParams(method, options, signal, body))
       .then((result) => {
         if (!result.ok) throw result
         if (options?.noResolveJson) return resolve(result)
@@ -55,18 +65,33 @@ async function _handleRequest(
   })
 }
 
-export async function get(url: string, options?: FetchOptions): Promise<any> {
-  return _handleRequest('GET', url, options)
+export async function get(url: string, options?: FetchOptions, signal?: AbortSignal): Promise<any> {
+  return _handleRequest('GET', url, options, signal)
 }
 
-export async function post(url: string, body: object, options?: FetchOptions): Promise<any> {
-  return _handleRequest('POST', url, options, body)
+export async function post(
+  url: string,
+  body: object,
+  options?: FetchOptions,
+  signal?: AbortSignal
+): Promise<any> {
+  return _handleRequest('POST', url, options, signal, body)
 }
 
-export async function put(url: string, body: object, options?: FetchOptions): Promise<any> {
-  return _handleRequest('PUT', url, options, body)
+export async function put(
+  url: string,
+  body: object,
+  options?: FetchOptions,
+  signal?: AbortSignal
+): Promise<any> {
+  return _handleRequest('PUT', url, options, signal, body)
 }
 
-export async function remove(url: string, body: object, options?: FetchOptions): Promise<any> {
-  return _handleRequest('DELETE', url, options, body)
+export async function remove(
+  url: string,
+  body: object,
+  options?: FetchOptions,
+  signal?: AbortSignal
+): Promise<any> {
+  return _handleRequest('DELETE', url, options, signal, body)
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Integrate AbortController signals to storage`fetch` methods (GET, POST, PUT, REMOVE)
- Allow `list` endpoint to accept a signal parameter

Some context: 
An initial optimization I added on the storage UI when we were directly calling the endpoints via the fetch method was to add an [`AbortController`](https://developer.mozilla.org/en-US/docs/Web/API/AbortController), so that FE can cancel API calls if they have not completed.

This is particularly useful such that if the user opens a folder (which triggers a POST request to list the items in a bucket by a path), but then opens another folder immediately while the previous POST request is still in progress, the previous POST request will be cancelled and the latest POST request  will be taken instead. With this, the UI won't have any flashing of the previously selected folder since the async POST requests are cancelled and not "queued".

I'm midway refactoring the storage UI to use the client library methods instead but would like to bring this behaviour into the client library as well as I think it might be really useful especially for calls that might be long running, and might possibly be useful in other parts of the library as well.

## Example usage from the client

The client will maintain a context of the `AbortController` as such:
```
let controller = new AbortController()
```

And just pass an AbortSignal to the client library. Let's say the client has a function that invokes the `list` method from the client library, it can do something like this

```
const fetchBucketContents = async () => {
  // Discard any signal that might be present
  controller.abort() // Once the signal is aborted, the controller is "discarded"
  controller = new AbortController() // Hence we create a new one to replace

  const { data, error } = await supabase.storage.from('bucket').list('path', {}, controller.signal)
}
```

Note that calling `controller.abort()` just cancels the API call which it's signal was associated with. In that sense, managing the context of the signals on the client side is an important consideration. e.g If we have 2 functions, one that lists items of a bucket and the other is updating an item:

```
const fetchBucketContents = async () => {
  controller.abort()
  controller = new AbortController()
  const { data, error } = await supabase.storage.from('bucket').list(path, {}, controller.signal)
}

const updateItem = async() => {
  controller.abort()
  controller = new AbortController()
  const { data, error } = await supabase.storage.from('bucket').update(path, file, controller.signal)
}
```

Calling these functions successively in any order will cancel the first request which may be unintended.

Lemme know if anything can be improved!

## Additional screenshots

Here's a screengrab to visualize the usage of abort controllers - I've deliberately throttled my network to make it more obvious

https://user-images.githubusercontent.com/19742402/114227479-a282c780-99a7-11eb-84f8-901b594b40a6.mov

