### PR TITLE
fix: unset `changedAccessToken` on sign out

### DIFF
--- a/src/SupabaseClient.ts
+++ b/src/SupabaseClient.ts
@@ -295,6 +295,8 @@ export default class SupabaseClient<
       // Token is removed
       this.realtime.setAuth(this.supabaseKey)
       if (source == 'STORAGE') this.auth.signOut()
+
+      this.changedAccessToken = undefined
     }
   }
 }


### PR DESCRIPTION
When a user signs out, the access token should no longer be kept in RAM.

See: https://github.com/supabase/gotrue-js/issues/524

Thanks @j4w8n.