### PR TITLE
chore: fix CI release process

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: ['12']
+        node: ['16']
 
     runs-on: ${{ matrix.os }}
 
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Set up Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: ['16']
+        node: ['14']
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: ['12']
+        node: ['16']
 
     runs-on: ${{ matrix.os }}
 
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Set up Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: ['16']
+        node: ['14']
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     name: Release / Node ${{ matrix.node }}
     strategy:
       matrix:
-        node: ['12']
+        node: ['16']
 
     runs-on: ubuntu-latest
 
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Set up Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     name: Release / Node ${{ matrix.node }}
     strategy:
       matrix:
-        node: ['16']
+        node: ['14']
 
     runs-on: ubuntu-latest
 
@@ -28,7 +28,7 @@ jobs:
           npm run build
 
       - name: Create a release
-        run: npx semantic-release
+        run: npx semantic-release@^18.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -16,10 +16,10 @@
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
     ["@semantic-release/github", {
-      successComment: false,
-      releasedLabels: false,
-      failTitle: false,
-      addReleases: false,
+      "successComment": false,
+      "releasedLabels": false,
+      "failTitle": false,
+      "addReleases": false,
     }],
     "@semantic-release/npm"
   ]

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -15,7 +15,12 @@
     ],
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
-    "@semantic-release/github",
+    ["@semantic-release/github", {
+      successComment: false,
+      releasedLabels: false,
+      failTitle: false,
+      addReleases: false,
+    }],
     "@semantic-release/npm"
   ]
 }


### PR DESCRIPTION
- update to node16 from 12 (semantic-release now requires at least node14)
- disable commenting on PRs/issues included in the release (semantic release seems to be running into some github API issue)

Could pin to the last major release of semantic release to avoid bumping node versions for a little while.