### PR TITLE
bump @supabase/gotrue-js to ^v2.47.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@supabase/functions-js": "^2.1.0",
-    "@supabase/gotrue-js": "^2.46.1",
+    "@supabase/gotrue-js": "^2.47.0",
     "@supabase/postgrest-js": "^1.8.0",
     "@supabase/realtime-js": "^2.7.3",
     "@supabase/storage-js": "^2.5.1",


### PR DESCRIPTION
## What kind of change does this PR introduce?

remove stack guards, lock on external calls

## What is the current behavior?

See [#746](https://github.com/supabase/gotrue-js/issues/746)

Some supabase-js users' (inluding me) Next.js projects are breaking in production
