### PR TITLE
feat: add debug option for gotrue client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@supabase/functions-js": "^2.1.0",
-        "@supabase/gotrue-js": "^2.31.0",
+        "@supabase/gotrue-js": "^2.39.0",
         "@supabase/postgrest-js": "^1.7.0",
         "@supabase/realtime-js": "^2.7.3",
         "@supabase/storage-js": "^2.5.1",
@@ -1061,9 +1061,9 @@
       }
     },
     "node_modules/@supabase/gotrue-js": {
-      "version": "2.31.0",
-      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-2.31.0.tgz",
-      "integrity": "sha512-YcwlbbNfedlue/HVIXtYBb4fuOrs29gNOTl6AmyxPp4zryRxzFvslVN9kmLDBRUAVU9fnPJh2bgOR3chRjJX5w==",
+      "version": "2.39.1",
+      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-2.39.1.tgz",
+      "integrity": "sha512-qRz9mBleA/QATGKOdMAUjpn+YcbZJrTHyWQCe2hAFqJo15JIe1XziD1ZeFraRpsXwja+vONslGeynGv7H8ZZeQ==",
       "dependencies": {
         "cross-fetch": "^3.1.5"
       }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@supabase/functions-js": "^2.1.0",
-    "@supabase/gotrue-js": "^2.31.0",
+    "@supabase/gotrue-js": "^2.39.0",
     "@supabase/postgrest-js": "^1.7.0",
     "@supabase/realtime-js": "^2.7.3",
     "@supabase/storage-js": "^2.5.1",

--- a/src/SupabaseClient.ts
+++ b/src/SupabaseClient.ts
@@ -252,6 +252,7 @@ export default class SupabaseClient<
       storage,
       storageKey,
       flowType,
+      debug,
     }: SupabaseAuthClientOptions,
     headers?: Record<string, string>,
     fetch?: Fetch
@@ -269,6 +270,7 @@ export default class SupabaseClient<
       detectSessionInUrl,
       storage,
       flowType,
+      debug,
       fetch,
     })
   }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -40,6 +40,10 @@ export type SupabaseClientOptions<SchemaName> = {
      * OAuth flow to use - defaults to implicit flow. PKCE is recommended for mobile and server-side applications.
      */
     flowType?: SupabaseAuthClientOptions['flowType']
+    /**
+     * If debug messages for authentication client are emitted. Can be used to inspect the behavior of the library.
+     */ 
+    debug?: boolean
   }
   /**
    * Options passed to the realtime-js instance


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature to introduce the option to pass a debug flag down to gotrue client.
Bumps `gotrue-js` to v2.39.1.

## What is the current behavior?

Currently it is not possible to pass the debug flag to the authentication client.
The debug flag was recently introduced [here](https://github.com/supabase/gotrue-js/commit/c990bc23f08f56e34502b4fc62334da96bd3ca3b) and first released in [v2.35.0](https://github.com/supabase/gotrue-js/releases/tag/v2.35.0).

## What is the new behavior?

`gotrue-js` has been bumped to v2.39.1 in order to make the debug flag option available in `SupabaseAuthClientOptions`.
Introduce debug flag in `auth` settings for `SupabaseClientOptions` and pass it on to the `SupabaseAuthClient`.

## Additional context

This is my first try of a contribution, so please let me know if I did something wrong. Since this was faster implemented than described, I went straight to implementation instead of raising a discussion first.
If I should split the version bump in a separate PR please let me know as well.

Currently I have an issue with authentication in `supabase-js` client and I believe having this debug option could help me understand the issue better.
