### PR TITLE
Fix - Set custom jwt as auth token

### DIFF
--- a/src/SupabaseClient.ts
+++ b/src/SupabaseClient.ts
@@ -274,6 +274,7 @@ export default class SupabaseClient<
     if ( authToken ) {
       newRealtimeClient.setAuth(authToken)
     }
+    return newRealtimeClient
   }
 
   private _listenForAuthEvents() {

--- a/src/SupabaseClient.ts
+++ b/src/SupabaseClient.ts
@@ -267,10 +267,13 @@ export default class SupabaseClient<
   private _initRealtimeClient(options: RealtimeClientOptions) {
     const authHeader = options.headers?.Authorization
     const authToken = authHeader?.startsWith('Bearer ') && authHeader.split(' ')[1]
-    return new RealtimeClient(this.realtimeUrl, {
+    const newRealtimeClient = new RealtimeClient(this.realtimeUrl, {
       ...options,
-      params: { ...{ apikey: authToken || this.supabaseKey }, ...options?.params },
+      params: { ...{ apikey: this.supabaseKey }, ...options?.params },
     })
+    if ( authToken ) {
+      newRealtimeClient.setAuth(authToken)
+    }
   }
 
   private _listenForAuthEvents() {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix - Initializing realtime client failing when custom JWT sent through Authorization header 
Please find the issue [here](https://github.com/supabase/realtime/issues/470)

## What is the current behavior?

If the custom JWT is sent through global Authorization Header then this custom JWT is used as apikey while making new realtime connection. This behaviour is added in this [pr](https://github.com/supabase/supabase-js/pull/699)

## What is the new behavior?

If the custom JWT is sent through headers, we create new realtime client using supabasekey as apikey and then we use setAuth function to set the custom JWT

## Additional context

Please find this [issue](https://github.com/supabase/realtime/issues/470) created in realtime repo