### PR TITLE
feat: allow overriding default PostgREST route prefix

### DIFF
--- a/src/SupabaseClient.ts
+++ b/src/SupabaseClient.ts
@@ -17,6 +17,7 @@ import {
   DEFAULT_DB_OPTIONS,
   DEFAULT_AUTH_OPTIONS,
   DEFAULT_REALTIME_OPTIONS,
+  DEFAULT_POSTGREST_OPTIONS,
 } from './lib/constants'
 import { fetchWithAuth } from './lib/fetch'
 import { stripTrailingSlash, applySettingDefaults } from './lib/helpers'
@@ -88,6 +89,7 @@ export default class SupabaseClient<
       realtime: DEFAULT_REALTIME_OPTIONS,
       auth: { ...DEFAULT_AUTH_OPTIONS, storageKey: defaultStorageKey },
       global: DEFAULT_GLOBAL_OPTIONS,
+      postgrest: DEFAULT_POSTGREST_OPTIONS,
     }
 
     const settings = applySettingDefaults(options ?? {}, DEFAULTS)
@@ -103,7 +105,7 @@ export default class SupabaseClient<
     this.fetch = fetchWithAuth(supabaseKey, this._getAccessToken.bind(this), settings.global?.fetch)
 
     this.realtime = this._initRealtimeClient({ headers: this.headers, ...settings.realtime })
-    this.rest = new PostgrestClient(`${_supabaseUrl}/rest/v1`, {
+    this.rest = new PostgrestClient(`${_supabaseUrl}${settings.postgrest?.routePrefix}`, {
       headers: this.headers,
       schema: settings.db?.schema,
       fetch: this.fetch,

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -33,3 +33,7 @@ export const DEFAULT_AUTH_OPTIONS: SupabaseAuthClientOptions = {
 }
 
 export const DEFAULT_REALTIME_OPTIONS: RealtimeClientOptions = {}
+
+export const DEFAULT_POSTGREST_OPTIONS = {
+  routePrefix: '/rest/v1',
+}

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -29,12 +29,14 @@ export function applySettingDefaults<
     auth: authOptions,
     realtime: realtimeOptions,
     global: globalOptions,
+    postgrest: postgrestOptions,
   } = options
   const {
     db: DEFAULT_DB_OPTIONS,
     auth: DEFAULT_AUTH_OPTIONS,
     realtime: DEFAULT_REALTIME_OPTIONS,
     global: DEFAULT_GLOBAL_OPTIONS,
+    postgrest: DEFAULT_POSTGREST_OPTIONS,
   } = defaults
 
   return {
@@ -53,6 +55,10 @@ export function applySettingDefaults<
     global: {
       ...DEFAULT_GLOBAL_OPTIONS,
       ...globalOptions,
+    },
+    postgrest: {
+      ...DEFAULT_POSTGREST_OPTIONS,
+      ...postgrestOptions,
     },
   }
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -66,6 +66,12 @@ export type SupabaseClientOptions<SchemaName> = {
      */
     headers?: Record<string, string>
   }
+  postgrest?: {
+    /**
+     * The route prefix for your PostgREST endpoint. Defaults to `/rest/v1`.
+     */
+    routePrefix?: string
+  }
 }
 
 export type GenericTable = {

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -67,6 +67,28 @@ describe('Dynamic schema', () => {
   })
 })
 
+describe('PostgREST prefix', () => {
+  test('is /rest/v1 by default', async () => {
+    const client = createClient<Database>('HTTP://localhost:3000', KEY)
+
+    // @ts-ignore
+    const restUrl = client.rest.url
+
+    expect(restUrl).toEqual('HTTP://localhost:3000/rest/v1')
+  })
+
+  test('is set to custom value when provided', async () => {
+    const client = createClient<Database>('HTTP://localhost:3000', KEY, {
+      postgrest: { routePrefix: '/custom' },
+    })
+
+    // @ts-ignore
+    const restUrl = client.rest.url
+
+    expect(restUrl).toEqual('HTTP://localhost:3000/custom')
+  })
+})
+
 // Socket should close when there are no open connections
 // https://github.com/supabase/supabase-js/issues/44
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

* adds the ability to specify a custom route prefix for a project's PostgREST service

## Additional context

https://supabase.slack.com/archives/C01D6TWFFFW/p1715697051055689