### PR TITLE
fix: version bump realtime-js to 2.7.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@supabase/functions-js": "^2.1.0",
         "@supabase/gotrue-js": "^2.46.1",
         "@supabase/postgrest-js": "^1.8.0",
-        "@supabase/realtime-js": "^2.7.3",
+        "@supabase/realtime-js": "^2.7.4",
         "@supabase/storage-js": "^2.5.1",
         "cross-fetch": "^3.1.5"
       },
@@ -1077,9 +1077,9 @@
       }
     },
     "node_modules/@supabase/realtime-js": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.7.3.tgz",
-      "integrity": "sha512-c7TzL81sx2kqyxsxcDduJcHL9KJdCOoKimGP6lQSqiZKX42ATlBZpWbyy9KFGFBjAP4nyopMf5JhPi2ZH9jyNw==",
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.7.4.tgz",
+      "integrity": "sha512-FzSzs1k9ruh/uds5AJ95Nc3beiMCCIhougExJ3O98CX1LMLAKUKFy5FivKLvcNhXnNfUEL0XUfGMb4UH2J7alg==",
       "dependencies": {
         "@types/phoenix": "^1.5.4",
         "@types/websocket": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@supabase/functions-js": "^2.1.0",
     "@supabase/gotrue-js": "^2.46.1",
     "@supabase/postgrest-js": "^1.8.0",
-    "@supabase/realtime-js": "^2.7.3",
+    "@supabase/realtime-js": "^2.7.4",
     "@supabase/storage-js": "^2.5.1",
     "cross-fetch": "^3.1.5"
   },


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Realtime access token is not set on client instantiation.

## What is the new behavior?

Realtime access token is set on client instantiation.

## Additional context

- https://github.com/supabase/realtime-js/pull/245
