### PR TITLE
fix: bump gotrue-js and storage-js next versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,10 @@
       "license": "MIT",
       "dependencies": {
         "@supabase/functions-js": "^1.3.3",
-        "@supabase/gotrue-js": "^1.23.0-next.8",
+        "@supabase/gotrue-js": "^1.23.0-next.12",
         "@supabase/postgrest-js": "^1.0.0-next.2",
         "@supabase/realtime-js": "^1.8.0-next.13",
-        "@supabase/storage-js": "^1.8.0-next.1",
+        "@supabase/storage-js": "^1.8.0-next.3",
         "cross-fetch": "^3.1.5"
       },
       "devDependencies": {
@@ -919,9 +919,9 @@
       }
     },
     "node_modules/@supabase/gotrue-js": {
-      "version": "1.23.0-next.8",
-      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-1.23.0-next.8.tgz",
-      "integrity": "sha512-PG1zXXG5shKIVMYXnLxCrk0q1ZdUHjqoK5nwMtJVUOlTwVUNjLR3gk73IsSxOTmnTzfBiyZE1jkGgcxOnCBYAA==",
+      "version": "1.23.0-next.12",
+      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-1.23.0-next.12.tgz",
+      "integrity": "sha512-F+XFCnexNwDHD9JcbqhnJeM10MSBRuLZXWKvEGLjrRSHJdxYm7z+HSf1t8mlvno2Xd97oWUFTr6lSnSQmDM+Bw==",
       "dependencies": {
         "cross-fetch": "^3.1.5"
       }
@@ -944,9 +944,9 @@
       }
     },
     "node_modules/@supabase/storage-js": {
-      "version": "1.8.0-next.1",
-      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-1.8.0-next.1.tgz",
-      "integrity": "sha512-osTNB9iHag5Q3aNwUtju+9jZ3mida1o9TvudQo3VSwU4UchuNo6Uy12xkqsCb0ArOrL90dKFm7N3tUK3ltXB+g==",
+      "version": "1.8.0-next.3",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-1.8.0-next.3.tgz",
+      "integrity": "sha512-3gfrXap+awcgwyw44s0x248Qu4x+yaqpe8JLWEnp/G2hecD+J/7vEJ9MJe+GS0ZL+ZJalnWcDWt1m86fxoDyFg==",
       "dependencies": {
         "cross-fetch": "^3.1.5"
       }
@@ -9097,9 +9097,9 @@
       }
     },
     "@supabase/gotrue-js": {
-      "version": "1.23.0-next.8",
-      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-1.23.0-next.8.tgz",
-      "integrity": "sha512-PG1zXXG5shKIVMYXnLxCrk0q1ZdUHjqoK5nwMtJVUOlTwVUNjLR3gk73IsSxOTmnTzfBiyZE1jkGgcxOnCBYAA==",
+      "version": "1.23.0-next.12",
+      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-1.23.0-next.12.tgz",
+      "integrity": "sha512-F+XFCnexNwDHD9JcbqhnJeM10MSBRuLZXWKvEGLjrRSHJdxYm7z+HSf1t8mlvno2Xd97oWUFTr6lSnSQmDM+Bw==",
       "requires": {
         "cross-fetch": "^3.1.5"
       }
@@ -9122,9 +9122,9 @@
       }
     },
     "@supabase/storage-js": {
-      "version": "1.8.0-next.1",
-      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-1.8.0-next.1.tgz",
-      "integrity": "sha512-osTNB9iHag5Q3aNwUtju+9jZ3mida1o9TvudQo3VSwU4UchuNo6Uy12xkqsCb0ArOrL90dKFm7N3tUK3ltXB+g==",
+      "version": "1.8.0-next.3",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-1.8.0-next.3.tgz",
+      "integrity": "sha512-3gfrXap+awcgwyw44s0x248Qu4x+yaqpe8JLWEnp/G2hecD+J/7vEJ9MJe+GS0ZL+ZJalnWcDWt1m86fxoDyFg==",
       "requires": {
         "cross-fetch": "^3.1.5"
       }

--- a/package.json
+++ b/package.json
@@ -38,10 +38,10 @@
   },
   "dependencies": {
     "@supabase/functions-js": "^1.3.3",
-    "@supabase/gotrue-js": "^1.23.0-next.8",
+    "@supabase/gotrue-js": "^1.23.0-next.12",
     "@supabase/postgrest-js": "^1.0.0-next.2",
     "@supabase/realtime-js": "^1.8.0-next.13",
-    "@supabase/storage-js": "^1.8.0-next.1",
+    "@supabase/storage-js": "^1.8.0-next.3",
     "cross-fetch": "^3.1.5"
   },
   "devDependencies": {


### PR DESCRIPTION
Bumps:
- `gotrue-js` to `^1.23.0-next.12`
- `storage-js` to `^1.8.0-next.3`