### PR TITLE
fix: allow overriding Bearer token

### DIFF
--- a/src/SupabaseClient.ts
+++ b/src/SupabaseClient.ts
@@ -247,7 +247,7 @@ export default class SupabaseClient {
     const headers: GenericObject = this.headers
     const authBearer = this.auth.session()?.access_token ?? this.supabaseKey
     headers['apikey'] = this.supabaseKey
-    headers['Authorization'] = `Bearer ${authBearer}`
+    headers['Authorization'] = headers['Authorization'] || `Bearer ${authBearer}`
     return headers
   }
 


### PR DESCRIPTION
When initializing SupabaseClient, if the `Authorization` header is provided, it will be used for `_getAuthHeaders()` instead of the session's access token or Supabase key.