### PR TITLE
Update @supabase/postgrest-js to v1.16.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@supabase/auth-js": "2.65.1",
         "@supabase/functions-js": "2.4.3",
         "@supabase/node-fetch": "2.6.15",
-        "@supabase/postgrest-js": "1.16.2",
+        "@supabase/postgrest-js": "1.16.3",
         "@supabase/realtime-js": "2.10.7",
         "@supabase/storage-js": "2.7.1"
       },
@@ -1196,9 +1196,9 @@
       }
     },
     "node_modules/@supabase/postgrest-js": {
-      "version": "1.16.2",
-      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.16.2.tgz",
-      "integrity": "sha512-dA/CIrSO2YDQ6ABNpbvEg9DwBMMbuKfWaFuZAU9c66PenoLSoIoyXk1Yq/wC2XISgEIqaMHmTrDAAsO80kjHqg==",
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.16.3.tgz",
+      "integrity": "sha512-HI6dsbW68AKlOPofUjDTaosiDBCtW4XAm0D18pPwxoW3zKOE2Ru13Z69Wuys9fd6iTpfDViNco5sgrtnP0666A==",
       "dependencies": {
         "@supabase/node-fetch": "^2.6.14"
       }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@supabase/auth-js": "2.65.1",
     "@supabase/functions-js": "2.4.3",
     "@supabase/node-fetch": "2.6.15",
-    "@supabase/postgrest-js": "1.16.3",
+    "@supabase/postgrest-js": "1.16.2",
     "@supabase/realtime-js": "2.10.7",
     "@supabase/storage-js": "2.7.1"
   },

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@supabase/auth-js": "2.65.1",
     "@supabase/functions-js": "2.4.3",
     "@supabase/node-fetch": "2.6.15",
-    "@supabase/postgrest-js": "1.16.2",
+    "@supabase/postgrest-js": "1.16.3",
     "@supabase/realtime-js": "2.10.7",
     "@supabase/storage-js": "2.7.1"
   },


### PR DESCRIPTION
## What kind of change does this PR introduce?

Update @supabase/postgrest-js to v1.16.3

## What is the current behavior?

Type `PostgrestError` is not assignable to class `PostgrestError`: https://github.com/supabase/supabase-js/issues/1287

## What is the new behavior?

Type `PostgrestError` is removed, class `PostgrestError` is used instead
