### PR TITLE
feat: add third-party auth support

### DIFF
--- a/src/SupabaseClient.ts
+++ b/src/SupabaseClient.ts
@@ -51,6 +51,7 @@ export default class SupabaseClient<
   protected storageKey: string
   protected fetch?: Fetch
   protected changedAccessToken?: string
+  protected accessToken?: () => Promise<string>
 
   protected headers: Record<string, string>
 
@@ -95,11 +96,26 @@ export default class SupabaseClient<
     this.storageKey = settings.auth.storageKey ?? ''
     this.headers = settings.global.headers ?? {}
 
-    this.auth = this._initSupabaseAuthClient(
-      settings.auth ?? {},
-      this.headers,
-      settings.global.fetch
-    )
+    if (!settings.accessToken) {
+      this.auth = this._initSupabaseAuthClient(
+        settings.auth ?? {},
+        this.headers,
+        settings.global.fetch
+      )
+    } else {
+      this.accessToken = settings.accessToken
+
+      this.auth = new Proxy<SupabaseAuthClient>({} as any, {
+        get: (_, prop) => {
+          throw new Error(
+            `@supabase/supabase-js: Supabase Client is configured with the accessToken option, accessing supabase.auth.${String(
+              prop
+            )} is not possible`
+          )
+        },
+      })
+    }
+
     this.fetch = fetchWithAuth(supabaseKey, this._getAccessToken.bind(this), settings.global.fetch)
 
     this.realtime = this._initRealtimeClient({ headers: this.headers, ...settings.realtime })
@@ -109,7 +125,9 @@ export default class SupabaseClient<
       fetch: this.fetch,
     })
 
-    this._listenForAuthEvents()
+    if (!settings.accessToken) {
+      this._listenForAuthEvents()
+    }
   }
 
   /**
@@ -244,6 +262,10 @@ export default class SupabaseClient<
   }
 
   private async _getAccessToken() {
+    if (this.accessToken) {
+      return await this.accessToken()
+    }
+
     const { data } = await this.auth.getSession()
 
     return data.session?.access_token ?? null

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -37,7 +37,7 @@ export function applySettingDefaults<
     global: DEFAULT_GLOBAL_OPTIONS,
   } = defaults
 
-  return {
+  const result: Required<SupabaseClientOptions<SchemaName>> = {
     db: {
       ...DEFAULT_DB_OPTIONS,
       ...dbOptions,
@@ -54,5 +54,15 @@ export function applySettingDefaults<
       ...DEFAULT_GLOBAL_OPTIONS,
       ...globalOptions,
     },
+    accessToken: async () => '',
   }
+
+  if (options.accessToken) {
+    result.accessToken = options.accessToken
+  } else {
+    // hack around Required<>
+    delete (result as any).accessToken
+  }
+
+  return result
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -66,6 +66,18 @@ export type SupabaseClientOptions<SchemaName> = {
      */
     headers?: Record<string, string>
   }
+  /**
+   * Optional function for using a third-party authentication system with
+   * Supabase. The function should return an access token or ID token (JWT) by
+   * obtaining it from the third-party auth client library. Note that this
+   * function may be called concurrently and many times. Use memoization and
+   * locking techniques if this is not supported by the client libraries.
+   *
+   * When set, the `auth` namespace of the Supabase client cannot be used.
+   * Create another client if you wish to use Supabase Auth and third-party
+   * authentications concurrently in the same application.
+   */
+  accessToken?: () => Promise<string>
 }
 
 export type GenericTable = {

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -7,6 +7,18 @@ const KEY = 'some.fake.key'
 
 const supabase = createClient(URL, KEY)
 
+test('it should create a client with third-party auth accessToken', async () => {
+  const client = createClient(URL, KEY, {
+    accessToken: async () => {
+      return 'jwt'
+    },
+  })
+
+  expect(() => client.auth.getUser()).toThrowError(
+    '@supabase/supabase-js: Supabase Client is configured with the accessToken option, accessing supabase.auth.getUser is not possible'
+  )
+})
+
 test('it should create the client connection', async () => {
   expect(supabase).toBeDefined()
   expect(supabase).toBeInstanceOf(SupabaseClient)


### PR DESCRIPTION
Adds support for the `accessToken` option on the Supabase client which can be used to provide a third-party authentication (e.g. Auth0, Clerk, Firebase Auth, ...) access token or ID token to be used instead of Supabase Auth.

When set, `supabase.auth.xyz` cannot be used and an error will be thrown.