### PR TITLE
fix: Bump up realtime-js 2.10.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@supabase/functions-js": "2.4.1",
         "@supabase/node-fetch": "2.6.15",
         "@supabase/postgrest-js": "1.15.7",
-        "@supabase/realtime-js": "2.10.1",
+        "@supabase/realtime-js": "2.10.2",
         "@supabase/storage-js": "2.6.0"
       },
       "devDependencies": {
@@ -1211,9 +1211,9 @@
       }
     },
     "node_modules/@supabase/realtime-js": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.10.1.tgz",
-      "integrity": "sha512-SrrXxE8xgwWvjREQMkC9LIHIoCQde+OqkFPKP2s/O0ROjhmJ/iXeLvoWhAzXh9gwire4oaK14/ncL/iRiaVWQw==",
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.10.2.tgz",
+      "integrity": "sha512-qyCQaNg90HmJstsvr2aJNxK2zgoKh9ZZA8oqb7UT2LCh3mj9zpa3Iwu167AuyNxsxrUE8eEJ2yH6wLCij4EApA==",
       "dependencies": {
         "@supabase/node-fetch": "^2.6.14",
         "@types/phoenix": "^1.5.4",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@supabase/functions-js": "2.4.1",
     "@supabase/node-fetch": "2.6.15",
     "@supabase/postgrest-js": "1.15.7",
-    "@supabase/realtime-js": "2.10.1",
+    "@supabase/realtime-js": "2.10.2",
     "@supabase/storage-js": "2.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bump up realtime-js 2.10.2 - https://github.com/supabase/realtime-js/pull/412
