### PR TITLE
Allow to override Supabase service URLs in client

### DIFF
--- a/src/SupabaseClient.ts
+++ b/src/SupabaseClient.ts
@@ -74,10 +74,10 @@ export default class SupabaseClient {
     const _supabaseUrl = stripTrailingSlash(supabaseUrl)
     const settings = { ...DEFAULT_OPTIONS, ...options }
 
-    this.restUrl = `${_supabaseUrl}/rest/v1`
-    this.realtimeUrl = `${_supabaseUrl}/realtime/v1`.replace('http', 'ws')
-    this.authUrl = `${_supabaseUrl}/auth/v1`
-    this.storageUrl = `${_supabaseUrl}/storage/v1`
+    this.restUrl = options?.restUrl || `${_supabaseUrl}/rest/v1`
+    this.realtimeUrl = options?.realtimeUrl || `${_supabaseUrl}/realtime/v1`.replace('http', 'ws')
+    this.authUrl = options?.authUrl || `${_supabaseUrl}/auth/v1`
+    this.storageUrl = options?.storageUrl || `${_supabaseUrl}/storage/v1`
 
     const isPlatform = _supabaseUrl.match(/(supabase\.co)|(supabase\.in)/)
     if (isPlatform) {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -58,6 +58,26 @@ export type SupabaseClientOptions = {
    * Options passed to the gotrue-js instance
    */
   cookieOptions?: SupabaseAuthClientOptions['cookieOptions']
+
+  /**
+   * Override the restUrl
+   */
+  restUrl?: string
+
+  /**
+   * Override the realtimeUrl (must be ws:// scheme)
+   */
+  realtimeUrl?: string
+
+  /**
+   * Override the authUrl
+   */
+  authUrl?: string
+
+  /**
+   * Override the storageUrl
+   */
+  storageUrl?: string
 }
 
 export type SupabaseRealtimePayload<T> = {


### PR DESCRIPTION
Add 4 options to SupabaseClient that allow to set urls for Supabase
services: REST, Realtime, Auth, Storage, by option keys restUrl,
realtimeUrl, authUrl and storageUrl. The option should contain full
url (eg. https://foo.com/auth/v1 for GoTrue hosted at such url.)

## What kind of change does this PR introduce? What is the current behavior?

Current SupabaseClient behaviour is to accept an url to Supabase instance, and construct sub-service urls by appending paths (`/rest/v1`, `/auth/v1` etc).
This change allows to override the urls by passing them in options, when for example in self-hosting context such services run under different domains.

## Please link any relevant issues here.

This solution helps to mitigate [lack of custom domain support in Supabase](https://github.com/supabase/supabase/issues/12429).
Thanks to generously decoupled architecture, we will be able to just self-host GoTrue under our custom domain, and use SaaS Supabase. For this to work, we need to pass `authUrl` that points to our custom GoTrue instance.

## What is the new behavior?

The new behaviour is same, unless options are used to override URLs for Supabase sub-services.
