### PR TITLE
fix: custom authorization header should not be overwritten

### DIFF
--- a/src/SupabaseClient.ts
+++ b/src/SupabaseClient.ts
@@ -248,7 +248,7 @@ export default class SupabaseClient<
     }
     return new SupabaseAuthClient({
       url: this.authUrl,
-      headers: { ...headers, ...authHeaders },
+      headers: { ...authHeaders, ...headers },
       storageKey: storageKey,
       autoRefreshToken,
       persistSession,

--- a/test/SupabaseAuthClient.test.ts
+++ b/test/SupabaseAuthClient.test.ts
@@ -1,5 +1,5 @@
 import { SupabaseAuthClient } from '../src/lib/SupabaseAuthClient'
-import { SupabaseClientOptions } from '../src/lib/types'
+import SupabaseClient from '../src/SupabaseClient'
 import { DEFAULT_HEADERS } from '../src/lib/constants'
 
 const DEFAULT_OPTIONS = {
@@ -22,4 +22,14 @@ const authSettings = { ...settings.global, ...settings.auth }
 test('it should create a new instance of the class', () => {
   const authClient = new SupabaseAuthClient(authSettings)
   expect(authClient).toBeInstanceOf(SupabaseAuthClient)
+})
+
+test('_initSupabaseAuthClient should overwrite authHeaders if headers are provided', () => {
+  const authClient = new SupabaseClient('https://example.supabase.com', 'supabaseKey')[
+    '_initSupabaseAuthClient'
+  ](authSettings, {
+    Authorization: 'Bearer custom-auth-header',
+  })
+  expect(authClient['headers']['Authorization']).toBe('Bearer custom-auth-header')
+  expect(authClient['headers']['apikey']).toBe('supabaseKey')
 })


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Fixes a bug with `_initSupabaseAuthClient` where it overwrites the custom `Authorization` header passed into `SupabaseClient` with the default authorization header (the supabase key)
* The auth client should be using the custom `Authorizaion` header instead 