### PR TITLE
Fixes supabase/supabase-js#236

### DIFF
--- a/src/SupabaseClient.ts
+++ b/src/SupabaseClient.ts
@@ -95,10 +95,16 @@ export default class SupabaseClient {
    *
    * @param fn  The function name to call.
    * @param params  The parameters to pass to the function call.
+   * @param count  Count algorithm to use to count rows in a table.
+   *
    */
-  rpc<T = any>(fn: string, params?: object) {
+  rpc<T = any>(
+    fn: string,
+    params?: object,
+    { count = null }: { count?: null | 'exact' | 'planned' | 'estimated' } = {}
+  ) {
     const rest = this._initPostgRESTClient()
-    return rest.rpc<T>(fn, params)
+    return rest.rpc<T>(fn, params, { count })
   }
 
   /**


### PR DESCRIPTION
## What kind of change does this PR introduce?
Fix the rpc count missing in the function


## What is the current behavior?
`supabase.rpc('fnc_name', { params }, { count: "exact" })` is missing the count object parameter.

## What is the new behavior?
Fix the function, able to create rpc function that return `count`