### PR TITLE
fix: bump gotrue-js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@supabase/functions-js": "^2.1.5",
-        "@supabase/gotrue-js": "^2.56.0",
+        "@supabase/gotrue-js": "^2.60.0",
         "@supabase/node-fetch": "^2.6.14",
         "@supabase/postgrest-js": "^1.8.6",
         "@supabase/realtime-js": "^2.8.4",
@@ -1133,9 +1133,9 @@
       }
     },
     "node_modules/@supabase/gotrue-js": {
-      "version": "2.56.0",
-      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-2.56.0.tgz",
-      "integrity": "sha512-UJEPWls3fN2TfqiDWP/b78Kby4VjPcXnMGmF2lfzP5IDS4xr1+kxBugGmrQXxX8mxBsmvmW1ATahzyBUU9FZyQ==",
+      "version": "2.60.1",
+      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-2.60.1.tgz",
+      "integrity": "sha512-dM28NhyPS5NLWpJbVokxGbuEMmMK2K+EBXYlNU2NEYzp1BrkdxetNh8ucslMbKauJ93XAEhbMCQHSO9fZ2E+DQ==",
       "dependencies": {
         "@supabase/node-fetch": "^2.6.14"
       }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@supabase/functions-js": "^2.1.5",
-    "@supabase/gotrue-js": "^2.56.0",
+    "@supabase/gotrue-js": "^2.60.0",
     "@supabase/node-fetch": "^2.6.14",
     "@supabase/postgrest-js": "^1.8.6",
     "@supabase/realtime-js": "^2.8.4",


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Bump gotrue-js version to [v2.60.0](https://github.com/supabase/gotrue-js/releases) which includes the new identity linking methods and weak password errors