### PR TITLE
fix: allow overriding urls

### DIFF
--- a/src/SupabaseClient.ts
+++ b/src/SupabaseClient.ts
@@ -67,10 +67,22 @@ export default class SupabaseClient {
     const _supabaseUrl = stripTrailingSlash(supabaseUrl)
     const settings = { ...DEFAULT_OPTIONS, ...options }
 
-    this.restUrl = `${_supabaseUrl}/rest/v1`
-    this.realtimeUrl = `${_supabaseUrl}/realtime/v1`.replace('http', 'ws')
-    this.authUrl = `${_supabaseUrl}/auth/v1`
-    this.storageUrl = `${_supabaseUrl}/storage/v1`
+    this.restUrl =
+      options?.overrideUrls?.restUrl != null
+        ? options.overrideUrls.restUrl
+        : `${_supabaseUrl}/rest/v1`
+    this.realtimeUrl =
+      options?.overrideUrls?.realtimeUrl != null
+        ? options.overrideUrls.realtimeUrl
+        : `${_supabaseUrl}/realtime/v1`.replace('http', 'ws')
+    this.authUrl =
+      options?.overrideUrls?.authUrl != null
+        ? options.overrideUrls.authUrl
+        : `${_supabaseUrl}/auth/v1`
+    this.storageUrl =
+      options?.overrideUrls?.storageUrl != null
+        ? options.overrideUrls.storageUrl
+        : `${_supabaseUrl}/storage/v1`
     this.schema = settings.schema
     this.multiTab = settings.multiTab
     this.fetch = settings.fetch

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -53,6 +53,16 @@ export type SupabaseClientOptions = {
    * Throw errors, instead of returning them.
    */
   shouldThrowOnError?: boolean
+
+  /**
+   * Overrides urls
+   */
+  overrideUrls?: {
+    restUrl?: string
+    realtimeUrl?: string
+    authUrl?: string
+    storageUrl?: string
+  }
 }
 
 export type SupabaseRealtimePayload<T> = {


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR allows developers to control services urls, in case if they use Supabase behind the proxy.

## What is the current behavior?
Current behavior appends /rest/v1, /realtime/v1, etc. paths to the url, which sometimes is not desired, and there is not option to easily disable this behavior.

## What is the new behavior?
New behavior by default works as old one, but if user specifies overrideUrls option, he will be able to change "/*/v1" url append logic
