### PR TITLE
feat: bump @supabase/gotrue-js to ^v2.46.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@supabase/functions-js": "^2.1.0",
-        "@supabase/gotrue-js": "2.43.1",
+        "@supabase/gotrue-js": "^2.46.1",
         "@supabase/postgrest-js": "^1.7.0",
         "@supabase/realtime-js": "^2.7.3",
         "@supabase/storage-js": "^2.5.1",
@@ -1061,9 +1061,9 @@
       }
     },
     "node_modules/@supabase/gotrue-js": {
-      "version": "2.43.1",
-      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-2.43.1.tgz",
-      "integrity": "sha512-HVjjElEPbM5sDoK1pXry/H181X7A1a9G9O68PZwN276y/EUwWOw3pA8KKKSRTaTSiK+41BPC8HUfsfbe7470RQ==",
+      "version": "2.46.1",
+      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-2.46.1.tgz",
+      "integrity": "sha512-tebFX3XvPqEJKHOVgkXTN20g9iUhLx6tebIYQvTggYTrqOT2af8oTpSBdgYzbwJ291G6P6CSpR6KY0cT9ade5A==",
       "dependencies": {
         "cross-fetch": "^3.1.5"
       }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@supabase/functions-js": "^2.1.0",
-    "@supabase/gotrue-js": "2.43.1",
+    "@supabase/gotrue-js": "^2.46.1",
     "@supabase/postgrest-js": "^1.7.0",
     "@supabase/realtime-js": "^2.7.3",
     "@supabase/storage-js": "^2.5.1",


### PR DESCRIPTION
Bumps `@supabase/gotrue-js` to `^v2.46.1` after issues discovered with #817.