### PR TITLE
Updates supabase sub-modules to latest versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,12 @@
       "version": "0.0.0-automated",
       "license": "MIT",
       "dependencies": {
-        "@supabase/auth-js": "2.65.0",
-        "@supabase/functions-js": "2.4.1",
+        "@supabase/auth-js": "2.65.1",
+        "@supabase/functions-js": "2.4.3",
         "@supabase/node-fetch": "2.6.15",
-        "@supabase/postgrest-js": "1.16.1",
-        "@supabase/realtime-js": "2.10.2",
-        "@supabase/storage-js": "2.7.0"
+        "@supabase/postgrest-js": "1.16.2",
+        "@supabase/realtime-js": "2.10.7",
+        "@supabase/storage-js": "2.7.1"
       },
       "devDependencies": {
         "@sebbo2002/semantic-release-jsr": "^1.0.0",
@@ -1169,18 +1169,17 @@
       }
     },
     "node_modules/@supabase/auth-js": {
-      "version": "2.65.0",
-      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.65.0.tgz",
-      "integrity": "sha512-+wboHfZufAE2Y612OsKeVP4rVOeGZzzMLD/Ac3HrTQkkY4qXNjI6Af9gtmxwccE5nFvTiF114FEbIQ1hRq5uUw==",
+      "version": "2.65.1",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.65.1.tgz",
+      "integrity": "sha512-IA7i2Xq2SWNCNMKxwmPlHafBQda0qtnFr8QnyyBr+KaSxoXXqEzFCnQ1dGTy6bsZjVBgXu++o3qrDypTspaAPw==",
       "dependencies": {
         "@supabase/node-fetch": "^2.6.14"
       }
     },
     "node_modules/@supabase/functions-js": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.4.1.tgz",
-      "integrity": "sha512-8sZ2ibwHlf+WkHDUZJUXqqmPvWQ3UHN0W30behOJngVh/qHHekhJLCFbh0AjkE9/FqqXtf9eoVvmYgfCLk5tNA==",
-      "license": "MIT",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.4.3.tgz",
+      "integrity": "sha512-sOLXy+mWRyu4LLv1onYydq+10mNRQ4rzqQxNhbrKLTLTcdcmS9hbWif0bGz/NavmiQfPs4ZcmQJp4WqOXlR4AQ==",
       "dependencies": {
         "@supabase/node-fetch": "^2.6.14"
       }
@@ -1197,17 +1196,17 @@
       }
     },
     "node_modules/@supabase/postgrest-js": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.16.1.tgz",
-      "integrity": "sha512-EOSEZFm5pPuCPGCmLF1VOCS78DfkSz600PBuvBND/IZmMciJ1pmsS3ss6TkB6UkuvTybYiBh7gKOYyxoEO3USA==",
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.16.2.tgz",
+      "integrity": "sha512-dA/CIrSO2YDQ6ABNpbvEg9DwBMMbuKfWaFuZAU9c66PenoLSoIoyXk1Yq/wC2XISgEIqaMHmTrDAAsO80kjHqg==",
       "dependencies": {
         "@supabase/node-fetch": "^2.6.14"
       }
     },
     "node_modules/@supabase/realtime-js": {
-      "version": "2.10.2",
-      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.10.2.tgz",
-      "integrity": "sha512-qyCQaNg90HmJstsvr2aJNxK2zgoKh9ZZA8oqb7UT2LCh3mj9zpa3Iwu167AuyNxsxrUE8eEJ2yH6wLCij4EApA==",
+      "version": "2.10.7",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.10.7.tgz",
+      "integrity": "sha512-OLI0hiSAqQSqRpGMTUwoIWo51eUivSYlaNBgxsXZE7PSoWh12wPRdVt0psUMaUzEonSB85K21wGc7W5jHnT6uA==",
       "dependencies": {
         "@supabase/node-fetch": "^2.6.14",
         "@types/phoenix": "^1.5.4",
@@ -1216,9 +1215,9 @@
       }
     },
     "node_modules/@supabase/storage-js": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.7.0.tgz",
-      "integrity": "sha512-iZenEdO6Mx9iTR6T7wC7sk6KKsoDPLq8rdu5VRy7+JiT1i8fnqfcOr6mfF2Eaqky9VQzhP8zZKQYjzozB65Rig==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.7.1.tgz",
+      "integrity": "sha512-asYHcyDR1fKqrMpytAS1zjyEfvxuOIp1CIXX7ji4lHHcJKqyk+sLl/Vxgm4sN6u8zvuUtae9e4kDxQP2qrwWBA==",
       "dependencies": {
         "@supabase/node-fetch": "^2.6.14"
       }

--- a/package.json
+++ b/package.json
@@ -40,12 +40,12 @@
     "serve:coverage": "npm run test:coverage && serve test/coverage"
   },
   "dependencies": {
-    "@supabase/auth-js": "2.65.0",
-    "@supabase/functions-js": "2.4.1",
+    "@supabase/auth-js": "2.65.1",
+    "@supabase/functions-js": "2.4.3",
     "@supabase/node-fetch": "2.6.15",
-    "@supabase/postgrest-js": "1.16.1",
-    "@supabase/realtime-js": "2.10.2",
-    "@supabase/storage-js": "2.7.0"
+    "@supabase/postgrest-js": "1.16.2",
+    "@supabase/realtime-js": "2.10.7",
+    "@supabase/storage-js": "2.7.1"
   },
   "devDependencies": {
     "@sebbo2002/semantic-release-jsr": "^1.0.0",


### PR DESCRIPTION
I just ran into the issue described in https://github.com/supabase/realtime/issues/282 — the `subscribe` does not mean that I'm successfully subscribed to `postgres_changes` - instead I need to listen on `'system'` messages for that confirmation, checking the `extension` and `status` properties, as @chasers described in that thread.

I searched around to see if the types for `@supabase/supabase-js` to include `'system'`, and was happily surprised to see that @filipecabaco added it in https://github.com/supabase/realtime-js/pull/422 last month.

Then I was confused to discover that this module hadn't been updated since then.

Thankfully a simple fix! Just updating these version numbers. I went ahead and update the other supabase modules that are behind their latest versions, too.

It would be ideal if this module was automatically updated when its supabase sub-modules are updated, as I think everyone is mostly using them via this module, as the docs say to do. Or perhaps a more lenient version constraint at least so users can more easily update them on their own?