### PR TITLE
feat: bump gotrue-js to v2.31.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@supabase/functions-js": "^2.1.0",
-        "@supabase/gotrue-js": "^2.26.0",
+        "@supabase/gotrue-js": "^2.31.0",
         "@supabase/postgrest-js": "^1.7.0",
         "@supabase/realtime-js": "^2.7.3",
         "@supabase/storage-js": "^2.5.1",
@@ -1061,9 +1061,9 @@
       }
     },
     "node_modules/@supabase/gotrue-js": {
-      "version": "2.26.0",
-      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-2.26.0.tgz",
-      "integrity": "sha512-orxz8nwaF5D1nY/9H5xxTfFSCTvYeDLx24UO/Mxsx83xFP0t5RNxQZ0lEHBOhHhXJ4vR/COv79AxoWCOTu/7Rg==",
+      "version": "2.31.0",
+      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-2.31.0.tgz",
+      "integrity": "sha512-YcwlbbNfedlue/HVIXtYBb4fuOrs29gNOTl6AmyxPp4zryRxzFvslVN9kmLDBRUAVU9fnPJh2bgOR3chRjJX5w==",
       "dependencies": {
         "cross-fetch": "^3.1.5"
       }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@supabase/functions-js": "^2.1.0",
-    "@supabase/gotrue-js": "^2.26.0",
+    "@supabase/gotrue-js": "^2.31.0",
     "@supabase/postgrest-js": "^1.7.0",
     "@supabase/realtime-js": "^2.7.3",
     "@supabase/storage-js": "^2.5.1",


### PR DESCRIPTION
Bumps `gotrue-js` to v2.31.0.