### PR TITLE
feat: bump gotrue-js to 2.12.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@supabase/functions-js": "^2.0.0",
-        "@supabase/gotrue-js": "^2.10.2",
+        "@supabase/gotrue-js": "^2.12.0",
         "@supabase/postgrest-js": "^1.1.1",
         "@supabase/realtime-js": "^2.4.0",
         "@supabase/storage-js": "^2.1.0",
@@ -1074,9 +1074,9 @@
       }
     },
     "node_modules/@supabase/gotrue-js": {
-      "version": "2.10.2",
-      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-2.10.2.tgz",
-      "integrity": "sha512-tzfPtEPnLfeghxDvSS28/AiWgBcwNPjG70Tn1owlB2mumsf4xkTfXiZBYUjtCCL65/bUncs8Pbive4tL+vfIgA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-2.12.0.tgz",
+      "integrity": "sha512-sx9YbCf2wjdYww7j3bkpPHSQ6Ur79xSlxBw0Kq6chWqCeG8vst1dUCPeHZZWfu++nblCRnCajhryZ3Xt5XVj8g==",
       "dependencies": {
         "cross-fetch": "^3.1.5"
       }
@@ -6891,9 +6891,9 @@
       }
     },
     "@supabase/gotrue-js": {
-      "version": "2.10.2",
-      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-2.10.2.tgz",
-      "integrity": "sha512-tzfPtEPnLfeghxDvSS28/AiWgBcwNPjG70Tn1owlB2mumsf4xkTfXiZBYUjtCCL65/bUncs8Pbive4tL+vfIgA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-2.12.0.tgz",
+      "integrity": "sha512-sx9YbCf2wjdYww7j3bkpPHSQ6Ur79xSlxBw0Kq6chWqCeG8vst1dUCPeHZZWfu++nblCRnCajhryZ3Xt5XVj8g==",
       "requires": {
         "cross-fetch": "^3.1.5"
       }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@supabase/functions-js": "^2.0.0",
-    "@supabase/gotrue-js": "^2.10.2",
+    "@supabase/gotrue-js": "^2.12.0",
     "@supabase/postgrest-js": "^1.1.1",
     "@supabase/realtime-js": "^2.4.0",
     "@supabase/storage-js": "^2.1.0",


### PR DESCRIPTION
Bumps gotrue-js to 2.12.0 which includes `supabase.auth.signInWithIdToken` and some additional improvements.