### PR TITLE
fix: add multiTab TS support during createClient

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -23,6 +23,10 @@ export type SupabaseClientOptions = {
    */
   autoRefreshToken?: boolean
   /**
+   * Allows to enable/disable multi-tab/window events
+   */
+  multiTab?: boolean
+  /**
    * Whether to persist a logged in session to storage.
    */
   persistSession?: boolean


### PR DESCRIPTION
TS support for **multiTab** in the third argument in **createClient**

```
createClient(
      SUPABASE_URL,
      SUPABASE_SECRET_KEY,
      { multiTab: false }
    )
```