### PR TITLE
refactor: remove unused exports, files and variables

### DIFF
--- a/src/SupabaseClient.ts
+++ b/src/SupabaseClient.ts
@@ -1,4 +1,3 @@
-import { DEFAULT_HEADERS } from './lib/constants'
 import { SupabaseClientOptions } from './lib/types'
 import { SupabaseAuthClient } from './lib/SupabaseAuthClient'
 import { SupabaseQueryBuilder } from './lib/SupabaseQueryBuilder'
@@ -12,7 +11,7 @@ const DEFAULT_OPTIONS = {
   persistSession: true,
   detectSessionInUrl: true,
   localStorage: globalThis.localStorage,
-  headers: DEFAULT_HEADERS,
+  headers: {},
 }
 
 /**

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,3 +1,0 @@
-// constants.ts
-
-export const DEFAULT_HEADERS = {}

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -1,9 +1,0 @@
-// helpers.ts
-
-export function uuid() {
-  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
-    var r = (Math.random() * 16) | 0,
-      v = c == 'x' ? r : (r & 0x3) | 0x8
-    return v.toString(16)
-  })
-}

--- a/src/lib/storage/types.ts
+++ b/src/lib/storage/types.ts
@@ -18,7 +18,7 @@ export interface FileObject {
   buckets: Bucket
 }
 
-export interface SortBy {
+interface SortBy {
   column?: string
   order?: string
 }


### PR DESCRIPTION

## What kind of change does this PR introduce?

- As these items (files and variables) were defined at least 6 months
and until today they are not being used, we can remove and if necessary
in the future, we could search in history (if necessary)
