### PR TITLE
fix: stop using unstable type params from postgrest-js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@supabase/functions-js": "^2.1.5",
         "@supabase/gotrue-js": "^2.60.0",
         "@supabase/node-fetch": "^2.6.14",
-        "@supabase/postgrest-js": "^1.8.6",
+        "@supabase/postgrest-js": "^1.9.0",
         "@supabase/realtime-js": "^2.8.4",
         "@supabase/storage-js": "^2.5.4"
       },
@@ -1152,9 +1152,9 @@
       }
     },
     "node_modules/@supabase/postgrest-js": {
-      "version": "1.8.6",
-      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.8.6.tgz",
-      "integrity": "sha512-iiEgF6o/pBumdFe/A2HSG/xx3L6ap7OO3IpTB2hsamNiH/gWb8ru4Z8bdwZjN4sQQttxgsIgZVMsNLkTOCOQhw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.9.0.tgz",
+      "integrity": "sha512-axP6cU69jDrLbfihJKQ6vU27tklD0gzb9idkMN363MtTXeJVt5DQNT3JnJ58JVNBdL74hgm26rAsFNvHk+tnSw==",
       "dependencies": {
         "@supabase/node-fetch": "^2.6.14"
       }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@supabase/functions-js": "^2.1.5",
     "@supabase/gotrue-js": "^2.60.0",
     "@supabase/node-fetch": "^2.6.14",
-    "@supabase/postgrest-js": "^1.8.6",
+    "@supabase/postgrest-js": "^1.9.0",
     "@supabase/realtime-js": "^2.8.4",
     "@supabase/storage-js": "^2.5.4"
   },

--- a/src/SupabaseClient.ts
+++ b/src/SupabaseClient.ts
@@ -1,10 +1,6 @@
 import { FunctionsClient } from '@supabase/functions-js'
 import { AuthChangeEvent } from '@supabase/gotrue-js'
-import {
-  PostgrestClient,
-  PostgrestFilterBuilder,
-  PostgrestQueryBuilder,
-} from '@supabase/postgrest-js'
+import { PostgrestClient } from '@supabase/postgrest-js'
 import {
   RealtimeChannel,
   RealtimeChannelOptions,
@@ -143,20 +139,12 @@ export default class SupabaseClient<
     return new SupabaseStorageClient(this.storageUrl, this.headers, this.fetch)
   }
 
-  from<
-    TableName extends string & keyof Schema['Tables'],
-    Table extends Schema['Tables'][TableName]
-  >(relation: TableName): PostgrestQueryBuilder<Schema, Table>
-  from<ViewName extends string & keyof Schema['Views'], View extends Schema['Views'][ViewName]>(
-    relation: ViewName
-  ): PostgrestQueryBuilder<Schema, View>
-  from(relation: string): PostgrestQueryBuilder<Schema, any>
   /**
    * Perform a query on a table or a view.
    *
    * @param relation - The table or view name to query
    */
-  from(relation: string): PostgrestQueryBuilder<Schema, any> {
+  from: PostgrestClient<Database, SchemaName>['from'] = (relation: string) => {
     return this.rest.from(relation)
   }
 
@@ -168,13 +156,11 @@ export default class SupabaseClient<
    *
    * @param schema - The name of the schema to query
    */
-  schema<DynamicSchema extends string & keyof Database>(
+  schema: PostgrestClient<Database, SchemaName>['schema'] = <
+    DynamicSchema extends string & keyof Database
+  >(
     schema: DynamicSchema
-  ): PostgrestClient<
-    Database,
-    DynamicSchema,
-    Database[DynamicSchema] extends GenericSchema ? Database[DynamicSchema] : any
-  > {
+  ) => {
     return this.rest.schema<DynamicSchema>(schema)
   }
 
@@ -199,7 +185,7 @@ export default class SupabaseClient<
    * `"estimated"`: Uses exact count for low numbers and planned count for high
    * numbers.
    */
-  rpc<
+  rpc: PostgrestClient<Database, SchemaName>['rpc'] = <
     FunctionName extends string & keyof Schema['Functions'],
     Function_ extends Schema['Functions'][FunctionName]
   >(
@@ -209,15 +195,7 @@ export default class SupabaseClient<
       head?: boolean
       count?: 'exact' | 'planned' | 'estimated'
     }
-  ): PostgrestFilterBuilder<
-    Schema,
-    Function_['Returns'] extends any[]
-      ? Function_['Returns'][number] extends Record<string, unknown>
-        ? Function_['Returns'][number]
-        : never
-      : never,
-    Function_['Returns']
-  > {
+  ) => {
     return this.rest.rpc(fn, args, options)
   }
 


### PR DESCRIPTION
We're currently duplicating passing the type params to postgrest-js classes - we may change the order and/or add new type params on the postgrest-js side, so the type params in supabase-js can get out of sync.

This also fixes the issue in this [demo](https://github.com/daichi5/supabase-demo/blob/91385f2c1d509109938cb0e02d2a3b00201cf044/src/index.ts#L12) (`users` in `data` should be `T[]`, not `T | null`).