### PR TITLE
Add dynamic schemas on a per-query basis

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@supabase/functions-js": "^2.1.0",
         "@supabase/gotrue-js": "^2.46.1",
-        "@supabase/postgrest-js": "^1.7.0",
+        "@supabase/postgrest-js": "^1.8.0",
         "@supabase/realtime-js": "^2.7.3",
         "@supabase/storage-js": "^2.5.1",
         "cross-fetch": "^3.1.5"
@@ -1069,9 +1069,9 @@
       }
     },
     "node_modules/@supabase/postgrest-js": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.7.0.tgz",
-      "integrity": "sha512-wLADHZ5jm7LljF4GigK0H2vc1wGupBY2hGYfb4fVo0UuyMftmA6tOYy+ZpMH/vPq01CUFwXGwvIke6kyqh/QDg==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.8.0.tgz",
+      "integrity": "sha512-R6leDIC92NgjyG2/tCRJ42rWN7+fZY6ulTEE+c00tcnghn6cX4IYUlnTNMtrdfYC2JYNOTyM+rWj63Wdhr7Zig==",
       "dependencies": {
         "cross-fetch": "^3.1.5"
       }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@supabase/functions-js": "^2.1.0",
     "@supabase/gotrue-js": "^2.46.1",
-    "@supabase/postgrest-js": "^1.7.0",
+    "@supabase/postgrest-js": "^1.8.0",
     "@supabase/realtime-js": "^2.7.3",
     "@supabase/storage-js": "^2.5.1",
     "cross-fetch": "^3.1.5"

