### PR TITLE
fix: bump next versions of dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,11 @@
       "version": "0.0.0-automated",
       "license": "MIT",
       "dependencies": {
-        "@supabase/functions-js": "^1.4.0-next.1",
-        "@supabase/gotrue-js": "^1.23.0-next.15",
-        "@supabase/postgrest-js": "^1.0.0-next.6",
+        "@supabase/functions-js": "^1.4.0-next.5",
+        "@supabase/gotrue-js": "^1.23.0-next.20",
+        "@supabase/postgrest-js": "^1.0.0-next.7",
         "@supabase/realtime-js": "^1.8.0-next.16",
-        "@supabase/storage-js": "^1.8.0-next.5",
+        "@supabase/storage-js": "^1.8.0-next.6",
         "cross-fetch": "^3.1.5"
       },
       "devDependencies": {
@@ -944,25 +944,25 @@
       }
     },
     "node_modules/@supabase/functions-js": {
-      "version": "1.4.0-next.1",
-      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-1.4.0-next.1.tgz",
-      "integrity": "sha512-MeWpPDn2zOd2StEZdrCP0dfRSbUZ2dJ6HzCBz+FP0PJYmrdlEq4JXU39rq14QRcvC+xESsHDFGrwlilipSTEVw==",
+      "version": "1.4.0-next.5",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-1.4.0-next.5.tgz",
+      "integrity": "sha512-y2lPF1+U5e0DbJo3wKbTQsIB+3Vqq3PZ0pOAjt4RhI9MZBl/or88KcAHzBey+lG38NjQtAo9y0yx0r1mZGm8zQ==",
       "dependencies": {
         "cross-fetch": "^3.1.5"
       }
     },
     "node_modules/@supabase/gotrue-js": {
-      "version": "1.23.0-next.15",
-      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-1.23.0-next.15.tgz",
-      "integrity": "sha512-qNqusLLyhdcaoeNtvvo76gRqRqBnwWZ7DqpcwzR19xZbfgdgR1CqQj/EbvcYfiVSIymnhvji7hTtoOSbf2i9ow==",
+      "version": "1.23.0-next.20",
+      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-1.23.0-next.20.tgz",
+      "integrity": "sha512-/cAkv1dkhQojYGdEiE57TGeGw6mOooyaGLIJUNmPhcsPi92ADiaBvpELOkDvVseKuLvOt7sy7XrEA/D8kUZ0sQ==",
       "dependencies": {
         "cross-fetch": "^3.1.5"
       }
     },
     "node_modules/@supabase/postgrest-js": {
-      "version": "1.0.0-next.6",
-      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.0.0-next.6.tgz",
-      "integrity": "sha512-Owd9qwe7GpH78gtwKh/QBfVaJsmkE/xUGwkDox6P+Cud6jDP0xo2dFVgSsw2GJ5sUxCElr2o3YHOjhRZwX7xSg==",
+      "version": "1.0.0-next.7",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.0.0-next.7.tgz",
+      "integrity": "sha512-UefMDfIJ0aqZoJhIWLHbrrksIiqH+Sv9uml0sfISNX4nm4Q+hqm0aR32pFzr6VfMP7sXK1PaYKyPqGv0a4h7LA==",
       "dependencies": {
         "cross-fetch": "^3.1.5"
       }
@@ -977,9 +977,9 @@
       }
     },
     "node_modules/@supabase/storage-js": {
-      "version": "1.8.0-next.5",
-      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-1.8.0-next.5.tgz",
-      "integrity": "sha512-2lpfuOttdPr9vbJnUv4oGaXrw+/aHmUFmpN4Pd365CNt3wKOVzbn1oVc7ykeky3Ou//KHoSXlzRiG4SRq3m3sw==",
+      "version": "1.8.0-next.6",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-1.8.0-next.6.tgz",
+      "integrity": "sha512-7cLxxvCwlUBe0b6DltI/i/EAFE8RxvouL7FIcW8ysyd30+rAOq14BIbuJjx1PForxQzapcBoaZBUHf+x3xyssw==",
       "dependencies": {
         "cross-fetch": "^3.1.5"
       }
@@ -9159,25 +9159,25 @@
       }
     },
     "@supabase/functions-js": {
-      "version": "1.4.0-next.1",
-      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-1.4.0-next.1.tgz",
-      "integrity": "sha512-MeWpPDn2zOd2StEZdrCP0dfRSbUZ2dJ6HzCBz+FP0PJYmrdlEq4JXU39rq14QRcvC+xESsHDFGrwlilipSTEVw==",
+      "version": "1.4.0-next.5",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-1.4.0-next.5.tgz",
+      "integrity": "sha512-y2lPF1+U5e0DbJo3wKbTQsIB+3Vqq3PZ0pOAjt4RhI9MZBl/or88KcAHzBey+lG38NjQtAo9y0yx0r1mZGm8zQ==",
       "requires": {
         "cross-fetch": "^3.1.5"
       }
     },
     "@supabase/gotrue-js": {
-      "version": "1.23.0-next.15",
-      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-1.23.0-next.15.tgz",
-      "integrity": "sha512-qNqusLLyhdcaoeNtvvo76gRqRqBnwWZ7DqpcwzR19xZbfgdgR1CqQj/EbvcYfiVSIymnhvji7hTtoOSbf2i9ow==",
+      "version": "1.23.0-next.20",
+      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-1.23.0-next.20.tgz",
+      "integrity": "sha512-/cAkv1dkhQojYGdEiE57TGeGw6mOooyaGLIJUNmPhcsPi92ADiaBvpELOkDvVseKuLvOt7sy7XrEA/D8kUZ0sQ==",
       "requires": {
         "cross-fetch": "^3.1.5"
       }
     },
     "@supabase/postgrest-js": {
-      "version": "1.0.0-next.6",
-      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.0.0-next.6.tgz",
-      "integrity": "sha512-Owd9qwe7GpH78gtwKh/QBfVaJsmkE/xUGwkDox6P+Cud6jDP0xo2dFVgSsw2GJ5sUxCElr2o3YHOjhRZwX7xSg==",
+      "version": "1.0.0-next.7",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.0.0-next.7.tgz",
+      "integrity": "sha512-UefMDfIJ0aqZoJhIWLHbrrksIiqH+Sv9uml0sfISNX4nm4Q+hqm0aR32pFzr6VfMP7sXK1PaYKyPqGv0a4h7LA==",
       "requires": {
         "cross-fetch": "^3.1.5"
       }
@@ -9192,9 +9192,9 @@
       }
     },
     "@supabase/storage-js": {
-      "version": "1.8.0-next.5",
-      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-1.8.0-next.5.tgz",
-      "integrity": "sha512-2lpfuOttdPr9vbJnUv4oGaXrw+/aHmUFmpN4Pd365CNt3wKOVzbn1oVc7ykeky3Ou//KHoSXlzRiG4SRq3m3sw==",
+      "version": "1.8.0-next.6",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-1.8.0-next.6.tgz",
+      "integrity": "sha512-7cLxxvCwlUBe0b6DltI/i/EAFE8RxvouL7FIcW8ysyd30+rAOq14BIbuJjx1PForxQzapcBoaZBUHf+x3xyssw==",
       "requires": {
         "cross-fetch": "^3.1.5"
       }

--- a/package.json
+++ b/package.json
@@ -37,11 +37,11 @@
     "docs:json": "typedoc --entryPoints src/index.ts --out docs --includes src/**/*.ts --json docs/spec.json"
   },
   "dependencies": {
-    "@supabase/functions-js": "^1.4.0-next.1",
-    "@supabase/gotrue-js": "^1.23.0-next.15",
-    "@supabase/postgrest-js": "^1.0.0-next.6",
+    "@supabase/functions-js": "^1.4.0-next.5",
+    "@supabase/gotrue-js": "^1.23.0-next.20",
+    "@supabase/postgrest-js": "^1.0.0-next.7",
     "@supabase/realtime-js": "^1.8.0-next.16",
-    "@supabase/storage-js": "^1.8.0-next.5",
+    "@supabase/storage-js": "^1.8.0-next.6",
     "cross-fetch": "^3.1.5"
   },
   "devDependencies": {

--- a/src/SupabaseClient.ts
+++ b/src/SupabaseClient.ts
@@ -234,7 +234,6 @@ export default class SupabaseClient<
       persistSession,
       detectSessionInUrl,
       storage,
-      cookieOptions,
       storageKey,
     }: SupabaseAuthClientOptions,
     headers?: Record<string, string>,
@@ -253,7 +252,6 @@ export default class SupabaseClient<
       detectSessionInUrl,
       storage,
       fetch,
-      cookieOptions,
     })
   }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -36,10 +36,6 @@ export type SupabaseClientOptions<SchemaName> = {
      * A storage provider. Used to store the logged in session.
      */
     storage?: SupabaseAuthClientOptions['storage']
-    /**
-     * Options passed to the gotrue-js instance
-     */
-    cookieOptions?: SupabaseAuthClientOptions['cookieOptions']
   }
   /**
    * Options passed to the realtime-js instance


### PR DESCRIPTION
`@supabase/functions-js`: `^1.4.0-next.1` -> `^1.4.0-next.5`
`@supabase/gotrue-js`: `^1.23.0-next.15` -> `^1.23.0-next.20`
`@supabase/postgrest-js`: `^1.0.0-next.6` -> `^1.0.0-next.7`
`@supabase/storage-js`: `^1.8.0-next.5` -> `^1.8.0-next.6`