### PR TITLE
Revamp Supabase Constructor for V2

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,5 +1,8 @@
 import { GoTrueClient } from '@supabase/gotrue-js'
 import { RealtimeClientOptions } from '@supabase/realtime-js'
+// TODO(Joel): Validate if this is something we want
+// import { FunctionsOptions } from '@supabase/functions-js'
+// import { StorageOptions } from '@supabase/storage-js'
 
 type GoTrueClientOptions = ConstructorParameters<typeof GoTrueClient>[0]
 
@@ -13,51 +16,64 @@ export type SupabaseClientOptions = {
   /**
    * The Postgres schema which your tables belong to. Must be on the list of exposed schemas in Supabase. Defaults to 'public'.
    */
-  schema?: string
-  /**
-   * Optional headers for initializing the client.
-   */
-  headers?: GenericObject
-  /**
-   * Automatically refreshes the token for logged in users.
-   */
-  autoRefreshToken?: boolean
-  /**
-   * Allows to enable/disable multi-tab/window events
-   */
-  multiTab?: boolean
-  /**
-   * Whether to persist a logged in session to storage.
-   */
-  persistSession?: boolean
-  /**
-   * Detect a session from the URL. Used for OAuth login callbacks.
-   */
-  detectSessionInUrl?: boolean
-  /**
-   * A storage provider. Used to store the logged in session.
-   */
-  localStorage?: SupabaseAuthClientOptions['localStorage']
+  api: {
+    schema?: string
+  },
+
+  auth: {
+    /**
+     * Automatically refreshes the token for logged in users.
+     */
+    autoRefreshToken?: boolean,
+    /**
+     * Allows to enable/disable multi-tab/window events
+     */
+    multiTab?: boolean,
+    /**
+     * Whether to persist a logged in session to storage.
+     */
+    persistSession?: boolean,
+    /**
+     * Detect a session from the URL. Used for OAuth login callbacks.
+     */
+    detectSessionInUrl?: boolean,
+    /**
+     * A storage provider. Used to store the logged in session.
+     */
+    localStorage?: SupabaseAuthClientOptions['localStorage'],
+    /**
+     * Options passed to the gotrue-js instance
+     */
+    cookieOptions?: SupabaseAuthClientOptions['cookieOptions']
+  },
 
   /**
    * Options passed to the realtime-js instance
    */
-  realtime?: RealtimeClientOptions
-
+  realtime?: RealtimeClientOptions,
+  // TODO(Joel) -- Validate if this is needed
+  /**
+   * Options passed to the storage-js instance
+   */
+  storage?: StorageOptions,
+  /**
+   * Options passed to the functions-js instance
+   */
+  functions?: FunctionsOptions,
   /**
    * A custom `fetch` implementation.
    */
-  fetch?: Fetch
-
+  fetch?: Fetch,
+  /**
+   * Optional headers for initializing the client.
+   */
+  headers?: GenericObject,
   /**
    * Throw errors, instead of returning them.
    */
-  shouldThrowOnError?: boolean
+  shouldThrowOnError?: boolean,
 
-  /**
-   * Options passed to the gotrue-js instance
-   */
-  cookieOptions?: SupabaseAuthClientOptions['cookieOptions']
+
 }
 
 export type SupabaseRealtimePayload<T> = {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Alters SupabaseClient constructor and types 
## What is the current behavior?
Options all around

## What is the new behavior?

Splits Supabase constructor to use client library specific  scoped options

## Additional context

Add any other context or screenshots.
