### PR TITLE
Export GenericSchema types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,18 @@ export {
 } from '@supabase/functions-js'
 export * from '@supabase/realtime-js'
 export { default as SupabaseClient } from './SupabaseClient'
-export type { SupabaseClientOptions, QueryResult, QueryData, QueryError } from './lib/types'
+export type {
+  GenericFunction,
+  GenericNonUpdatableView,
+  GenericSchema,
+  GenericTable,
+  GenericUpdatableView,
+  GenericView,
+  QueryResult,
+  QueryData,
+  QueryError,
+  SupabaseClientOptions,
+} from './lib/types'
 
 /**
  * Creates a new Supabase Client.


### PR DESCRIPTION
## What kind of change does this PR introduce?

Improvement

## What is the current behavior?

Database / Schema types can be supplied / inferred.

## What is the new behavior?

Able to extend/reuse the types for schema interfaces.

## Additional context

It's not strictly necessary but I think is friendlier to export all the named types that are referenced in exported types.

I'm making a library that expects a table with a specific schema to be defined, it's nicer to be able to require the `SupabaseClient` that a user passes through has the table with the expected schema defined, plus all usage of the client conforms to the declared interfaces. Also declaring my schema as extends `GenericSchema` catches issues from future type changes in the right place, and also documents to consumers what the schema/database objects are.

It's also nicer for future breaks in the interfaces to cause errors in the types that use them instead of in function calls spread around.
