### PR TITLE
fix: update version before minified output is generated

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,7 @@ jobs:
 
       - run: |
           npm ci
+          npx semantic-release --plugins 'semantic-release-plugin-update-version-in-files'
           npm run build
 
       - name: Create a release


### PR DESCRIPTION
this ensures that the files served by CDN networks based on
minified files published report the correct version, rather than the
placeholder '0.0.0'.

I _think_ this works, but its hard to test.