### PR TITLE
fix: bump auth to v2.63.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.0.0-automated",
       "license": "MIT",
       "dependencies": {
+        "@supabase/auth-js": "2.63.0",
         "@supabase/functions-js": "2.1.5",
-        "@supabase/gotrue-js": "2.62.2",
         "@supabase/node-fetch": "2.6.15",
         "@supabase/postgrest-js": "1.9.2",
         "@supabase/realtime-js": "2.9.3",
@@ -1161,18 +1161,18 @@
         "@sinonjs/commons": "^2.0.0"
       }
     },
-    "node_modules/@supabase/functions-js": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.1.5.tgz",
-      "integrity": "sha512-BNzC5XhCzzCaggJ8s53DP+WeHHGT/NfTsx2wUSSGKR2/ikLFQTBCDzMvGz/PxYMqRko/LwncQtKXGOYp1PkPaw==",
+    "node_modules/@supabase/auth-js": {
+      "version": "2.63.0",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.63.0.tgz",
+      "integrity": "sha512-yIgcHnlgv24GxHtVGUhwGqAFDyJkPIC/xjx7HostN08A8yCy8HIfl4JEkTKyBqD1v1L05jNEJOUke4Lf4O1+Qg==",
       "dependencies": {
         "@supabase/node-fetch": "^2.6.14"
       }
     },
-    "node_modules/@supabase/gotrue-js": {
-      "version": "2.62.2",
-      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-2.62.2.tgz",
-      "integrity": "sha512-AP6e6W9rQXFTEJ7sTTNYQrNf0LCcnt1hUW+RIgUK+Uh3jbWvcIST7wAlYyNZiMlS9+PYyymWQ+Ykz/rOYSO0+A==",
+    "node_modules/@supabase/functions-js": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.1.5.tgz",
+      "integrity": "sha512-BNzC5XhCzzCaggJ8s53DP+WeHHGT/NfTsx2wUSSGKR2/ikLFQTBCDzMvGz/PxYMqRko/LwncQtKXGOYp1PkPaw==",
       "dependencies": {
         "@supabase/node-fetch": "^2.6.14"
       }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@supabase/functions-js": "2.1.5",
-    "@supabase/gotrue-js": "2.62.2",
+    "@supabase/auth-js": "2.63.0",
     "@supabase/node-fetch": "2.6.15",
     "@supabase/postgrest-js": "1.9.2",
     "@supabase/realtime-js": "2.9.3",

--- a/src/SupabaseClient.ts
+++ b/src/SupabaseClient.ts
@@ -1,5 +1,5 @@
 import { FunctionsClient } from '@supabase/functions-js'
-import { AuthChangeEvent } from '@supabase/gotrue-js'
+import { AuthChangeEvent } from '@supabase/auth-js'
 import {
   PostgrestClient,
   PostgrestFilterBuilder,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
 import SupabaseClient from './SupabaseClient'
 import type { GenericSchema, SupabaseClientOptions } from './lib/types'
 
-export * from '@supabase/gotrue-js'
-export type { User as AuthUser, Session as AuthSession } from '@supabase/gotrue-js'
+export * from '@supabase/auth-js'
+export type { User as AuthUser, Session as AuthSession } from '@supabase/auth-js'
 export type {
   PostgrestResponse,
   PostgrestSingleResponse,

--- a/src/lib/SupabaseAuthClient.ts
+++ b/src/lib/SupabaseAuthClient.ts
@@ -1,7 +1,7 @@
-import { GoTrueClient } from '@supabase/gotrue-js'
+import { AuthClient } from '@supabase/auth-js'
 import { SupabaseAuthClientOptions } from './types'
 
-export class SupabaseAuthClient extends GoTrueClient {
+export class SupabaseAuthClient extends AuthClient {
   constructor(options: SupabaseAuthClientOptions) {
     super(options)
   }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,10 +1,10 @@
-import { GoTrueClient } from '@supabase/gotrue-js'
+import { AuthClient } from '@supabase/auth-js'
 import { RealtimeClientOptions } from '@supabase/realtime-js'
 import { PostgrestError } from '@supabase/postgrest-js'
 
-type GoTrueClientOptions = ConstructorParameters<typeof GoTrueClient>[0]
+type AuthClientOptions = ConstructorParameters<typeof AuthClient>[0]
 
-export interface SupabaseAuthClientOptions extends GoTrueClientOptions {}
+export interface SupabaseAuthClientOptions extends AuthClientOptions {}
 
 export type Fetch = typeof fetch
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Bump auth to v2.63.0 which includes the `signInAnonymously` method