### PR TITLE
fix: bump auth-js to v2.64.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0-automated",
       "license": "MIT",
       "dependencies": {
-        "@supabase/auth-js": "2.64.2",
+        "@supabase/auth-js": "2.64.4",
         "@supabase/functions-js": "2.4.1",
         "@supabase/node-fetch": "2.6.15",
         "@supabase/postgrest-js": "1.15.8",
@@ -1175,9 +1175,9 @@
       }
     },
     "node_modules/@supabase/auth-js": {
-      "version": "2.64.2",
-      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.64.2.tgz",
-      "integrity": "sha512-s+lkHEdGiczDrzXJ1YWt2y3bxRi+qIUnXcgkpLSrId7yjBeaXBFygNjTaoZLG02KNcYwbuZ9qkEIqmj2hF7svw==",
+      "version": "2.64.4",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.64.4.tgz",
+      "integrity": "sha512-9ITagy4WP4FLl+mke1rchapOH0RQpf++DI+WSG2sO1OFOZ0rW3cwAM0nCrMOxu+Zw4vJ4zObc08uvQrXx590Tg==",
       "dependencies": {
         "@supabase/node-fetch": "^2.6.14"
       }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "serve:coverage": "npm run test:coverage && serve test/coverage"
   },
   "dependencies": {
-    "@supabase/auth-js": "2.64.2",
+    "@supabase/auth-js": "2.64.4",
     "@supabase/functions-js": "2.4.1",
     "@supabase/node-fetch": "2.6.15",
     "@supabase/postgrest-js": "1.15.8",


### PR DESCRIPTION
## What kind of change does this PR introduce?
* See [changelog](https://github.com/supabase/auth-js/compare/v2.64.2...v2.64.4)


## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
