### PR TITLE
fix: Allow passing a custom lock function to supabase client

### DIFF
--- a/src/SupabaseClient.ts
+++ b/src/SupabaseClient.ts
@@ -279,6 +279,7 @@ export default class SupabaseClient<
       storage,
       storageKey,
       flowType,
+      lock,
       debug,
     }: SupabaseAuthClientOptions,
     headers?: Record<string, string>,
@@ -297,6 +298,7 @@ export default class SupabaseClient<
       detectSessionInUrl,
       storage,
       flowType,
+      lock,
       debug,
       fetch,
       // auth checks if there is a custom authorizaiton header using this flag


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

You cannot pass a custom `lock` function to `createClient`. It's currently being lost  in the `_initSupabaseAuthClient()` function. The `lock` parameter is not being used.

## What is the new behavior?

A custom `lock` function will be used (and correctly passed to the GoTrueClient) inside the `_initSupabaseAuthClient()` function.


