### PR TITLE
fix: ignore case when creating realtime url

### DIFF
--- a/src/SupabaseClient.ts
+++ b/src/SupabaseClient.ts
@@ -84,7 +84,7 @@ export default class SupabaseClient<
 
     const _supabaseUrl = stripTrailingSlash(supabaseUrl)
 
-    this.realtimeUrl = `${_supabaseUrl}/realtime/v1`.replace('http', 'ws')
+    this.realtimeUrl = `${_supabaseUrl}/realtime/v1`.replace(/^http/i, 'ws')
     this.authUrl = `${_supabaseUrl}/auth/v1`
     this.storageUrl = `${_supabaseUrl}/storage/v1`
 

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -28,6 +28,35 @@ describe('Custom Headers', () => {
   })
 })
 
+describe('Realtime url', () => {
+  test('should switch protocol from http to ws', () => {
+    const client = createClient('http://localhost:3000', KEY)
+
+    // @ts-ignore
+    const realtimeUrl = client.realtimeUrl
+
+    expect(realtimeUrl).toEqual('ws://localhost:3000/realtime/v1')
+  })
+
+  test('should switch protocol from https to wss', () => {
+    const client = createClient('https://localhost:3000', KEY)
+
+    // @ts-ignore
+    const realtimeUrl = client.realtimeUrl
+
+    expect(realtimeUrl).toEqual('wss://localhost:3000/realtime/v1')
+  })
+
+  test('should ignore case', () => {
+    const client = createClient('HTTP://localhost:3000', KEY)
+
+    // @ts-ignore
+    const realtimeUrl = client.realtimeUrl
+
+    expect(realtimeUrl).toEqual('ws://localhost:3000/realtime/v1')
+  })
+})
+
 // Socket should close when there are no open connections
 // https://github.com/supabase/supabase-js/issues/44
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

If the supabase url passed to the client contains upercase chars in the protocol, the realtime url does not switch protocols from `http | https` to `ws | wss`. 
See this issue in realtime-js: supabase/supabase-js#531

## What is the new behavior?

Case is ignored when replacing `http` with `ws`. 

## Additional context

Another option could be to clean the whole supabase url with `url.toLowerCase()`.
