### PR TITLE
fix: bump auth-js to v2.63.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0-automated",
       "license": "MIT",
       "dependencies": {
-        "@supabase/auth-js": "2.63.0",
+        "@supabase/auth-js": "2.63.1",
         "@supabase/functions-js": "2.3.0",
         "@supabase/node-fetch": "2.6.15",
         "@supabase/postgrest-js": "1.15.2",
@@ -1162,9 +1162,9 @@
       }
     },
     "node_modules/@supabase/auth-js": {
-      "version": "2.63.0",
-      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.63.0.tgz",
-      "integrity": "sha512-yIgcHnlgv24GxHtVGUhwGqAFDyJkPIC/xjx7HostN08A8yCy8HIfl4JEkTKyBqD1v1L05jNEJOUke4Lf4O1+Qg==",
+      "version": "2.63.1",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.63.1.tgz",
+      "integrity": "sha512-iwdmIc/w5QN7aMfYThEgUt1l2i0KuohZ4XNk1adECg0LETQYEzmbVToKFKZLLZ+GyNtpsExSgVY/AUWOwubGXA==",
       "dependencies": {
         "@supabase/node-fetch": "^2.6.14"
       }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "serve:coverage": "npm run test:coverage && serve test/coverage"
   },
   "dependencies": {
-    "@supabase/auth-js": "2.63.0",
+    "@supabase/auth-js": "2.63.1",
     "@supabase/functions-js": "2.3.0",
     "@supabase/node-fetch": "2.6.15",
     "@supabase/postgrest-js": "1.15.2",


### PR DESCRIPTION
## What kind of change does this PR introduce?
* see [changelog](https://github.com/supabase/auth-js/releases/tag/v2.63.1)
* addresses #1010 