### PR TITLE
feat: use getSession from gotrue-js

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - next
   workflow_dispatch:
 
 jobs:

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,4 +1,5 @@
 {
+  "branches": [{ "name": "master" }, { "name": "next", "channel": "next", "prerelease": true }],
   "plugins": [
     [
       "semantic-release-plugin-update-version-in-files",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,11 @@
       "license": "MIT",
       "dependencies": {
         "@supabase/functions-js": "^1.3.3",
-        "@supabase/gotrue-js": "^1.22.14",
+        "@supabase/gotrue-js": "^1.23.0-next.1",
         "@supabase/postgrest-js": "^0.37.2",
         "@supabase/realtime-js": "^1.7.2",
-        "@supabase/storage-js": "^1.7.0"
+        "@supabase/storage-js": "^1.7.0",
+        "cross-fetch": "^3.1.5"
       },
       "devDependencies": {
         "@types/jest": "^26.0.13",
@@ -918,9 +919,9 @@
       }
     },
     "node_modules/@supabase/gotrue-js": {
-      "version": "1.22.14",
-      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-1.22.14.tgz",
-      "integrity": "sha512-/LeNV9BFJ9hxzK6KcmJsOF3apxSYd7HlZOD9dd9a3+Ah0cIMmjlFloW/u4vJXN7ko+Ol3EUWJ6iHcgNoT4gvTw==",
+      "version": "1.23.0-next.1",
+      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-1.23.0-next.1.tgz",
+      "integrity": "sha512-f+jRgR+MKfB+JVZKbZ9C9dsN7Ri40Os0wwliWDev6aqipYgSCeeS3I8h7QoZgMWerXIMy/UQMIRluZvOP1zN1g==",
       "dependencies": {
         "cross-fetch": "^3.0.6"
       }
@@ -9096,9 +9097,9 @@
       }
     },
     "@supabase/gotrue-js": {
-      "version": "1.22.14",
-      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-1.22.14.tgz",
-      "integrity": "sha512-/LeNV9BFJ9hxzK6KcmJsOF3apxSYd7HlZOD9dd9a3+Ah0cIMmjlFloW/u4vJXN7ko+Ol3EUWJ6iHcgNoT4gvTw==",
+      "version": "1.23.0-next.1",
+      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-1.23.0-next.1.tgz",
+      "integrity": "sha512-f+jRgR+MKfB+JVZKbZ9C9dsN7Ri40Os0wwliWDev6aqipYgSCeeS3I8h7QoZgMWerXIMy/UQMIRluZvOP1zN1g==",
       "requires": {
         "cross-fetch": "^3.0.6"
       }

--- a/package.json
+++ b/package.json
@@ -38,10 +38,11 @@
   },
   "dependencies": {
     "@supabase/functions-js": "^1.3.3",
-    "@supabase/gotrue-js": "^1.22.14",
+    "@supabase/gotrue-js": "^1.23.0-next.1",
     "@supabase/postgrest-js": "^0.37.2",
     "@supabase/realtime-js": "^1.7.2",
-    "@supabase/storage-js": "^1.7.0"
+    "@supabase/storage-js": "^1.7.0",
+    "cross-fetch": "^3.1.5"
   },
   "devDependencies": {
     "@types/jest": "^26.0.13",

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -1,0 +1,42 @@
+import crossFetch, { Headers as CrossFetchHeaders } from 'cross-fetch'
+
+type Fetch = typeof fetch
+
+export const resolveFetch = (customFetch?: Fetch): Fetch => {
+  let _fetch: Fetch
+  if (customFetch) {
+    _fetch = customFetch
+  } else if (typeof fetch === 'undefined') {
+    _fetch = crossFetch as unknown as Fetch
+  } else {
+    _fetch = fetch
+  }
+  return (...args) => _fetch(...args)
+}
+
+export const resolveHeadersConstructor = () => {
+  if (typeof Headers === 'undefined') {
+    return CrossFetchHeaders
+  }
+
+  return Headers
+}
+
+export const fetchWithAuth = (
+  getAccessToken: () => Promise<string | null>,
+  customFetch?: Fetch
+): Fetch => {
+  const fetch = resolveFetch(customFetch)
+  const HeadersConstructor = resolveHeadersConstructor()
+
+  return async (input, init) => {
+    const accessToken = await getAccessToken()
+    let headers = new HeadersConstructor(init?.headers)
+
+    if (!headers.has('Authorization') && accessToken) {
+      headers.set('Authorization', `Bearer ${accessToken}`)
+    }
+
+    return fetch(input, { ...init, headers })
+  }
+}

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -1,5 +1,4 @@
 import { createClient, SupabaseClient } from '../src/index'
-import { DEFAULT_HEADERS } from '../src/lib/constants'
 
 const URL = 'http://localhost:3000'
 const KEY = 'some.fake.key'
@@ -17,37 +16,36 @@ test('it should throw an error if no valid params are provided', async () => {
 })
 
 test('it should not cache Authorization header', async () => {
-  const checkHeadersSpy = jest.spyOn(SupabaseClient.prototype as any, '_getAuthHeaders')
-
   supabase.auth.setAuth('token1')
-  supabase.rpc('') // Calling public method `rpc` calls private method _getAuthHeaders which result we want to test
-  supabase.auth.setAuth('token2')
-  supabase.rpc('') // Calling public method `rpc` calls private method _getAuthHeaders which result we want to test
+  supabase.rpc('')
+  expect(supabase.auth.session()?.access_token).toBe('token1')
 
-  expect(checkHeadersSpy.mock.results[0].value).toHaveProperty('Authorization', 'Bearer token1')
-  expect(checkHeadersSpy.mock.results[1].value).toHaveProperty('Authorization', 'Bearer token2')
+  supabase.auth.setAuth('token2')
+  supabase.rpc('')
+  expect(supabase.auth.session()?.access_token).toBe('token2')
 })
 
 describe('Custom Headers', () => {
   test('should have custom header set', () => {
     const customHeader = { 'X-Test-Header': 'value' }
 
-    const checkHeadersSpy = jest.spyOn(SupabaseClient.prototype as any, '_getAuthHeaders')
-    createClient(URL, KEY, { headers: customHeader }).rpc('') // Calling public method `rpc` calls private method _getAuthHeaders which result we want to test
-    const getHeaders = checkHeadersSpy.mock.results[0].value
+    const request = createClient(URL, KEY, { headers: customHeader }).rpc('')
 
-    expect(checkHeadersSpy).toBeCalled()
+    // @ts-ignore
+    const getHeaders = request.headers
+
     expect(getHeaders).toHaveProperty('X-Test-Header', 'value')
   })
 
   test('should allow custom Authorization header', () => {
     const customHeader = { Authorization: 'Bearer custom_token' }
     supabase.auth.setAuth('override_me')
-    const checkHeadersSpy = jest.spyOn(SupabaseClient.prototype as any, '_getAuthHeaders')
-    createClient(URL, KEY, { headers: customHeader }).rpc('') // Calling public method `rpc` calls private method _getAuthHeaders which result we want to test
-    const getHeaders = checkHeadersSpy.mock.results[0].value
 
-    expect(checkHeadersSpy).toBeCalled()
+    const request = createClient(URL, KEY, { headers: customHeader }).rpc('')
+
+    // @ts-ignore
+    const getHeaders = request.headers
+
     expect(getHeaders).toHaveProperty('Authorization', 'Bearer custom_token')
   })
 })


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature/chore

## What is the current behavior?

Currently using the old method of setting auth headers

## What is the new behavior?

Uses `gotrue-js`'s `getSession()` method for asynchronously getting the token

## Additional context

This is using a prerelease version of `gotrue-js`, so should **not** be merge into master.

Also, suggestions for more/better tests are welcome!
