### PR TITLE
Remove trailing whitespace from url

### DIFF
--- a/src/SupabaseClient.ts
+++ b/src/SupabaseClient.ts
@@ -9,7 +9,7 @@ import { RealtimeChannel, RealtimeClient, RealtimeClientOptions } from '@supabas
 import { StorageClient as SupabaseStorageClient } from '@supabase/storage-js'
 import { DEFAULT_HEADERS } from './lib/constants'
 import { fetchWithAuth } from './lib/fetch'
-import { stripTrailingSlash, applySettingDefaults } from './lib/helpers'
+import { cleanUrl, applySettingDefaults } from './lib/helpers'
 import { SupabaseAuthClient } from './lib/SupabaseAuthClient'
 import { SupabaseRealtimeChannel } from './lib/SupabaseRealtimeChannel'
 import { Fetch, GenericSchema, SupabaseClientOptions, SupabaseAuthClientOptions } from './lib/types'
@@ -83,7 +83,7 @@ export default class SupabaseClient<
     if (!supabaseUrl) throw new Error('supabaseUrl is required.')
     if (!supabaseKey) throw new Error('supabaseKey is required.')
 
-    const _supabaseUrl = stripTrailingSlash(supabaseUrl)
+    const _supabaseUrl = cleanUrl(supabaseUrl)
 
     this.realtimeUrl = `${_supabaseUrl}/realtime/v1`.replace('http', 'ws')
     this.authUrl = `${_supabaseUrl}/auth/v1`

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -9,8 +9,8 @@ export function uuid() {
   })
 }
 
-export function stripTrailingSlash(url: string): string {
-  return url.replace(/\/$/, '')
+export function cleanUrl(url: string): string {
+  return url.replace(/[\/\s]*$/, '')
 }
 
 export const isBrowser = () => typeof window !== 'undefined'

--- a/test/helper.test.ts
+++ b/test/helper.test.ts
@@ -1,13 +1,25 @@
-import { stripTrailingSlash } from '../src/lib/helpers'
+import { cleanUrl } from '../src/lib/helpers'
 
 test('Strip trailing slash from URL', () => {
   const URL = 'http://localhost:3000/'
   const expectedURL = URL.slice(0, -1)
-  expect(stripTrailingSlash(URL)).toBe(expectedURL)
+  expect(cleanUrl(URL)).toBe(expectedURL)
 })
 
-test('Return the original URL if there is no slash at the end', () => {
+test('Return the original URL if there is no slash or white space at the end', () => {
   const URL = 'http://localhost:3000'
   const expectedURL = URL
-  expect(stripTrailingSlash(URL)).toBe(expectedURL)
+  expect(cleanUrl(URL)).toBe(expectedURL)
+})
+
+test('Strip trailing white space from URL', () => {
+  const URL = 'http://localhost:3000 '
+  const expectedURL = URL.slice(0, -1)
+  expect(cleanUrl(URL)).toBe(expectedURL)
+})
+
+test('Strip trailing slash followed by white space from URL', () => {
+  const URL = 'http://localhost:3000/ '
+  const expectedURL = URL.slice(0, -2)
+  expect(cleanUrl(URL)).toBe(expectedURL)
 })


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the current behavior?

Trailing white space(s?) are not trimmed from URL.  Recently there was a [question in discord](https://discord.com/channels/839993398554656828/1004278230427107328), where the URL looked like this:
`https://{REF}.supabase.co/%20/rest/...`

## What is the new behavior?

Trailing white spaces are trimmed. 


