### PR TITLE
Chore/gotrue 1.22.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@supabase/gotrue-js": "^1.22.0",
     "@supabase/postgrest-js": "^0.36.0",
     "@supabase/realtime-js": "^1.3.5",
-    "@supabase/storage-js": "^1.5.0"
+    "@supabase/storage-js": "^1.5.1"
   },
   "devDependencies": {
     "@types/jest": "^26.0.13",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "docs:json": "typedoc --json docs/spec.json --mode modules --includeDeclarations --excludeExternals"
   },
   "dependencies": {
-    "@supabase/gotrue-js": "^1.21.7",
+    "@supabase/gotrue-js": "^1.22.0",
     "@supabase/postgrest-js": "^0.35.0",
     "@supabase/realtime-js": "^1.3.5",
     "@supabase/storage-js": "^1.5.0"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@supabase/gotrue-js": "^1.22.0",
-    "@supabase/postgrest-js": "^0.35.0",
+    "@supabase/postgrest-js": "^0.36.0",
     "@supabase/realtime-js": "^1.3.5",
     "@supabase/storage-js": "^1.5.0"
   },


### PR DESCRIPTION
bumps gotrue-js, postgrest-js, and storage-js submodule versions to latest