### PR TITLE
fix: bump auth-js to v2.64.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0-automated",
       "license": "MIT",
       "dependencies": {
-        "@supabase/auth-js": "2.64.1",
+        "@supabase/auth-js": "2.64.2",
         "@supabase/functions-js": "2.3.1",
         "@supabase/node-fetch": "2.6.15",
         "@supabase/postgrest-js": "1.15.2",
@@ -1162,9 +1162,9 @@
       }
     },
     "node_modules/@supabase/auth-js": {
-      "version": "2.64.1",
-      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.64.1.tgz",
-      "integrity": "sha512-tA2PXLoWEzhD0N1Vysree+HftfeWBbFV0E+taND5rj/pZTjkwKq/9GlrnXkbs5pnw+tsnABDRo2WLZmymihGdA==",
+      "version": "2.64.2",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.64.2.tgz",
+      "integrity": "sha512-s+lkHEdGiczDrzXJ1YWt2y3bxRi+qIUnXcgkpLSrId7yjBeaXBFygNjTaoZLG02KNcYwbuZ9qkEIqmj2hF7svw==",
       "dependencies": {
         "@supabase/node-fetch": "^2.6.14"
       }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "serve:coverage": "npm run test:coverage && serve test/coverage"
   },
   "dependencies": {
-    "@supabase/auth-js": "2.64.1",
+    "@supabase/auth-js": "2.64.2",
     "@supabase/functions-js": "2.3.1",
     "@supabase/node-fetch": "2.6.15",
     "@supabase/postgrest-js": "1.15.2",


### PR DESCRIPTION
## What kind of change does this PR introduce?
* bumps auth-js to v2.64.2 which contains these changes (https://github.com/supabase/auth-js/releases/tag/v2.64.2)

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
