### PR TITLE
chore(deps): bump storage-js dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@supabase/node-fetch": "2.6.15",
         "@supabase/postgrest-js": "1.15.2",
         "@supabase/realtime-js": "2.9.5",
-        "@supabase/storage-js": "2.5.5"
+        "@supabase/storage-js": "2.6.0"
       },
       "devDependencies": {
         "@sebbo2002/semantic-release-jsr": "^1.0.0",
@@ -1221,9 +1221,9 @@
       }
     },
     "node_modules/@supabase/storage-js": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.5.5.tgz",
-      "integrity": "sha512-OpLoDRjFwClwc2cjTJZG8XviTiQH4Ik8sCiMK5v7et0MDu2QlXjCAW3ljxJB5+z/KazdMOTnySi+hysxWUPu3w==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.6.0.tgz",
+      "integrity": "sha512-REAxr7myf+3utMkI2oOmZ6sdplMZZ71/2NEIEMBZHL9Fkmm3/JnaOZVSRqvG4LStYj2v5WhCruCzuMn6oD/Drw==",
       "dependencies": {
         "@supabase/node-fetch": "^2.6.14"
       }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@supabase/node-fetch": "2.6.15",
     "@supabase/postgrest-js": "1.15.2",
     "@supabase/realtime-js": "2.9.5",
-    "@supabase/storage-js": "2.5.5"
+    "@supabase/storage-js": "2.6.0"
   },
   "devDependencies": {
     "@sebbo2002/semantic-release-jsr": "^1.0.0",


### PR DESCRIPTION
## What kind of change does this PR introduce?

dependency update

## What is the new behavior?

Bump storage-js to v2.6.0
