### PR TITLE
feat: add user_token when creating realtime channel subscription

### DIFF
--- a/src/lib/SupabaseQueryBuilder.ts
+++ b/src/lib/SupabaseQueryBuilder.ts
@@ -23,7 +23,7 @@ export class SupabaseQueryBuilder<T> extends PostgrestQueryBuilder<T> {
   ) {
     super(url, { headers, schema })
 
-    this._subscription = new SupabaseRealtimeClient(realtime, schema, table)
+    this._subscription = new SupabaseRealtimeClient(realtime, headers, schema, table)
     this._realtime = realtime
   }
 

--- a/src/lib/SupabaseRealtimeClient.ts
+++ b/src/lib/SupabaseRealtimeClient.ts
@@ -4,9 +4,21 @@ import { SupabaseEventTypes, SupabaseRealtimePayload } from './types'
 export class SupabaseRealtimeClient {
   subscription: RealtimeSubscription
 
-  constructor(socket: RealtimeClient, schema: string, tableName: string) {
+  constructor(
+    socket: RealtimeClient,
+    headers: { [key: string]: string },
+    schema: string,
+    tableName: string
+  ) {
+    const chanParams: { [key: string]: string } = {}
     const topic = tableName === '*' ? `realtime:${schema}` : `realtime:${schema}:${tableName}`
-    this.subscription = socket.channel(topic)
+    const userToken = headers['Authorization'].split(' ')[1]
+
+    if (userToken) {
+      chanParams['user_token'] = userToken
+    }
+
+    this.subscription = socket.channel(topic, chanParams)
   }
 
   private getPayloadRecords(payload: any) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the new behavior?

Pass the user access token to Realtime in order to apply RLS on a per topic basis via [WALRUS](https://github.com/supabase/walrus).

## Additional context

Related issue: https://github.com/supabase/walrus/issues/4
