### PR TITLE
fix: Override X-Client-Info header for postgrest-js and storage-js

### DIFF
--- a/src/SupabaseClient.ts
+++ b/src/SupabaseClient.ts
@@ -177,7 +177,7 @@ export default class SupabaseClient {
   }
 
   private _getAuthHeaders(): { [key: string]: string } {
-    const headers: { [key: string]: string } = {}
+    const headers: { [key: string]: string } = DEFAULT_HEADERS
     const authBearer = this.auth.session()?.access_token ?? this.supabaseKey
     headers['apikey'] = this.supabaseKey
     headers['Authorization'] = `Bearer ${authBearer}`


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR will override the `X-Client-Info` header of `postgrest-js` and `storage-js` just like how it is already doing for `realtime-js` and `gotrue-js`. 

Related https://github.com/supabase/supabase-js/pull/238

## What is the current behavior?

`supabase-js` does not override the `X-Client-Info` header of `postgrest-js` and `storage-js`. 

## What is the new behavior?

`supabase-js` does override the `X-Client-Info` header of `postgrest-js` and `storage-js`. 

## Additional context

If not overriding the headers of `postgrest-js` and `storage-js` is intentional, please feel free to close this P. 

