### PR TITLE
feat: bump `@supabase/gotrue-js` to v2.53.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@supabase/functions-js": "^2.1.5",
-        "@supabase/gotrue-js": "^2.51.0",
+        "@supabase/gotrue-js": "^2.53.0",
         "@supabase/node-fetch": "^2.6.14",
         "@supabase/postgrest-js": "^1.8.4",
         "@supabase/realtime-js": "^2.7.4",
@@ -1061,9 +1061,9 @@
       }
     },
     "node_modules/@supabase/gotrue-js": {
-      "version": "2.51.0",
-      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-2.51.0.tgz",
-      "integrity": "sha512-9bXV38OTd4tNHukwPDkfYNLyoGuzKeNPRaQ675rsv4JV7YCTliGLJiDadTCZjsMo2v1gVDDUtrJHF8kIxxPP1w==",
+      "version": "2.53.0",
+      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-2.53.0.tgz",
+      "integrity": "sha512-GCF8meXaF6fMVciBsWTKN5neSennGgOMrUC3rjVOlSr/0yNi1YnqJyTi6ULaSrG2eyx8f5pv1zB1jD3Thw9Fag==",
       "dependencies": {
         "@supabase/node-fetch": "^2.6.14"
       }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@supabase/functions-js": "^2.1.5",
-    "@supabase/gotrue-js": "^2.51.0",
+    "@supabase/gotrue-js": "^2.53.0",
     "@supabase/node-fetch": "^2.6.14",
     "@supabase/postgrest-js": "^1.8.4",
     "@supabase/realtime-js": "^2.7.4",

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -43,7 +43,7 @@ export type SupabaseClientOptions<SchemaName> = {
     /**
      * If debug messages for authentication client are emitted. Can be used to inspect the behavior of the library.
      */
-    debug?: boolean
+    debug?: SupabaseAuthClientOptions['debug']
     /**
      * Provide your own locking mechanism based on the environment. By default no locking is done at this time.
      *


### PR DESCRIPTION
Bumps `@supabase/gotrue-js` to v2.53.0.