### PR TITLE
feat: switch to `@supabase/auth-js`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.0.0-automated",
       "license": "MIT",
       "dependencies": {
+        "@supabase/auth-js": "^2.62.0",
         "@supabase/functions-js": "^2.1.5",
-        "@supabase/gotrue-js": "^2.60.0",
         "@supabase/node-fetch": "^2.6.14",
         "@supabase/postgrest-js": "^1.8.6",
         "@supabase/realtime-js": "^2.8.4",
@@ -1124,18 +1124,18 @@
         "@sinonjs/commons": "^2.0.0"
       }
     },
-    "node_modules/@supabase/functions-js": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.1.5.tgz",
-      "integrity": "sha512-BNzC5XhCzzCaggJ8s53DP+WeHHGT/NfTsx2wUSSGKR2/ikLFQTBCDzMvGz/PxYMqRko/LwncQtKXGOYp1PkPaw==",
+    "node_modules/@supabase/auth-js": {
+      "version": "2.62.0",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.62.0.tgz",
+      "integrity": "sha512-2pkOkd+NBBbLazy2IswnqahEBQTM4fB+U0HiNO/+mUrPCjCZV6RKhzt1AX4SqFfVW5eOENsh0vVc8IcACSpiTg==",
       "dependencies": {
         "@supabase/node-fetch": "^2.6.14"
       }
     },
-    "node_modules/@supabase/gotrue-js": {
-      "version": "2.60.1",
-      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-2.60.1.tgz",
-      "integrity": "sha512-dM28NhyPS5NLWpJbVokxGbuEMmMK2K+EBXYlNU2NEYzp1BrkdxetNh8ucslMbKauJ93XAEhbMCQHSO9fZ2E+DQ==",
+    "node_modules/@supabase/functions-js": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.1.5.tgz",
+      "integrity": "sha512-BNzC5XhCzzCaggJ8s53DP+WeHHGT/NfTsx2wUSSGKR2/ikLFQTBCDzMvGz/PxYMqRko/LwncQtKXGOYp1PkPaw==",
       "dependencies": {
         "@supabase/node-fetch": "^2.6.14"
       }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@supabase/functions-js": "^2.1.5",
-    "@supabase/gotrue-js": "^2.60.0",
+    "@supabase/auth-js": "^2.62.0",
     "@supabase/node-fetch": "^2.6.14",
     "@supabase/postgrest-js": "^1.8.6",
     "@supabase/realtime-js": "^2.8.4",

--- a/src/SupabaseClient.ts
+++ b/src/SupabaseClient.ts
@@ -1,5 +1,5 @@
 import { FunctionsClient } from '@supabase/functions-js'
-import { AuthChangeEvent } from '@supabase/gotrue-js'
+import { AuthChangeEvent } from '@supabase/auth-js'
 import {
   PostgrestClient,
   PostgrestFilterBuilder,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
 import SupabaseClient from './SupabaseClient'
 import type { GenericSchema, SupabaseClientOptions } from './lib/types'
 
-export * from '@supabase/gotrue-js'
-export type { User as AuthUser, Session as AuthSession } from '@supabase/gotrue-js'
+export * from '@supabase/auth-js'
+export type { User as AuthUser, Session as AuthSession } from '@supabase/auth-js'
 export type {
   PostgrestResponse,
   PostgrestSingleResponse,

--- a/src/lib/SupabaseAuthClient.ts
+++ b/src/lib/SupabaseAuthClient.ts
@@ -1,7 +1,7 @@
-import { GoTrueClient } from '@supabase/gotrue-js'
+import { AuthClient } from '@supabase/auth-js'
 import { SupabaseAuthClientOptions } from './types'
 
-export class SupabaseAuthClient extends GoTrueClient {
+export class SupabaseAuthClient extends AuthClient {
   constructor(options: SupabaseAuthClientOptions) {
     super(options)
   }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,10 +1,10 @@
-import { GoTrueClient } from '@supabase/gotrue-js'
+import { AuthClient } from '@supabase/auth-js'
 import { RealtimeClientOptions } from '@supabase/realtime-js'
 import { PostgrestError } from '@supabase/postgrest-js'
 
-type GoTrueClientOptions = ConstructorParameters<typeof GoTrueClient>[0]
+type AuthClientOptions = ConstructorParameters<typeof AuthClient>[0]
 
-export interface SupabaseAuthClientOptions extends GoTrueClientOptions {}
+export interface SupabaseAuthClientOptions extends AuthClientOptions {}
 
 export type Fetch = typeof fetch
 


### PR DESCRIPTION
Switches to using [@supabase/auth-js]() instead of @supabase/gotrue-js. Note that these two packages are **equvalent** and **guaranteed to remain equivalent for as long as version 2 is maintained.**