### PR TITLE
feat: bump `@supabase/gotrue-js` to v2.54.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@supabase/functions-js": "^2.1.5",
-        "@supabase/gotrue-js": "^2.53.0",
+        "@supabase/gotrue-js": "^2.54.0",
         "@supabase/node-fetch": "^2.6.14",
         "@supabase/postgrest-js": "^1.8.4",
         "@supabase/realtime-js": "^2.7.4",
@@ -1061,9 +1061,9 @@
       }
     },
     "node_modules/@supabase/gotrue-js": {
-      "version": "2.53.0",
-      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-2.53.0.tgz",
-      "integrity": "sha512-GCF8meXaF6fMVciBsWTKN5neSennGgOMrUC3rjVOlSr/0yNi1YnqJyTi6ULaSrG2eyx8f5pv1zB1jD3Thw9Fag==",
+      "version": "2.54.0",
+      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-2.54.0.tgz",
+      "integrity": "sha512-JjtbchtPbpgK0O8NIMIvKLk7HHv0kd23L3UO5a398nczCcBkI0IvmbPtbS4Xs5AUIuJ+JHtV6siOZR1ha5EzQw==",
       "dependencies": {
         "@supabase/node-fetch": "^2.6.14"
       }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@supabase/functions-js": "^2.1.5",
-    "@supabase/gotrue-js": "^2.53.0",
+    "@supabase/gotrue-js": "^2.54.0",
     "@supabase/node-fetch": "^2.6.14",
     "@supabase/postgrest-js": "^1.8.4",
     "@supabase/realtime-js": "^2.7.4",


### PR DESCRIPTION
Bumps `@supabase/gotrue-js` to v2.54.0.