### PR TITLE
fix typo in rpc call doc

### DIFF
--- a/src/SupabaseClient.ts
+++ b/src/SupabaseClient.ts
@@ -164,9 +164,9 @@ export default class SupabaseClient<
    * Perform a function call.
    *
    * @param fn  The function name to call.
-   * @param params  The parameters to pass to the function call.
-   * @param head   When set to true, no data will be returned.
-   * @param count  Count algorithm to use to count rows in a table.
+   * @param args  The parameters to pass to the function call.
+   * @param options.head   When set to true, no data will be returned.
+   * @param options.count  Count algorithm to use to count rows in a table.
    *
    */
   rpc<


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix typo in JSDoc for PostgREST -> rpc call

## What is the current behavior?

parameters had old names

## What is the new behavior?

JSDoc for PostgREST rpc call is up to date
