### PR TITLE
build: sets up the next branch as an npm prerelease

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - next
   workflow_dispatch:
 
 jobs:

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,4 +1,5 @@
 {
+  "branches": [{ "name": "master" }, { "name": "next", "channel": "next", "prerelease": true }],
   "plugins": [
     [
       "semantic-release-plugin-update-version-in-files",


### PR DESCRIPTION
## What kind of change does this PR introduce?

Build

## What is the current behavior?

There is currently no prerelease pipeline.

## What is the new behavior?

Pushes to the next branch will be included as an npm prerelease under the next tag.

## Additional context

This setup is working in here: https://github.com/supabase/gotrue-js/pull/293
