### PR TITLE
fix: bump postgrest-js to 1.8.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@supabase/functions-js": "^2.1.5",
         "@supabase/gotrue-js": "^2.56.0",
         "@supabase/node-fetch": "^2.6.14",
-        "@supabase/postgrest-js": "^1.8.5",
+        "@supabase/postgrest-js": "^1.8.6",
         "@supabase/realtime-js": "^2.8.4",
         "@supabase/storage-js": "^2.5.4"
       },
@@ -1152,9 +1152,9 @@
       }
     },
     "node_modules/@supabase/postgrest-js": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.8.5.tgz",
-      "integrity": "sha512-XvoqN5e5Z4TsQOYWLQYLW0HIlZtFSzwAcwiuToaSBSTpLOGCg4NaZ7au5GfBzCQJZdZPY5vk5FvwthfDsQK/Jw==",
+      "version": "1.8.6",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.8.6.tgz",
+      "integrity": "sha512-iiEgF6o/pBumdFe/A2HSG/xx3L6ap7OO3IpTB2hsamNiH/gWb8ru4Z8bdwZjN4sQQttxgsIgZVMsNLkTOCOQhw==",
       "dependencies": {
         "@supabase/node-fetch": "^2.6.14"
       }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@supabase/functions-js": "^2.1.5",
     "@supabase/gotrue-js": "^2.56.0",
     "@supabase/node-fetch": "^2.6.14",
-    "@supabase/postgrest-js": "^1.8.5",
+    "@supabase/postgrest-js": "^1.8.6",
     "@supabase/realtime-js": "^2.8.4",
     "@supabase/storage-js": "^2.5.4"
   },


### PR DESCRIPTION
Includes fix done to `postgrest-js` in https://github.com/supabase/postgrest-js/pull/506
