### PR TITLE
fix: bump realtime-js version to 2.0.0-rc.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@supabase/functions-js": "^2.0.0-rc.1",
         "@supabase/gotrue-js": "^2.0.0-rc.2",
         "@supabase/postgrest-js": "^1.0.0-rc.1",
-        "@supabase/realtime-js": "^2.0.0-rc.4",
+        "@supabase/realtime-js": "^2.0.0-rc.5",
         "@supabase/storage-js": "^2.0.0-rc.1",
         "cross-fetch": "^3.1.5"
       },
@@ -968,9 +968,9 @@
       }
     },
     "node_modules/@supabase/realtime-js": {
-      "version": "2.0.0-rc.4",
-      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.0.0-rc.4.tgz",
-      "integrity": "sha512-hT3osSZNnCiE6K6s2wgcm0PT7+KsBwswWgoYS5JaTOXC+zVtXACAT07ov5mX+bLl9t1mnCVfa/+bZwnzxwfxmQ==",
+      "version": "2.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.0.0-rc.5.tgz",
+      "integrity": "sha512-0JiSJjoTmwleufGzBQwEVamI047jnAiemBk8qOkgwyoLOlfGTQk8XSA7aT023BsGVgRNKZqp/jJJAVBht/Rd2w==",
       "dependencies": {
         "@types/phoenix": "^1.5.4",
         "websocket": "^1.0.34"
@@ -9183,9 +9183,9 @@
       }
     },
     "@supabase/realtime-js": {
-      "version": "2.0.0-rc.4",
-      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.0.0-rc.4.tgz",
-      "integrity": "sha512-hT3osSZNnCiE6K6s2wgcm0PT7+KsBwswWgoYS5JaTOXC+zVtXACAT07ov5mX+bLl9t1mnCVfa/+bZwnzxwfxmQ==",
+      "version": "2.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.0.0-rc.5.tgz",
+      "integrity": "sha512-0JiSJjoTmwleufGzBQwEVamI047jnAiemBk8qOkgwyoLOlfGTQk8XSA7aT023BsGVgRNKZqp/jJJAVBht/Rd2w==",
       "requires": {
         "@types/phoenix": "^1.5.4",
         "websocket": "^1.0.34"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@supabase/functions-js": "^2.0.0-rc.1",
     "@supabase/gotrue-js": "^2.0.0-rc.2",
     "@supabase/postgrest-js": "^1.0.0-rc.1",
-    "@supabase/realtime-js": "^2.0.0-rc.4",
+    "@supabase/realtime-js": "^2.0.0-rc.5",
     "@supabase/storage-js": "^2.0.0-rc.1",
     "cross-fetch": "^3.1.5"
   },


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Developing in React/NextJS Strict Mode causes Realtime channel to close due to rapid mount -> unmount -> mount cycle.

## What is the new behavior?

Realtime channel is is successfully connected despite Strict Mode.

## Additional context

Related issue: https://github.com/supabase/realtime-js/issues/169
