### PR TITLE
fix: solved the crash error

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@supabase/auth-js": "2.64.2",
     "@supabase/functions-js": "2.4.1",
     "@supabase/node-fetch": "2.6.15",
-    "@supabase/postgrest-js": "1.15.7",
+    "@supabase/postgrest-js": "1.15.8",
     "@supabase/realtime-js": "2.10.2",
     "@supabase/storage-js": "2.6.0"
   },


### PR DESCRIPTION
## What kind of change does this PR introduce?

I just upgraded the version of `@supabase/postgrest-js`

## What is the current behavior?

My e2e tests always failed after I upgraded the `@supabase/supabase-js` version to `2.44.2`. The related package `@supabase/postgrest-js` has been released a new version, however `@supabase/supabase-js` didn't follow up.

<img width="459" alt="image" src="https://github.com/supabase/supabase-js/assets/32405058/90112017-32c6-45e9-8d71-2677e79efd32">

<img width="800" alt="image" src="https://github.com/supabase/supabase-js/assets/32405058/284068cb-1558-4141-bbf1-4b75d7f502bc">

<img width="664" alt="image" src="https://github.com/supabase/supabase-js/assets/32405058/3fb56db5-7921-4e10-b2e0-e56715afa75b">


## What is the new behavior?

When I fixed the version of `@supabase/postgrest-js` to `1.15.8` as a workaround then the problem gone.

```
"resolutions": {
    "@supabase/postgrest-js": "^1.15.8"
}
```

## Additional context

