### PR TITLE
feat: add client and version to Realtime params

### DIFF
--- a/src/SupabaseClient.ts
+++ b/src/SupabaseClient.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_HEADERS, STORAGE_KEY } from './lib/constants'
+import { CLIENT_VERSION, DEFAULT_HEADERS, STORAGE_KEY } from './lib/constants'
 import { stripTrailingSlash, isBrowser } from './lib/helpers'
 import { Fetch, GenericObject, SupabaseClientOptions } from './lib/types'
 import { SupabaseAuthClient } from './lib/SupabaseAuthClient'
@@ -226,7 +226,7 @@ export default class SupabaseClient {
   private _initRealtimeClient(options?: RealtimeClientOptions) {
     return new RealtimeClient(this.realtimeUrl, {
       ...options,
-      params: { ...options?.params, apikey: this.supabaseKey },
+      params: { ...options?.params, apikey: this.supabaseKey, client_vsn: CLIENT_VERSION },
     })
   }
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,4 +1,5 @@
 // constants.ts
 import { version } from './version'
-export const DEFAULT_HEADERS = { 'X-Client-Info': `supabase-js/${version}` }
+export const CLIENT_VERSION = `supabase-js/${version}`
+export const DEFAULT_HEADERS = { 'X-Client-Info': CLIENT_VERSION }
 export const STORAGE_KEY = 'supabase.auth.token'


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the new behavior?

Realtime RLS server will receive another param called `client_vsn` during socket connection which will be the client and version in the following format: `supabase-js/0.0.0`.
