### PR TITLE
fix: types for create signed URL; copy it as a prop outside

### DIFF
--- a/src/lib/storage/StorageFileApi.ts
+++ b/src/lib/storage/StorageFileApi.ts
@@ -137,7 +137,11 @@ export class StorageFileApi {
   async createSignedUrl(
     path: string,
     expiresIn: number
-  ): Promise<{ data: { signedUrl: string } | null; error: Error | null }> {
+  ): Promise<{
+    data: { signedURL: string } | null
+    error: Error | null
+    signedURL: string | null
+  }> {
     try {
       const _path = this._getFinalPath(path)
       let data = await post(
@@ -145,10 +149,11 @@ export class StorageFileApi {
         { expiresIn },
         { headers: this.headers }
       )
-      data = { signedURL: `${this.url}${data.signedURL}` }
-      return { data, error: null }
+      const signedURL = `${this.url}${data.signedURL}`
+      data = { signedURL }
+      return { data, error: null, signedURL }
     } catch (error) {
-      return { data: null, error }
+      return { data: null, error, signedURL: null }
     }
   }
 


### PR DESCRIPTION
Fixes the types for createdSignedURL. 

Also exposes it as a property outside `data` so that the URL can be accessed like
```js
const { signedURL, error } = await supabase.storage.createSignedURL('cat.png', 60) 
```