### PR TITLE
fix: type error for callback of on() in SupabaseRealtimeClient

### DIFF
--- a/src/lib/SupabaseRealtimeClient.ts
+++ b/src/lib/SupabaseRealtimeClient.ts
@@ -32,7 +32,7 @@ export class SupabaseRealtimeClient {
    * @param event The event
    * @param callback A callback function that is called whenever the event occurs.
    */
-  on(event: SupabaseEventTypes, callback: Function) {
+  on(event: SupabaseEventTypes, callback: (payload: SupabaseRealtimePayload<any>) => void) {
     this.subscription.on(event, (payload: any) => {
       let enrichedPayload: SupabaseRealtimePayload<any> = {
         schema: payload.schema,


### PR DESCRIPTION
Parameter of callback function of on() should have SupabaseRealtimePayload type instead of any Function.

## What kind of change does this PR introduce?

Type error fix. Solves the #179. Detailed information is given in issue.

## What is the current behavior?

callback function has type Function which can be replaced with `(payload: SupabaseRealtimePayload<T>) => void`
#179 

