### PR TITLE
fix: set hasCustomAuthorizationHeader property on the AuthClient

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0-automated",
       "license": "MIT",
       "dependencies": {
-        "@supabase/auth-js": "2.64.0",
+        "@supabase/auth-js": "2.64.1",
         "@supabase/functions-js": "2.3.1",
         "@supabase/node-fetch": "2.6.15",
         "@supabase/postgrest-js": "1.15.2",
@@ -1162,9 +1162,9 @@
       }
     },
     "node_modules/@supabase/auth-js": {
-      "version": "2.64.0",
-      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.64.0.tgz",
-      "integrity": "sha512-tC1fhVvzYlPA6gpSLR/BH2hM06ZZzSpi0oUOkNLm4lGrOUpsDa552fJMx9uuiEQ2/fpIbTh7MwjXb+zxVXWz6Q==",
+      "version": "2.64.1",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.64.1.tgz",
+      "integrity": "sha512-tA2PXLoWEzhD0N1Vysree+HftfeWBbFV0E+taND5rj/pZTjkwKq/9GlrnXkbs5pnw+tsnABDRo2WLZmymihGdA==",
       "dependencies": {
         "@supabase/node-fetch": "^2.6.14"
       }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "serve:coverage": "npm run test:coverage && serve test/coverage"
   },
   "dependencies": {
-    "@supabase/auth-js": "2.64.0",
+    "@supabase/auth-js": "2.64.1",
     "@supabase/functions-js": "2.3.1",
     "@supabase/node-fetch": "2.6.15",
     "@supabase/postgrest-js": "1.15.2",

--- a/src/SupabaseClient.ts
+++ b/src/SupabaseClient.ts
@@ -277,6 +277,9 @@ export default class SupabaseClient<
       flowType,
       debug,
       fetch,
+      // auth checks if there is a custom authorizaiton header using this flag
+      // so it knows whether to return an error when getUser is called with no session
+      hasCustomAuthorizationHeader: 'Authorization' in this.headers ?? false,
     })
   }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
* supabase-js sets the `hasCustomAuthorizationHeader` property internally when instantiating the auth client so that auth knows whether to return an error when `getUser` is called with no session and no custom auth header