### PR TITLE
fix: bump storage-js to 1.8.0-next.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@supabase/gotrue-js": "^1.23.0-next.12",
         "@supabase/postgrest-js": "^1.0.0-next.2",
         "@supabase/realtime-js": "^1.8.0-next.13",
-        "@supabase/storage-js": "^1.8.0-next.3",
+        "@supabase/storage-js": "^1.8.0-next.4",
         "cross-fetch": "^3.1.5"
       },
       "devDependencies": {
@@ -944,9 +944,9 @@
       }
     },
     "node_modules/@supabase/storage-js": {
-      "version": "1.8.0-next.3",
-      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-1.8.0-next.3.tgz",
-      "integrity": "sha512-3gfrXap+awcgwyw44s0x248Qu4x+yaqpe8JLWEnp/G2hecD+J/7vEJ9MJe+GS0ZL+ZJalnWcDWt1m86fxoDyFg==",
+      "version": "1.8.0-next.4",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-1.8.0-next.4.tgz",
+      "integrity": "sha512-qeHBaNUJkt+Wzzf8YAg5X/UkFFWHJyxXZ7fEXLdaxHlRj/GgdC5gOTx1LWVNhuYKA3ZFwkH5sYLLoAan8i4yRg==",
       "dependencies": {
         "cross-fetch": "^3.1.5"
       }
@@ -9122,9 +9122,9 @@
       }
     },
     "@supabase/storage-js": {
-      "version": "1.8.0-next.3",
-      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-1.8.0-next.3.tgz",
-      "integrity": "sha512-3gfrXap+awcgwyw44s0x248Qu4x+yaqpe8JLWEnp/G2hecD+J/7vEJ9MJe+GS0ZL+ZJalnWcDWt1m86fxoDyFg==",
+      "version": "1.8.0-next.4",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-1.8.0-next.4.tgz",
+      "integrity": "sha512-qeHBaNUJkt+Wzzf8YAg5X/UkFFWHJyxXZ7fEXLdaxHlRj/GgdC5gOTx1LWVNhuYKA3ZFwkH5sYLLoAan8i4yRg==",
       "requires": {
         "cross-fetch": "^3.1.5"
       }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@supabase/gotrue-js": "^1.23.0-next.12",
     "@supabase/postgrest-js": "^1.0.0-next.2",
     "@supabase/realtime-js": "^1.8.0-next.13",
-    "@supabase/storage-js": "^1.8.0-next.3",
+    "@supabase/storage-js": "^1.8.0-next.4",
     "cross-fetch": "^3.1.5"
   },
   "devDependencies": {

--- a/src/SupabaseClient.ts
+++ b/src/SupabaseClient.ts
@@ -6,7 +6,7 @@ import {
   PostgrestQueryBuilder,
 } from '@supabase/postgrest-js'
 import { RealtimeChannel, RealtimeClient, RealtimeClientOptions } from '@supabase/realtime-js'
-import { SupabaseStorageClient } from '@supabase/storage-js'
+import { StorageClient as SupabaseStorageClient } from '@supabase/storage-js'
 import { DEFAULT_HEADERS } from './lib/constants'
 import { fetchWithAuth } from './lib/fetch'
 import { stripTrailingSlash } from './lib/helpers'


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Bumps storage-js to 1.8.0-next.4 and changes the import from `SupabaseStorageClient` to `StorageClient` (see supabase/storage-js/pull/92)

## Additional context

When installing `@supabase/supabase-js@1.36.0-next.14` it installs `@supabase/storage-js@1.8.0-next.4` and the import is broken.

```bash
$ npm install --save @supabase/supabase-js@1.36.0-next.14
$ npm list @supabase/storage-js
my-awesome-app@1.0.0 /Users/pixtron/projects/my-awesome-app
└─┬ @supabase/supabase-js@1.36.0-next.14
  └── @supabase/storage-js@1.8.0-next.4
```
