### PR TITLE
Use additional headers from SupabaseClient into GotrueClient.

### DIFF
--- a/src/SupabaseClient.ts
+++ b/src/SupabaseClient.ts
@@ -141,13 +141,15 @@ export default class SupabaseClient {
     persistSession,
     detectSessionInUrl,
     localStorage,
+    headers
   }: SupabaseClientOptions) {
+    const authHeaders = {
+      Authorization: `Bearer ${this.supabaseKey}`,
+      apikey: `${this.supabaseKey}`,
+    }
     return new SupabaseAuthClient({
       url: this.authUrl,
-      headers: {
-        Authorization: `Bearer ${this.supabaseKey}`,
-        apikey: `${this.supabaseKey}`,
-      },
+      headers: { ...headers, ...authHeaders },
       autoRefreshToken,
       persistSession,
       detectSessionInUrl,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

When we instantiate SupabaseClient it is possible to specify additional headers to use in any API request :
https://github.com/supabase/supabase-js/blob/c5310d69cada1cb72b8d698d8a27c8a9590898d3/src/SupabaseClient.ts#L44

These headers don't seem to be actually used at all.   

Gotrue allows to specify the audience of the users during requests, by setting a header 'X-JWT-AUD' containing the audience, but we cannot use this feature yet because when SupabaseClient instantiates the GotrueClient, it doesn't forwards the custom headers to it.


## What is the new behavior?

When SupabaseClient instantiates the GotrueClient, it forwards the custom additional headers to the GotrueClient. It is now possible to set the 'X-JWT-AUD' header in every request to Gotrue.

