### PR TITLE
Allow for trailing slash in supabaseUrl

### DIFF
--- a/src/SupabaseClient.ts
+++ b/src/SupabaseClient.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_HEADERS } from './lib/constants'
+import { stripTrailingSlash } from './lib/helpers'
 import { SupabaseClientOptions } from './lib/types'
 import { SupabaseAuthClient } from './lib/SupabaseAuthClient'
 import { SupabaseQueryBuilder } from './lib/SupabaseQueryBuilder'
@@ -52,7 +53,7 @@ export default class SupabaseClient {
     if (!supabaseKey) throw new Error('supabaseKey is required.')
 
     const settings = { ...DEFAULT_OPTIONS, ...options }
-    this.restUrl = `${supabaseUrl}/rest/v1`
+    this.restUrl = `${stripTrailingSlash(supabaseUrl)}/rest/v1`
     this.realtimeUrl = `${supabaseUrl}/realtime/v1`.replace('http', 'ws')
     this.authUrl = `${supabaseUrl}/auth/v1`
     this.storageUrl = `${supabaseUrl}/storage/v1`

--- a/src/SupabaseClient.ts
+++ b/src/SupabaseClient.ts
@@ -52,8 +52,10 @@ export default class SupabaseClient {
     if (!supabaseUrl) throw new Error('supabaseUrl is required.')
     if (!supabaseKey) throw new Error('supabaseKey is required.')
 
+    supabaseUrl = stripTrailingSlash(supabaseUrl)
+
     const settings = { ...DEFAULT_OPTIONS, ...options }
-    this.restUrl = `${stripTrailingSlash(supabaseUrl)}/rest/v1`
+    this.restUrl = `${supabaseUrl}/rest/v1`
     this.realtimeUrl = `${supabaseUrl}/realtime/v1`.replace('http', 'ws')
     this.authUrl = `${supabaseUrl}/auth/v1`
     this.storageUrl = `${supabaseUrl}/storage/v1`

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -7,3 +7,7 @@ export function uuid() {
     return v.toString(16)
   })
 }
+
+export function stripTrailingSlash(url: string) {
+  return url.replace(/\/$/, "");
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

A trailing slash in the `supabaseUrl` causes duplication in the final URL

## What is the new behavior?

A trailing slash is removed from the `supabaseUrl` so the created URL does not contain duplicates

## Additional context

- The regex only accounts for a single `\`. 
- Another option would be to update the docs, but this improves DX as there is no need to worry about if a slash should be appended to the URL or not
- fixes https://github.com/supabase/supabase-js/issues/261
