### PR TITLE
Use custom headers in every client

### DIFF
--- a/src/SupabaseClient.ts
+++ b/src/SupabaseClient.ts
@@ -33,6 +33,9 @@ export default class SupabaseClient {
   protected storageUrl: string
   protected realtime: RealtimeClient
   protected fetch?: Fetch
+  protected headers: {
+    [key: string]: string
+  }
 
   /**
    * Create a new client for use in the browser.
@@ -63,9 +66,10 @@ export default class SupabaseClient {
     this.storageUrl = `${supabaseUrl}/storage/v1`
     this.schema = settings.schema
     this.fetch = settings.fetch
+    this.headers = { ...DEFAULT_HEADERS, ...options?.headers }
 
     this.auth = this._initSupabaseAuthClient(settings)
-    this.realtime = this._initRealtimeClient(settings.realtime)
+    this.realtime = this._initRealtimeClient({ headers: this.headers, ...settings.realtime })
 
     // In the future we might allow the user to pass in a logger to receive these events.
     // this.realtime.onOpen(() => console.log('OPEN'))
@@ -191,7 +195,7 @@ export default class SupabaseClient {
   }
 
   private _getAuthHeaders(): { [key: string]: string } {
-    const headers: { [key: string]: string } = DEFAULT_HEADERS
+    const headers: { [key: string]: string } = this.headers
     const authBearer = this.auth.session()?.access_token ?? this.supabaseKey
     headers['apikey'] = this.supabaseKey
     headers['Authorization'] = `Bearer ${authBearer}`

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -1,4 +1,5 @@
 import { createClient, SupabaseClient } from '../src/index'
+import { DEFAULT_HEADERS } from '../src/lib/constants'
 
 const URL = 'http://localhost:3000'
 const KEY = 'some.fake.key'
@@ -13,6 +14,19 @@ test('it should create the client connection', async () => {
 test('it should throw an error if no valid params are provided', async () => {
   expect(() => createClient('', KEY)).toThrowError('supabaseUrl is required.')
   expect(() => createClient(URL, '')).toThrowError('supabaseKey is required.')
+})
+
+describe('Custom Headers', () => {
+  const customHeader = { 'X-Test-Header': 'value' }
+
+  test('should have custom header set', () => {
+    const checkHeadersSpy = jest.spyOn(SupabaseClient.prototype as any, '_getAuthHeaders')
+    createClient(URL, KEY, { headers: customHeader }).rpc('') // Calling public method `rpc` calls private method _getAuthHeaders which result we want to test
+    const getHeaders = checkHeadersSpy.mock.results[0].value
+
+    expect(checkHeadersSpy).toBeCalled()
+    expect(getHeaders).toHaveProperty('X-Test-Header', 'value')
+  })
 })
 
 // Socket should close when there are no open connections


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

Since https://github.com/supabase/supabase-js/pull/218 custom headers passed to the `SupabaseClient` constructor are passed on to the `GoTrueClient`. 
However they are not passed on to the`PostgestClient`, `SupabaseStorageClient` and `SupabaseQueryBuilder`, although implied by the param description: 
https://github.com/supabase/supabase-js/blob/5f7f3d5f088d213ae56e9a806066c1c810c852ab/src/SupabaseClient.ts#L45

## What is the new behavior?

Headers passed through the `options.headers` parameter of the constructor are now stored in a new protected variable `headers`. Since all clients mentioned above call the private method `_getAuthHeaders` I decided to inject the custom headers here, together with the default headers that were already injected inside this method. 

## Additional context

I also created a very minimal test case, just to be sure the `_getAuthHeaders` method indeed returns the custom headers. I'm not an expert on Jest, so as far as convention goes there might be more optimal ways to test the functionality this PR introduces. 
Closes https://github.com/supabase/supabase-js/issues/166