### PR TITLE
fix: change release.yml node version to 14

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     name: Release / Node ${{ matrix.node }}
     strategy:
       matrix:
-        node: ['12']
+        node: ['14']
 
     runs-on: ubuntu-latest
 
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Set up Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

`semantic-release` breaking change raised minimum node version to 14.17 (see [here](https://github.com/semantic-release/semantic-release/pull/2132)) which is breaking our release (our node version is 12).

## What is the new behavior?

Sets our release node version to 14.
