### PR TITLE
ref: Update applySettingDefaults typings to use accurate return type

### DIFF
--- a/src/SupabaseClient.ts
+++ b/src/SupabaseClient.ts
@@ -92,20 +92,20 @@ export default class SupabaseClient<
 
     const settings = applySettingDefaults(options ?? {}, DEFAULTS)
 
-    this.storageKey = settings.auth?.storageKey ?? ''
-    this.headers = settings.global?.headers ?? {}
+    this.storageKey = settings.auth.storageKey ?? ''
+    this.headers = settings.global.headers ?? {}
 
     this.auth = this._initSupabaseAuthClient(
       settings.auth ?? {},
       this.headers,
-      settings.global?.fetch
+      settings.global.fetch
     )
-    this.fetch = fetchWithAuth(supabaseKey, this._getAccessToken.bind(this), settings.global?.fetch)
+    this.fetch = fetchWithAuth(supabaseKey, this._getAccessToken.bind(this), settings.global.fetch)
 
     this.realtime = this._initRealtimeClient({ headers: this.headers, ...settings.realtime })
     this.rest = new PostgrestClient(`${_supabaseUrl}/rest/v1`, {
       headers: this.headers,
-      schema: settings.db?.schema,
+      schema: settings.db.schema,
       fetch: this.fetch,
     })
 

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -23,7 +23,7 @@ export function applySettingDefaults<
 >(
   options: SupabaseClientOptions<SchemaName>,
   defaults: SupabaseClientOptions<any>
-): SupabaseClientOptions<SchemaName> {
+): Required<SupabaseClientOptions<SchemaName>> {
   const {
     db: dbOptions,
     auth: authOptions,

--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -33,10 +33,10 @@ test('override setting defaults', async () => {
     },
   }
   let settings = helpers.applySettingDefaults(options, defaults)
-  expect(settings?.auth?.autoRefreshToken).toBe(autoRefreshOption)
+  expect(settings.auth.autoRefreshToken).toBe(autoRefreshOption)
   // Existing default properties should not be overwritten
-  expect(settings?.auth?.persistSession).not.toBeNull()
-  expect(settings?.global?.headers).toBe(DEFAULT_HEADERS)
+  expect(settings.auth.persistSession).not.toBeNull()
+  expect(settings.global.headers).toBe(DEFAULT_HEADERS)
   // Existing property values should remain constant
-  expect(settings?.db?.schema).toBe(defaults.db.schema)
+  expect(settings.db.schema).toBe(defaults.db.schema)
 })


### PR DESCRIPTION
Internal, non-breaking change. `applySettingDefaults` enforces existence of all options namespaces, so they should not be optional anymore.