### PR TITLE
fix: bump storage-js v2.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@supabase/node-fetch": "2.6.15",
         "@supabase/postgrest-js": "1.15.8",
         "@supabase/realtime-js": "2.10.2",
-        "@supabase/storage-js": "2.6.0"
+        "@supabase/storage-js": "2.7.0"
       },
       "devDependencies": {
         "@sebbo2002/semantic-release-jsr": "^1.0.0",
@@ -1222,9 +1222,9 @@
       }
     },
     "node_modules/@supabase/storage-js": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.6.0.tgz",
-      "integrity": "sha512-REAxr7myf+3utMkI2oOmZ6sdplMZZ71/2NEIEMBZHL9Fkmm3/JnaOZVSRqvG4LStYj2v5WhCruCzuMn6oD/Drw==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.7.0.tgz",
+      "integrity": "sha512-iZenEdO6Mx9iTR6T7wC7sk6KKsoDPLq8rdu5VRy7+JiT1i8fnqfcOr6mfF2Eaqky9VQzhP8zZKQYjzozB65Rig==",
       "dependencies": {
         "@supabase/node-fetch": "^2.6.14"
       }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@supabase/node-fetch": "2.6.15",
     "@supabase/postgrest-js": "1.15.8",
     "@supabase/realtime-js": "2.10.2",
-    "@supabase/storage-js": "2.6.0"
+    "@supabase/storage-js": "2.7.0"
   },
   "devDependencies": {
     "@sebbo2002/semantic-release-jsr": "^1.0.0",


### PR DESCRIPTION
## What kind of change does this PR introduce?

Dep updated

## What is the new behavior?

storage-js version update, with support for metadata and exists.
