### PR TITLE
fix: remove projectref returned from upload and update object

### DIFF
--- a/src/lib/storage/StorageFileApi.ts
+++ b/src/lib/storage/StorageFileApi.ts
@@ -55,8 +55,9 @@ export class StorageFileApi {
       })
 
       if (res.ok) {
-        const data = await res.json()
-        return { data, error: null }
+        // const data = await res.json()
+        // temporary fix till backend is updated to the latest storage-api version
+        return { data: { Key: _path }, error: null }
       } else {
         const error = await res.json()
         return { data: null, error }
@@ -95,8 +96,9 @@ export class StorageFileApi {
       })
 
       if (res.ok) {
-        const data = await res.json()
-        return { data, error: null }
+        // const data = await res.json()
+        // temporary fix till backend is updated to the latest storage-api version
+        return { data: { Key: _path }, error: null }
       } else {
         const error = await res.json()
         return { data: null, error }


### PR DESCRIPTION
Previously the project ref was also returned in upload and update calls. This doesn't make a sense for the user as it is more of an implementation detail. This has already [been fixed](https://github.com/supabase/storage-api/commit/ff08bdf4a925dd500a8f5be3ced769c657bbfd47) in storage-api. This is a temporary patch till the fix gets rolled out to everyone. 