### PR TITLE
feat: typecheck table names in from clause

### DIFF
--- a/src/SupabaseClient.ts
+++ b/src/SupabaseClient.ts
@@ -130,10 +130,11 @@ export default class SupabaseClient<
   }
 
   // NOTE: signatures must be kept in sync with PostgrestClient.from
-  from<TableName extends keyof Schema['Tables'], Table extends Schema['Tables'][TableName]>(
-    relation: TableName
-  ): PostgrestQueryBuilder<Schema, Table, TableName>
-  from<ViewName extends keyof Schema['Views'], View extends Schema['Views'][ViewName]>(
+  from<
+    TableName extends string & keyof Schema['Tables'],
+    Table extends Schema['Tables'][TableName]
+  >(relation: TableName): PostgrestQueryBuilder<Schema, Table, TableName>
+  from<ViewName extends string & keyof Schema['Views'], View extends Schema['Views'][ViewName]>(
     relation: ViewName
   ): PostgrestQueryBuilder<Schema, View, ViewName>
   /**

--- a/src/SupabaseClient.ts
+++ b/src/SupabaseClient.ts
@@ -130,14 +130,12 @@ export default class SupabaseClient<
   }
 
   // NOTE: signatures must be kept in sync with PostgrestClient.from
-  from<
-    TableName extends string & keyof Schema['Tables'],
-    Table extends Schema['Tables'][TableName]
-  >(relation: TableName): PostgrestQueryBuilder<Schema, Table, TableName>
-  from<ViewName extends string & keyof Schema['Views'], View extends Schema['Views'][ViewName]>(
+  from<TableName extends keyof Schema['Tables'], Table extends Schema['Tables'][TableName]>(
+    relation: TableName
+  ): PostgrestQueryBuilder<Schema, Table, TableName>
+  from<ViewName extends keyof Schema['Views'], View extends Schema['Views'][ViewName]>(
     relation: ViewName
   ): PostgrestQueryBuilder<Schema, View, ViewName>
-  from(relation: string): PostgrestQueryBuilder<Schema, any, any>
   /**
    * Perform a query on a table or a view.
    *

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -9,6 +9,7 @@ const supabase = createClient<Database>(URL, KEY)
 // table invalid type
 {
   expectError(supabase.from(42))
+  expectError(supabase.from('some_table_that_does_not_exist'))
 }
 
 // `null` can't be used with `.eq()`


### PR DESCRIPTION
## What kind of change does this PR introduce?

Please take this as a sort of a question because I'm new to supabase. (and I'm aware of the `// NOTE: signatures must be kept in sync with PostgrestClient.from`).

### Motivation

I want to query supabase using the client and want to do that with the best possible guidance from TS.

Right now, TS (although it will suggest valid table names) won't complain if I try to query a non-existent table.
To me, this is a fairly unexpected limitation and I don't understand why it's there.

So I'm suggesting this change here (I can also make it in the other place) with the aim of achieving higher code safety.
If this is not possible, why? (Are there other cases like this, with low-hanging fruit for TS improvements?)

Thank you! :) 