### PR TITLE
Remove Multitab from constructor

### DIFF
--- a/src/SupabaseClient.ts
+++ b/src/SupabaseClient.ts
@@ -19,7 +19,6 @@ const DEFAULT_OPTIONS = {
   autoRefreshToken: true,
   persistSession: true,
   detectSessionInUrl: true,
-  multiTab: true,
   headers: DEFAULT_HEADERS,
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -40,10 +40,6 @@ export type SupabaseClientOptions<SchemaName> = {
      * Options passed to the gotrue-js instance
      */
     cookieOptions?: SupabaseAuthClientOptions['cookieOptions']
-    /**
-     * Allows to enable/disable multi-tab/window events
-     */
-    multiTab?: boolean
   }
   /**
    * Options passed to the realtime-js instance


### PR DESCRIPTION
## What kind of change does this PR introduce?

Remove MultiTab option as it has been removed in [GoTrue-js](https://github.com/supabase/gotrue-js/pull/366/files)

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
