### PR TITLE
feat: pass global header bearer token as apikey to RealtimeClient

### DIFF
--- a/src/SupabaseClient.ts
+++ b/src/SupabaseClient.ts
@@ -265,9 +265,11 @@ export default class SupabaseClient<
   }
 
   private _initRealtimeClient(options: RealtimeClientOptions) {
+    const authHeader = options.headers?.Authorization
+    const authToken = authHeader?.startsWith('Bearer ') && authHeader.split(' ')[1]
     return new RealtimeClient(this.realtimeUrl, {
       ...options,
-      params: { ...{ apikey: this.supabaseKey }, ...options?.params },
+      params: { ...{ apikey: authToken || this.supabaseKey }, ...options?.params },
     })
   }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the new behavior?

Enable custom token to be passed as apikey to RealtimeClient

## Additional context

Issue: https://github.com/supabase/supabase-js/issues/553
Discussion: https://github.com/supabase/supabase/discussions/11826
