### PR TITLE
fix: restrict realtime-js to v1.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "@supabase/gotrue-js": "^1.21.0",
     "@supabase/postgrest-js": "^0.35.0",
-    "@supabase/realtime-js": "^1.2.1",
+    "@supabase/realtime-js": "1.2.1",
     "@supabase/storage-js": "^1.5.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

run `npm update` and `realtime-js` is the latest version (`1.3.2`). However, Realtime RLS currently does not work with `realtime-js` past version `1.2.1`.

## What is the new behavior?

Restrict `realtime-js` to version `1.2.1`
