### PR TITLE
temporarily remove shouldThrowOnError

### DIFF
--- a/src/SupabaseClient.ts
+++ b/src/SupabaseClient.ts
@@ -51,7 +51,6 @@ export default class SupabaseClient<
   protected storageKey: string
   protected fetch?: Fetch
   protected changedAccessToken: string | undefined
-  protected shouldThrowOnError: boolean
 
   protected headers: {
     [key: string]: string
@@ -97,7 +96,6 @@ export default class SupabaseClient<
     const settings = { ...DEFAULT_OPTIONS, ...options, storageKey: this.storageKey }
 
     this.headers = { ...DEFAULT_HEADERS, ...options?.headers }
-    this.shouldThrowOnError = settings.shouldThrowOnError || false
 
     this.auth = this._initSupabaseAuthClient(settings.auth || {}, this.headers, settings.fetch)
     this.fetch = fetchWithAuth(supabaseKey, this._getAccessToken.bind(this), settings.fetch)
@@ -107,7 +105,6 @@ export default class SupabaseClient<
       headers: this.headers,
       schema: options?.db?.schema,
       fetch: this.fetch,
-      throwOnError: this.shouldThrowOnError,
     })
 
     this._listenForAuthEvents()

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -57,10 +57,6 @@ export type SupabaseClientOptions<SchemaName> = {
    * Optional headers for initializing the client.
    */
   headers?: Record<string, string>
-  /**
-   * Throw errors, instead of returning them.
-   */
-  shouldThrowOnError?: boolean
 }
 
 export type SupabaseRealtimePayload<T> = {


### PR DESCRIPTION
Till all the client libraries support this option.

Once they do, we can add this option back in to the parent library as a non-breaking change