### PR TITLE
Bump gotrue-js to 2.55.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@supabase/functions-js": "^2.1.5",
-        "@supabase/gotrue-js": "^2.54.2",
+        "@supabase/gotrue-js": "^2.55.0",
         "@supabase/node-fetch": "^2.6.14",
         "@supabase/postgrest-js": "^1.8.5",
         "@supabase/realtime-js": "^2.8.0",
@@ -1061,9 +1061,9 @@
       }
     },
     "node_modules/@supabase/gotrue-js": {
-      "version": "2.54.2",
-      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-2.54.2.tgz",
-      "integrity": "sha512-e6XCirHbacHFFPM60w0u+rVwcymOIvYIhor1VoUzr/6/whgI9ootiUcLngcGedc8mbHbjhuSQ6QuC9Mjs5+UHQ==",
+      "version": "2.55.0",
+      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-2.55.0.tgz",
+      "integrity": "sha512-wZAP66Lo68iROKo33m8seY30rCeGiR34leMEZ80j9fPm+/ar6h3y43Hb7f9F2STVMwT3Sv+aM+w0yCon5bih4g==",
       "dependencies": {
         "@supabase/node-fetch": "^2.6.14"
       }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@supabase/functions-js": "^2.1.5",
-    "@supabase/gotrue-js": "^2.54.2",
+    "@supabase/gotrue-js": "^2.55.0",
     "@supabase/node-fetch": "^2.6.14",
     "@supabase/postgrest-js": "^1.8.5",
     "@supabase/realtime-js": "^2.8.0",


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes an issue with React Native and Segment - https://github.com/supabase/gotrue-js/pull/772

## What is the current behavior?

See the [upstream PR](https://github.com/supabase/gotrue-js/pull/772) for more.

## What is the new behavior?

See the [upstream PR](https://github.com/supabase/gotrue-js/pull/772) for more.

## Additional context

N.A.
