### PR TITLE
hotfix:ts-error-fetchprotocol

### DIFF
--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -12,7 +12,7 @@ export const resolveFetch = (customFetch?: Fetch): Fetch => {
   } else {
     _fetch = fetch
   }
-  return (...args) => _fetch(...args)
+  return (...args: Parameters<Fetch>) => _fetch(...args)
 }
 
 export const resolveHeadersConstructor = () => {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes ```A spread argument must either have a tuple type or be passed to a rest parameter.ts(2556)```

## What is the current behavior?
Not explicitly typed, sometimes the compiler will interpret the type wrong.
![image](https://github.com/supabase/supabase-js/assets/81534875/59d3f57c-0a6d-4251-950f-75e488d5897d)

Please link any relevant issues here.

## What is the new behavior?
Explicit type specified.
Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
