### PR TITLE
Access localStorage lazily to avoid DOMExceptions in constrained envs when `localStorage` is provided using options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@supabase/gotrue-js": "^1.17.0",
+        "@supabase/gotrue-js": "^1.17.1",
         "@supabase/postgrest-js": "^0.33.3",
         "@supabase/realtime-js": "^1.1.3",
         "@supabase/storage-js": "^1.4.0"
@@ -665,6 +665,7 @@
         "jest-resolve": "^26.6.1",
         "jest-util": "^26.6.1",
         "jest-worker": "^26.6.1",
+        "node-notifier": "^8.0.0",
         "slash": "^3.0.0",
         "source-map": "^0.6.0",
         "string-length": "^4.0.1",
@@ -784,9 +785,9 @@
       }
     },
     "node_modules/@supabase/gotrue-js": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-1.17.0.tgz",
-      "integrity": "sha512-c+GSSoW+PIT3/r7TnBdc4gPjtWDutO/2ROafSKUFl39Pb8aHIUbUvzK9sjuedaaLKH7bV8VefuRy2L8c0BUAzg==",
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-1.17.1.tgz",
+      "integrity": "sha512-Lt3FhJlNC+OOgPtzvzoCHNvdsJOZbO03qM9Hmvhiw7MvGW80vkGsXu46boagtalqhdsEKgM94zNKhfwiIUa1Lw==",
       "dependencies": {
         "cross-fetch": "^3.0.6"
       }
@@ -3142,6 +3143,7 @@
         "minimist": "^1.2.5",
         "neo-async": "^2.6.0",
         "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4",
         "wordwrap": "^1.0.0"
       },
       "bin": {
@@ -4091,6 +4093,7 @@
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
+        "fsevents": "^2.1.2",
         "graceful-fs": "^4.2.4",
         "jest-regex-util": "^26.0.0",
         "jest-serializer": "^26.5.0",
@@ -8981,9 +8984,9 @@
       }
     },
     "@supabase/gotrue-js": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-1.17.0.tgz",
-      "integrity": "sha512-c+GSSoW+PIT3/r7TnBdc4gPjtWDutO/2ROafSKUFl39Pb8aHIUbUvzK9sjuedaaLKH7bV8VefuRy2L8c0BUAzg==",
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-1.17.1.tgz",
+      "integrity": "sha512-Lt3FhJlNC+OOgPtzvzoCHNvdsJOZbO03qM9Hmvhiw7MvGW80vkGsXu46boagtalqhdsEKgM94zNKhfwiIUa1Lw==",
       "requires": {
         "cross-fetch": "^3.0.6"
       }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "docs:json": "typedoc --json docs/spec.json --mode modules --includeDeclarations --excludeExternals"
   },
   "dependencies": {
-    "@supabase/gotrue-js": "^1.17.0",
+    "@supabase/gotrue-js": "^1.17.1",
     "@supabase/postgrest-js": "^0.33.3",
     "@supabase/realtime-js": "^1.1.3",
     "@supabase/storage-js": "^1.4.0"

--- a/src/SupabaseClient.ts
+++ b/src/SupabaseClient.ts
@@ -11,7 +11,6 @@ const DEFAULT_OPTIONS = {
   autoRefreshToken: true,
   persistSession: true,
   detectSessionInUrl: true,
-  localStorage: globalThis.localStorage,
   headers: DEFAULT_HEADERS,
 }
 

--- a/src/lib/SupabaseAuthClient.ts
+++ b/src/lib/SupabaseAuthClient.ts
@@ -1,14 +1,8 @@
 import { GoTrueClient } from '@supabase/gotrue-js'
+import { SupabaseAuthClientOptions } from './types'
 
 export class SupabaseAuthClient extends GoTrueClient {
-  constructor(options: {
-    url?: string
-    headers?: { [key: string]: string }
-    detectSessionInUrl?: boolean
-    autoRefreshToken?: boolean
-    persistSession?: boolean
-    localStorage?: Storage
-  }) {
+  constructor(options: SupabaseAuthClientOptions) {
     super(options)
   }
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,4 +1,9 @@
+import { GoTrueClient } from '@supabase/gotrue-js'
 import { RealtimeClientOptions } from '@supabase/realtime-js'
+
+type GoTrueClientOptions = ConstructorParameters<typeof GoTrueClient>[0]
+
+export interface SupabaseAuthClientOptions extends GoTrueClientOptions {}
 
 export type SupabaseClientOptions = {
   /**
@@ -24,7 +29,7 @@ export type SupabaseClientOptions = {
   /**
    * A storage provider. Used to store the logged in session.
    */
-  localStorage?: Storage
+  localStorage?: SupabaseAuthClientOptions['localStorage']
 
   /**
    * Options passed to the realtime-js instance


### PR DESCRIPTION
It's a follow up to: https://github.com/supabase/gotrue-js/pull/117 - just adjusting how options are passed around so one can leverage those downstream changes.