### PR TITLE
fix: clear this.changedAccessToken after signOut

### DIFF
--- a/src/SupabaseClient.ts
+++ b/src/SupabaseClient.ts
@@ -295,6 +295,7 @@ export default class SupabaseClient<
       // Token is removed
       this.realtime.setAuth(this.supabaseKey)
       if (source == 'STORAGE') this.auth.signOut()
+      this.changedAccessToken = undefined
     }
   }
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Resolves the last remaining issue of, and closes https://github.com/supabase/gotrue-js/issues/524

## What is the current behavior?

After a user is logged out, the supabase-js client's `changedAccessToken` property still contains the user's jwt.

## What is the new behavior?

`this.changedAccessToken` is set to `undefined`, per typing.

## Additional context

If a `TOKEN_REFRESHED` or `SIGNED_IN` event occurs, `_handleTokenChanged` sets `this.changedAccessToken` (under the proper conditions). So I assume `_handleTokenChanged` is the place to unset `this.changedAccessToken` if a `SIGNED_OUT` event occurs.
