### PR TITLE
feat: update Realtime transformations to accept array changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@supabase/gotrue-js": "^1.18.0",
         "@supabase/postgrest-js": "^0.34.0",
-        "@supabase/realtime-js": "^1.1.3",
+        "@supabase/realtime-js": "^1.2.0",
         "@supabase/storage-js": "^1.4.0"
       },
       "devDependencies": {
@@ -849,9 +849,9 @@
       }
     },
     "node_modules/@supabase/realtime-js": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-1.1.3.tgz",
-      "integrity": "sha512-zVquwxiv8xnjrh3n/WWbdsv6L39sq5vFBrlkKcRaJ/m9iT5HdLfa2hvCwmp0eaeExvDoJnaQ0u/gPBmTrq4xqw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-1.2.0.tgz",
+      "integrity": "sha512-DH+rkr+d3XUzeGBmw+ST6vT0rRZ3h8klhWeD89wP0SM/axTyx7xnCZKS0NZ7lBId+RHT5IBh7F78gaKrD19UOA==",
       "dependencies": {
         "@types/websocket": "^1.0.3",
         "websocket": "^1.0.34"
@@ -9324,9 +9324,9 @@
       }
     },
     "@supabase/realtime-js": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-1.1.3.tgz",
-      "integrity": "sha512-zVquwxiv8xnjrh3n/WWbdsv6L39sq5vFBrlkKcRaJ/m9iT5HdLfa2hvCwmp0eaeExvDoJnaQ0u/gPBmTrq4xqw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-1.2.0.tgz",
+      "integrity": "sha512-DH+rkr+d3XUzeGBmw+ST6vT0rRZ3h8klhWeD89wP0SM/axTyx7xnCZKS0NZ7lBId+RHT5IBh7F78gaKrD19UOA==",
       "requires": {
         "@types/websocket": "^1.0.3",
         "websocket": "^1.0.34"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "@supabase/gotrue-js": "^1.18.0",
     "@supabase/postgrest-js": "^0.34.0",
-    "@supabase/realtime-js": "^1.1.3",
+    "@supabase/realtime-js": "^1.2.0",
     "@supabase/storage-js": "^1.4.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Version bumping `@supabase/realtime-js` to v1.2.0

feature - enable Supabase transformations on Realtime changes to accept array types directly from Realtime server.

bug - fix existing issues with Supabase transformations on Realtime changes like how existing array types are split and how range types are handled.

## Additional context

`realtime-js` PR: https://github.com/supabase/realtime-js/pull/107