--- a/src/SupabaseClient.ts
+++ b/src/SupabaseClient.ts
@@ -161,6 +161,24 @@ export default class SupabaseClient<
   }
 
   /**
+   * Perform a query on a schema distinct from the default schema supplied via
+   * the `options.db.schema` constructor parameter.
+   *
+   * The schema needs to be on the list of exposed schemas inside Supabase.
+   *
+   * @param schema - The name of the schema to query
+   */
+  schema<DynamicSchema extends string & keyof Database>(
+    schema: DynamicSchema
+  ): PostgrestClient<
+    Database,
+    DynamicSchema,
+    Database[DynamicSchema] extends GenericSchema ? Database[DynamicSchema] : any
+  > {
+    return this.rest.schema<DynamicSchema>(schema)
+  }
+
+  /**
    * Perform a function call.
    *
    * @param fn - The function name to call

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -42,7 +42,7 @@ export type SupabaseClientOptions<SchemaName> = {
     flowType?: SupabaseAuthClientOptions['flowType']
     /**
      * If debug messages for authentication client are emitted. Can be used to inspect the behavior of the library.
-     */ 
+     */
     debug?: boolean
   }
   /**

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -1,4 +1,6 @@
+import { PostgrestClient } from '@supabase/postgrest-js'
 import { createClient, SupabaseClient } from '../src/index'
+import { Database } from './types'
 
 const URL = 'http://localhost:3000'
 const KEY = 'some.fake.key'
@@ -54,6 +56,14 @@ describe('Realtime url', () => {
     const realtimeUrl = client.realtimeUrl
 
     expect(realtimeUrl).toEqual('ws://localhost:3000/realtime/v1')
+  })
+})
+
+describe('Dynamic schema', () => {
+  test('should swap schemas', async () => {
+    const client = createClient<Database>('HTTP://localhost:3000', KEY)
+    expect(client.schema('personal')).toBeInstanceOf(PostgrestClient)
+    expect(client.schema('personal').from('users').schema).toBe('personal')
   })
 })
 

--- a/test/types.ts
+++ b/test/types.ts
@@ -1,0 +1,201 @@
+export type Json = string | number | boolean | null | { [key: string]: Json } | Json[]
+
+export interface Database {
+  personal: {
+    Tables: {
+      users: {
+        Row: {
+          age_range: unknown | null
+          data: Json | null
+          status: Database['public']['Enums']['user_status'] | null
+          username: string
+        }
+        Insert: {
+          age_range?: unknown | null
+          data?: Json | null
+          status?: Database['public']['Enums']['user_status'] | null
+          username: string
+        }
+        Update: {
+          age_range?: unknown | null
+          data?: Json | null
+          status?: Database['public']['Enums']['user_status'] | null
+          username?: string
+        }
+        Relationships: []
+      }
+    }
+    Views: {
+      [_ in never]: never
+    }
+    Functions: {
+      get_status: {
+        Args: {
+          name_param: string
+        }
+        Returns: Database['public']['Enums']['user_status']
+      }
+    }
+    Enums: {
+      user_status: 'ONLINE' | 'OFFLINE'
+    }
+    CompositeTypes: {
+      [_ in never]: never
+    }
+  }
+  public: {
+    Tables: {
+      channels: {
+        Row: {
+          data: Json | null
+          id: number
+          slug: string | null
+        }
+        Insert: {
+          data?: Json | null
+          id?: number
+          slug?: string | null
+        }
+        Update: {
+          data?: Json | null
+          id?: number
+          slug?: string | null
+        }
+        Relationships: []
+      }
+      messages: {
+        Row: {
+          channel_id: number
+          data: Json | null
+          id: number
+          message: string | null
+          username: string
+        }
+        Insert: {
+          channel_id: number
+          data?: Json | null
+          id?: number
+          message?: string | null
+          username: string
+        }
+        Update: {
+          channel_id?: number
+          data?: Json | null
+          id?: number
+          message?: string | null
+          username?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: 'messages_username_fkey'
+            columns: ['username']
+            referencedRelation: 'users'
+            referencedColumns: ['username']
+          },
+          {
+            foreignKeyName: 'messages_channel_id_fkey'
+            columns: ['channel_id']
+            referencedRelation: 'channels'
+            referencedColumns: ['id']
+          }
+        ]
+      }
+      shops: {
+        Row: {
+          address: string | null
+          id: number
+          shop_geom: unknown | null
+        }
+        Insert: {
+          address?: string | null
+          id: number
+          shop_geom?: unknown | null
+        }
+        Update: {
+          address?: string | null
+          id?: number
+          shop_geom?: unknown | null
+        }
+        Relationships: []
+      }
+      users: {
+        Row: {
+          age_range: unknown | null
+          catchphrase: unknown | null
+          data: Json | null
+          status: Database['public']['Enums']['user_status'] | null
+          username: string
+        }
+        Insert: {
+          age_range?: unknown | null
+          catchphrase?: unknown | null
+          data?: Json | null
+          status?: Database['public']['Enums']['user_status'] | null
+          username: string
+        }
+        Update: {
+          age_range?: unknown | null
+          catchphrase?: unknown | null
+          data?: Json | null
+          status?: Database['public']['Enums']['user_status'] | null
+          username?: string
+        }
+        Relationships: []
+      }
+    }
+    Views: {
+      non_updatable_view: {
+        Row: {
+          username: string | null
+        }
+      }
+      updatable_view: {
+        Row: {
+          non_updatable_column: number | null
+          username: string | null
+        }
+        Insert: {
+          non_updatable_column?: never
+          username?: string | null
+        }
+        Update: {
+          non_updatable_column?: never
+          username?: string | null
+        }
+      }
+    }
+    Functions: {
+      get_status: {
+        Args: {
+          name_param: string
+        }
+        Returns: Database['public']['Enums']['user_status']
+      }
+      get_username_and_status: {
+        Args: {
+          name_param: string
+        }
+        Returns: {
+          username: string
+          status: Database['public']['Enums']['user_status']
+        }[]
+      }
+      offline_user: {
+        Args: {
+          name_param: string
+        }
+        Returns: Database['public']['Enums']['user_status']
+      }
+      void_func: {
+        Args: Record<PropertyKey, never>
+        Returns: undefined
+      }
+    }
+    Enums: {
+      user_status: 'ONLINE' | 'OFFLINE'
+    }
+    CompositeTypes: {
+      [_ in never]: never
+    }
+  }
+}


### PR DESCRIPTION
Resolves https://github.com/supabase/postgrest-js/issues/280

## What kind of change does this PR introduce?

Feature

## What is the current behavior?

Currently, the supabase client is created and defaults to the `public` schema when no option is supplied:

```ts
createClient(supabaseUrl, supabaseKey)
```

Or, you can supply an alternative schema:

```ts
createClient(supabaseUrl, supabaseKey, {
  db: {
    schema: 'alternative'
  }
})
```

However, this means that all methods/queries for the client are associated to the single schema. Using multiple schemas requires multiple clients, which presents a challenge for auth where all clients need to be authenticated.

See pre-existing issue:

https://github.com/supabase/postgrest-js/issues/280

## What is the new behavior?

Extends on behavior added to underlying `PostgrestClient`: https://github.com/supabase/postgrest-js/pull/455

The method added to the supabase client allows for dynamic schema selection on a per-query basis.

```ts
const supabase = createClient(supabaseUrl, supabaseKey);

supabase.from('some_table_in_public').select();

supabase.schema('alt').from('table_in_alt').select()
```

If a `Database` generic type is supplied, type inference works as expected without additional generics:
<img width="514" alt="Screenshot 2023-08-06 at 1 12 31 PM" src="https://github.com/supabase/supabase-js/assets/12819256/ba9f9be8-0e19-4be3-8f0b-f1f510bc364d">

## Additional context

Add any other context or screenshots.
