### PR TITLE
fix: respect default options

### DIFF
--- a/src/SupabaseClient.ts
+++ b/src/SupabaseClient.ts
@@ -14,12 +14,20 @@ import { SupabaseAuthClient } from './lib/SupabaseAuthClient'
 import { SupabaseRealtimeChannel } from './lib/SupabaseRealtimeChannel'
 import { Fetch, GenericSchema, SupabaseClientOptions, SupabaseAuthClientOptions } from './lib/types'
 
-const DEFAULT_OPTIONS = {
+const DEFAULT_OPTIONS: SupabaseClientOptions<'public'> = {
+  headers: DEFAULT_HEADERS,
+}
+
+const DEFAULT_DB_OPTIONS = {
   schema: 'public',
+}
+
+const DEFAULT_REALTIME_OPTIONS: RealtimeClientOptions = {}
+
+const DEFAULT_AUTH_OPTIONS: SupabaseAuthClientOptions = {
   autoRefreshToken: true,
   persistSession: true,
   detectSessionInUrl: true,
-  headers: DEFAULT_HEADERS,
 }
 
 /**
@@ -90,9 +98,33 @@ export default class SupabaseClient<
     }
     // default storage key uses the supabase project ref as a namespace
     const defaultStorageKey = `sb-${new URL(this.authUrl).hostname.split('.')[0]}-auth-token`
-    this.storageKey = options?.auth?.storageKey ?? defaultStorageKey
 
-    const settings = { ...DEFAULT_OPTIONS, ...options, storageKey: this.storageKey }
+    const {
+      db: dbOptions,
+      auth: authOptions,
+      realtime: realtimeOptions,
+      ...restOptions
+    } = options || {}
+
+    const settings = {
+      ...DEFAULT_OPTIONS,
+      ...restOptions,
+      db: {
+        ...DEFAULT_DB_OPTIONS,
+        ...dbOptions,
+      },
+      auth: {
+        ...DEFAULT_AUTH_OPTIONS,
+        storageKey: defaultStorageKey,
+        ...authOptions,
+      },
+      realtime: {
+        ...DEFAULT_REALTIME_OPTIONS,
+        ...realtimeOptions,
+      },
+    }
+
+    this.storageKey = settings.auth.storageKey
 
     this.headers = { ...DEFAULT_HEADERS, ...options?.headers }
 

--- a/test/SupabaseAuthClient.test.ts
+++ b/test/SupabaseAuthClient.test.ts
@@ -1,10 +1,15 @@
 import { SupabaseAuthClient } from '../src/lib/SupabaseAuthClient'
+import { SupabaseClientOptions } from '../src/lib/types'
 
-const DEFAULT_OPTIONS = {
-  schema: 'public',
-  autoRefreshToken: true,
-  persistSession: true,
-  detectSessionInUrl: true,
+const DEFAULT_OPTIONS: SupabaseClientOptions<'public'> = {
+  db: {
+    schema: 'public',
+  },
+  auth: {
+    autoRefreshToken: true,
+    persistSession: true,
+    detectSessionInUrl: true,
+  },
   headers: {},
 }
 const settings = { ...DEFAULT_OPTIONS }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

After #458, default options of supabase-js does not have any effect on auth anymore as they are expected in `settings.auth` now.  `auth` is undefined in `DEFAULT_OPTIONS`, although default options specifies default auth settings like `autoRefreshToken`. 

## What is the new behavior?

Properly merges default options and user options. Although a testable utility method would probably be superior.
A shallow copy of default options and user options is not sufficient as a partial auth setting passed by the user would override the default options not set in the user options. 

```js
const settings = {
  ...{auth: {a: true}}
  ...{auth: {b: true}}
} 

--> {auth: {b: true}}
```

## Additional context

There seems to be another bug (or is that intentional?) in `_initSupabaseAuthClient`, overriding default gotrue-js options with undefined.

For example when calling `this._initSupabaseAuthClient({persistSession: false});` GotrueClient will be constructed with these options:

```js
{
  persistSession: false,
  storageKey: undefined,
  autoRefreshToken: undefined,
  detectSessionInUrl: undefined,
  storage: undefined,
  cookieOptions: undefined,
 }
```
These undefined values then override the gotrue-js default options
```js
const DEFAULT_OPTIONS = {autoRefreshToken: true}
const settings = {...DEFAULT_OPTIONS, {autoRefreshToken: undefined, persistSession: false}}
--> {autoRefreshToken: undefined, persistSession: false}
```
