### PR TITLE
feat: roll back to fixed gotrue-js 2.43.1 until 2.45.0 is fixed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@supabase/functions-js": "^2.1.0",
-        "@supabase/gotrue-js": "^2.45.0",
+        "@supabase/gotrue-js": "2.43.1",
         "@supabase/postgrest-js": "^1.7.0",
         "@supabase/realtime-js": "^2.7.3",
         "@supabase/storage-js": "^2.5.1",
@@ -1061,9 +1061,9 @@
       }
     },
     "node_modules/@supabase/gotrue-js": {
-      "version": "2.45.0",
-      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-2.45.0.tgz",
-      "integrity": "sha512-ctHQqk9foMHvU9pyGXbSbyalmyJ4dkpK/72jIytH5DbXxawqPIjUmJ+Ww9yyJLFP6wCsjPdeYBI+NW070WESvg==",
+      "version": "2.43.1",
+      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-2.43.1.tgz",
+      "integrity": "sha512-HVjjElEPbM5sDoK1pXry/H181X7A1a9G9O68PZwN276y/EUwWOw3pA8KKKSRTaTSiK+41BPC8HUfsfbe7470RQ==",
       "dependencies": {
         "cross-fetch": "^3.1.5"
       }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@supabase/functions-js": "^2.1.0",
-    "@supabase/gotrue-js": "^2.45.0",
+    "@supabase/gotrue-js": "2.43.1",
     "@supabase/postgrest-js": "^1.7.0",
     "@supabase/realtime-js": "^2.7.3",
     "@supabase/storage-js": "^2.5.1",


### PR DESCRIPTION
v2.45.0 has some issues with waiting for the `_initialize` promise that breaks some flows. We're pinning to v2.43.1 as this one does not suffer from any issues.