### PR TITLE
fix: track javascript environment.

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,3 +1,14 @@
 // constants.ts
 import { version } from './version'
-export const DEFAULT_HEADERS = { 'X-Client-Info': `supabase-js/${version}` }
+let JS_ENV = ''
+// @ts-ignore
+if (typeof Deno !== 'undefined') {
+  JS_ENV = 'deno'
+} else if (typeof document !== 'undefined') {
+  JS_ENV = 'web'
+} else if (typeof navigator !== 'undefined' && navigator.product === 'ReactNative') {
+  JS_ENV = 'react-native'
+} else {
+  JS_ENV = 'node'
+}
+export const DEFAULT_HEADERS = { 'X-Client-Info': `supabase-js-${JS_ENV}/${version}` }

--- a/test/constants.test.ts
+++ b/test/constants.test.ts
@@ -2,8 +2,19 @@ import { DEFAULT_HEADERS } from '../src/lib/constants'
 import { version } from '../src/lib/version'
 
 test('it has the correct type of returning with the correct value', () => {
+  let JS_ENV = ''
+  // @ts-ignore
+  if (typeof Deno !== 'undefined') {
+    JS_ENV = 'deno'
+  } else if (typeof document !== 'undefined') {
+    JS_ENV = 'web'
+  } else if (typeof navigator !== 'undefined' && navigator.product === 'ReactNative') {
+    JS_ENV = 'react-native'
+  } else {
+    JS_ENV = 'node'
+  }
   const expected = {
-    'X-Client-Info': `supabase-js/${version}`,
+    'X-Client-Info': `supabase-js-${JS_ENV}/${version}`,
   }
   expect(DEFAULT_HEADERS).toEqual(expected)
   expect(typeof DEFAULT_HEADERS).toBe('object')


### PR DESCRIPTION
## What kind of change does this PR introduce?

More granular tracking of supabase-js usage environment. 

## What is the current behavior?

All usage is tracked as supabase-js

## What is the new behavior?

different environments Deno, Web, ReactNative, Node are appended to the clinet-info header. 

## Additional context

Add any other context or screenshots.
