### PR TITLE
fix: Bump up realtime-js version to 2.8.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@supabase/gotrue-js": "^2.56.0",
         "@supabase/node-fetch": "^2.6.14",
         "@supabase/postgrest-js": "^1.8.5",
-        "@supabase/realtime-js": "^2.8.2",
+        "@supabase/realtime-js": "^2.8.4",
         "@supabase/storage-js": "^2.5.4"
       },
       "devDependencies": {
@@ -1088,9 +1088,9 @@
       }
     },
     "node_modules/@supabase/realtime-js": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.8.2.tgz",
-      "integrity": "sha512-QY9H3an/TaInBJkGdKMrTVU1etomEtwStgeRGUFfYX0eURzBYKffgheZBnMdM9VgPCv0Oz5JcchoclpSlC8KvQ==",
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.8.4.tgz",
+      "integrity": "sha512-5C9slLTGikHnYmAnIBOaPogAgbcNY68vnIyE6GpqIKjHElVb6LIi4clwNcjHSj4z6szuvvzj8T/+ePEgGEGekw==",
       "dependencies": {
         "@supabase/node-fetch": "^2.6.14",
         "@types/phoenix": "^1.5.4",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@supabase/gotrue-js": "^2.56.0",
     "@supabase/node-fetch": "^2.6.14",
     "@supabase/postgrest-js": "^1.8.5",
-    "@supabase/realtime-js": "^2.8.2",
+    "@supabase/realtime-js": "^2.8.4",
     "@supabase/storage-js": "^2.5.4"
   },
   "devDependencies": {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bump up realtime-js version to 2.8.4