### PR TITLE
Set functions-js and postgrest-js versions to exact

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,12 @@
       "version": "0.0.0-automated",
       "license": "MIT",
       "dependencies": {
-        "@supabase/functions-js": "^2.1.5",
-        "@supabase/gotrue-js": "^2.60.0",
-        "@supabase/node-fetch": "^2.6.14",
-        "@supabase/postgrest-js": "^1.9.0",
-        "@supabase/realtime-js": "^2.9.3",
-        "@supabase/storage-js": "^2.5.4"
+        "@supabase/functions-js": "2.1.5",
+        "@supabase/gotrue-js": "2.62.2",
+        "@supabase/node-fetch": "2.6.15",
+        "@supabase/postgrest-js": "1.9.2",
+        "@supabase/realtime-js": "2.9.3",
+        "@supabase/storage-js": "2.5.5"
       },
       "devDependencies": {
         "@types/jest": "^29.2.5",
@@ -1133,17 +1133,17 @@
       }
     },
     "node_modules/@supabase/gotrue-js": {
-      "version": "2.60.1",
-      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-2.60.1.tgz",
-      "integrity": "sha512-dM28NhyPS5NLWpJbVokxGbuEMmMK2K+EBXYlNU2NEYzp1BrkdxetNh8ucslMbKauJ93XAEhbMCQHSO9fZ2E+DQ==",
+      "version": "2.62.2",
+      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-2.62.2.tgz",
+      "integrity": "sha512-AP6e6W9rQXFTEJ7sTTNYQrNf0LCcnt1hUW+RIgUK+Uh3jbWvcIST7wAlYyNZiMlS9+PYyymWQ+Ykz/rOYSO0+A==",
       "dependencies": {
         "@supabase/node-fetch": "^2.6.14"
       }
     },
     "node_modules/@supabase/node-fetch": {
-      "version": "2.6.14",
-      "resolved": "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.14.tgz",
-      "integrity": "sha512-w/Tsd22e/5fAeoxqQ4P2MX6EyF+iM6rc9kmlMVFkHuG0rAltt2TLhFbDJfemnHbtvnazWaRfy5KnFU/SYT37dQ==",
+      "version": "2.6.15",
+      "resolved": "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.15.tgz",
+      "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -1152,9 +1152,9 @@
       }
     },
     "node_modules/@supabase/postgrest-js": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.9.0.tgz",
-      "integrity": "sha512-axP6cU69jDrLbfihJKQ6vU27tklD0gzb9idkMN363MtTXeJVt5DQNT3JnJ58JVNBdL74hgm26rAsFNvHk+tnSw==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.9.2.tgz",
+      "integrity": "sha512-I6yHo8CC9cxhOo6DouDMy9uOfW7hjdsnCxZiaJuIVZm1dBGTFiQPgfMa9zXCamEWzNyWRjZvupAUuX+tqcl5Sw==",
       "dependencies": {
         "@supabase/node-fetch": "^2.6.14"
       }
@@ -1171,9 +1171,9 @@
       }
     },
     "node_modules/@supabase/storage-js": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.5.4.tgz",
-      "integrity": "sha512-yspHD19I9uQUgfTh0J94+/r/g6hnhdQmw6Y7OWqr/EbnL6uvicGV1i1UDkkmeUHqfF9Mbt2sLtuxRycYyKv2ew==",
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.5.5.tgz",
+      "integrity": "sha512-OpLoDRjFwClwc2cjTJZG8XviTiQH4Ik8sCiMK5v7et0MDu2QlXjCAW3ljxJB5+z/KazdMOTnySi+hysxWUPu3w==",
       "dependencies": {
         "@supabase/node-fetch": "^2.6.14"
       }

--- a/package.json
+++ b/package.json
@@ -37,12 +37,12 @@
     "docs:json": "typedoc --entryPoints src/index.ts --includes src/**/*.ts --json docs/v2/spec.json --excludeExternals"
   },
   "dependencies": {
-    "@supabase/functions-js": "^2.1.5",
-    "@supabase/gotrue-js": "^2.60.0",
-    "@supabase/node-fetch": "^2.6.14",
-    "@supabase/postgrest-js": "^1.9.0",
-    "@supabase/realtime-js": "^2.9.3",
-    "@supabase/storage-js": "^2.5.4"
+    "@supabase/functions-js": "2.1.5",
+    "@supabase/gotrue-js": "2.62.2",
+    "@supabase/node-fetch": "2.6.15",
+    "@supabase/postgrest-js": "1.9.2",
+    "@supabase/realtime-js": "2.9.3",
+    "@supabase/storage-js": "2.5.5"
   },
   "devDependencies": {
     "@types/jest": "^29.2.5",


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes the following issue by preventing the latest versions of postgrest-js by preventing supabase-js from accepting dependency versions above the tested working version. https://github.com/supabase/postgrest-js/issues/449

## What is the current behavior?

Arbitrary versions allow the version to update, causing unintended breaking changes (as explained in the issue)
```diff
"@supabase/functions-js@^2.1.0":
-  version "2.1.1"
+ version "2.1.2"
  dependencies:
    cross-fetch "^3.1.5"

"@supabase/gotrue-js@2.43.1":
  version "2.43.1"
  resolved "https://registry.yarnpkg.com/@supabase/gotrue-js/-/gotrue-js-2.43.1.tgz#4623791433f0b7ef4c17f0d880fba1f0307b4c81"
  integrity sha512-HVjjElEPbM5sDoK1pXry/H181X7A1a9G9O68PZwN276y/EUwWOw3pA8KKKSRTaTSiK+41BPC8HUfsfbe7470RQ==
  dependencies:
    cross-fetch "^3.1.5"

"@supabase/postgrest-js@^1.7.0":
-  version "1.7.0"
+  version "1.7.2"
  resolved "https://registry.yarnpkg.com/@supabase/postgrest-js/-/postgrest-js-1.7.0.tgz#69ffb605d083d4761d9c30075c04b10e32cc7fd0"
  integrity sha512-wLADHZ5jm7LljF4GigK0H2vc1wGupBY2hGYfb4fVo0UuyMftmA6tOYy+ZpMH/vPq01CUFwXGwvIke6kyqh/QDg==
  dependencies:
    cross-fetch "^3.1.5"

"@supabase/realtime-js@^2.7.3":
  version "2.7.3"
  dependencies:
    "@types/phoenix" "^1.5.4"
    "@types/websocket" "^1.0.3"
    websocket "^1.0.34"

"@supabase/storage-js@^2.5.1":
  version "2.5.1"
  dependencies:
    cross-fetch "^3.1.5"

"@supabase/supabase-js@^2.26.0":
  version "2.29.0"
  dependencies:
    "@supabase/functions-js" "^2.1.0"
    "@supabase/gotrue-js" "2.43.1"
    "@supabase/postgrest-js" "^1.7.0"
    "@supabase/realtime-js" "^2.7.3"
    "@supabase/storage-js" "^2.5.1"
    cross-fetch "^3.1.5"
```


## What is the new behavior?

The version is locked to the intended version

## Additional context

Add any other context or screenshots.
