### PR TITLE
feat: do not send non-JWTs in `Authorization` header

### DIFF
--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -1,5 +1,6 @@
 // @ts-ignore
 import nodeFetch, { Headers as NodeFetchHeaders } from '@supabase/node-fetch'
+import { isJWT } from './helpers'
 
 type Fetch = typeof fetch
 
@@ -31,15 +32,17 @@ export const fetchWithAuth = (
   const fetch = resolveFetch(customFetch)
   const HeadersConstructor = resolveHeadersConstructor()
 
+  const defaultAccessToken = isJWT(supabaseKey) ? supabaseKey : null
+
   return async (input, init) => {
-    const accessToken = (await getAccessToken()) ?? supabaseKey
+    const accessToken = (await getAccessToken()) ?? defaultAccessToken
     let headers = new HeadersConstructor(init?.headers)
 
     if (!headers.has('apikey')) {
       headers.set('apikey', supabaseKey)
     }
 
-    if (!headers.has('Authorization')) {
+    if (!headers.has('Authorization') && accessToken) {
       headers.set('Authorization', `Bearer ${accessToken}`)
     }
 

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -66,3 +66,60 @@ export function applySettingDefaults<
 
   return result
 }
+
+export const BASE64URL_REGEX = /^([a-z0-9_-]{4})*($|[a-z0-9_-]{3}$|[a-z0-9_-]{2}$)$/i
+
+/**
+ * Checks that the value somewhat looks like a JWT, does not do any additional parsing or verification.
+ */
+export function isJWT(value: string): boolean {
+  if (value.startsWith('Bearer ')) {
+    value = value.substring('Bearer '.length)
+  }
+
+  value = value.trim()
+
+  if (!value) {
+    return false
+  }
+
+  const parts = value.split('.')
+
+  if (parts.length !== 3) {
+    return false
+  }
+
+  for (let i = 0; i < parts.length; i += 1) {
+    const part = parts[i]
+
+    if (part.length < 4 || !BASE64URL_REGEX.test(part)) {
+      return false
+    }
+  }
+
+  return true
+}
+
+export function checkAuthorizationHeader(headers: { [header: string]: string }) {
+  if (headers.authorization && headers.Authorization) {
+    console.warn(
+      '@supabase-js: Both `authorization` and `Authorization` headers specified in createClient options. `Authorization` will be used.'
+    )
+
+    delete headers.authorization
+  }
+
+  const authorization = headers.Authorization ?? headers.authorization ?? null
+
+  if (!authorization) {
+    return
+  }
+
+  if (authorization.startsWith('Bearer ') && authorization.length > 'Bearer '.length) {
+    if (!isJWT(authorization)) {
+      throw new Error(
+        '@supabase-js: createClient called with global Authorization header that does not contain a JWT'
+      )
+    }
+  }
+}


### PR DESCRIPTION
In preparation for the introduction of new API keys, the client library should not pass non-JWT values in the `Authorization` header, as requests like this will definitely fail.

Two backward compatible changes are introduced:

- Configuring a `createClient()` with a non-JWT Supabase Key will not forward it as the `Authorization: Bearer <...>` header.
- Configuring a `createClient()` with global header options that contains a non-JWT in the `Authorization` header will throw an error.