### PR TITLE
fix: Use explicit return type for from/schema/rpc

### DIFF
--- a/src/SupabaseClient.ts
+++ b/src/SupabaseClient.ts
@@ -130,7 +130,7 @@ export default class SupabaseClient<
    *
    * @param relation - The table or view name to query
    */
-  from(relation: string) {
+  from(relation: string): ReturnType<PostgrestClient<Database, SchemaName>['from']> {
     return this.rest.from(relation)
   }
 
@@ -142,7 +142,9 @@ export default class SupabaseClient<
    *
    * @param schema - The name of the schema to query
    */
-  schema<DynamicSchema extends string & keyof Database>(schema: DynamicSchema) {
+  schema<DynamicSchema extends string & keyof Database>(
+    schema: DynamicSchema
+  ): ReturnType<PostgrestClient<Database, SchemaName>['schema']> {
     return this.rest.schema<DynamicSchema>(schema)
   }
 
@@ -174,7 +176,7 @@ export default class SupabaseClient<
       head?: boolean
       count?: 'exact' | 'planned' | 'estimated'
     }
-  ) {
+  ): ReturnType<PostgrestClient<Database, SchemaName>['rpc']> {
     return this.rest.rpc(fn, args, options)
   }
 


### PR DESCRIPTION
Use `ReturnType` as we implement those methods as a pass-through.
Tbh why this isn't inferred correctly by TypeScript is beyond me...

Verified on our own API repository this time to make sure it works correctly for all cases.

Fixes https://github.com/supabase/supabase-js/issues/974
Fixes https://github.com/supabase/supabase-js/pull/973#issuecomment-1942141729