### PR TITLE
fix: do not cache Authorization header (and add tests)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,7 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
+  clearMocks: true,
   collectCoverage: false,
   coverageDirectory: './test/coverage',
   coverageReporters: ['json', 'html', 'lcov'],

--- a/src/SupabaseClient.ts
+++ b/src/SupabaseClient.ts
@@ -265,7 +265,7 @@ export default class SupabaseClient {
   }
 
   private _getAuthHeaders(): GenericObject {
-    const headers: GenericObject = this.headers
+    const headers: GenericObject = { ...this.headers }
     const authBearer = this.auth.session()?.access_token ?? this.supabaseKey
     headers['apikey'] = this.supabaseKey
     headers['Authorization'] = headers['Authorization'] || `Bearer ${authBearer}`

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -16,16 +16,39 @@ test('it should throw an error if no valid params are provided', async () => {
   expect(() => createClient(URL, '')).toThrowError('supabaseKey is required.')
 })
 
-describe('Custom Headers', () => {
-  const customHeader = { 'X-Test-Header': 'value' }
+test('it should not cache Authorization header', async () => {
+  const checkHeadersSpy = jest.spyOn(SupabaseClient.prototype as any, '_getAuthHeaders')
 
+  supabase.auth.setAuth('token1')
+  supabase.rpc('') // Calling public method `rpc` calls private method _getAuthHeaders which result we want to test
+  supabase.auth.setAuth('token2')
+  supabase.rpc('') // Calling public method `rpc` calls private method _getAuthHeaders which result we want to test
+
+  expect(checkHeadersSpy.mock.results[0].value).toHaveProperty('Authorization', 'Bearer token1')
+  expect(checkHeadersSpy.mock.results[1].value).toHaveProperty('Authorization', 'Bearer token2')
+})
+
+describe('Custom Headers', () => {
   test('should have custom header set', () => {
+    const customHeader = { 'X-Test-Header': 'value' }
+
     const checkHeadersSpy = jest.spyOn(SupabaseClient.prototype as any, '_getAuthHeaders')
     createClient(URL, KEY, { headers: customHeader }).rpc('') // Calling public method `rpc` calls private method _getAuthHeaders which result we want to test
     const getHeaders = checkHeadersSpy.mock.results[0].value
 
     expect(checkHeadersSpy).toBeCalled()
     expect(getHeaders).toHaveProperty('X-Test-Header', 'value')
+  })
+
+  test('should allow custom Authorization header', () => {
+    const customHeader = { Authorization: 'Bearer custom_token' }
+    supabase.auth.setAuth('override_me')
+    const checkHeadersSpy = jest.spyOn(SupabaseClient.prototype as any, '_getAuthHeaders')
+    createClient(URL, KEY, { headers: customHeader }).rpc('') // Calling public method `rpc` calls private method _getAuthHeaders which result we want to test
+    const getHeaders = checkHeadersSpy.mock.results[0].value
+
+    expect(checkHeadersSpy).toBeCalled()
+    expect(getHeaders).toHaveProperty('Authorization', 'Bearer custom_token')
   })
 })
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

https://github.com/supabase/supabase-js/pull/402 caused a regression in the client that will cache the initial Authorization header

## What is the new behavior?

Still allows overriding the Authorization header, but otherwise will use the value from `auth.session()`

