### PR TITLE
chore(lib/fetch): dynamic import `@supabase/node-fetch`

### DIFF
--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -1,27 +1,5 @@
-// @ts-ignore
-import nodeFetch, { Headers as NodeFetchHeaders } from '@supabase/node-fetch'
-
-type Fetch = typeof fetch
-
-export const resolveFetch = (customFetch?: Fetch): Fetch => {
-  let _fetch: Fetch
-  if (customFetch) {
-    _fetch = customFetch
-  } else if (typeof fetch === 'undefined') {
-    _fetch = nodeFetch as unknown as Fetch
-  } else {
-    _fetch = fetch
-  }
-  return (...args: Parameters<Fetch>) => _fetch(...args)
-}
-
-export const resolveHeadersConstructor = () => {
-  if (typeof Headers === 'undefined') {
-    return NodeFetchHeaders
-  }
-
-  return Headers
-}
+import { resolveFetch, resolveHeadersConstructor } from './helpers'
+import { Fetch } from './types'
 
 export const fetchWithAuth = (
   supabaseKey: string,
@@ -29,10 +7,11 @@ export const fetchWithAuth = (
   customFetch?: Fetch
 ): Fetch => {
   const fetch = resolveFetch(customFetch)
-  const HeadersConstructor = resolveHeadersConstructor()
 
   return async (input, init) => {
     const accessToken = (await getAccessToken()) ?? supabaseKey
+
+    const HeadersConstructor = await resolveHeadersConstructor()
     let headers = new HeadersConstructor(init?.headers)
 
     if (!headers.has('apikey')) {

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -1,5 +1,5 @@
 // helpers.ts
-import { SupabaseClientOptions } from './types'
+import { Fetch, SupabaseClientOptions } from './types'
 
 export function uuid() {
   return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
@@ -65,4 +65,27 @@ export function applySettingDefaults<
   }
 
   return result
+}
+
+export const resolveFetch = (customFetch?: Fetch): Fetch => {
+  let _fetch: Fetch
+  if (customFetch) {
+    _fetch = customFetch
+  } else if (typeof fetch === 'undefined') {
+    _fetch = (...args) =>
+      import('@supabase/node-fetch' as any).then(({ default: fetch }) => fetch(...args))
+  } else {
+    _fetch = fetch
+  }
+  return (...args: Parameters<Fetch>) => _fetch(...args)
+}
+
+export const resolveHeadersConstructor = async () => {
+  if (typeof Headers === 'undefined') {
+    return import('@supabase/node-fetch' as any).then(
+      ({ Headers: NodeFetchHeaders }) => NodeFetchHeaders as typeof Headers
+    )
+  }
+
+  return Headers
 }


### PR DESCRIPTION
Dynamic import('@supabase/node-fetch') in `lib/fetch` to avoid possible `Cannot read property 'bind' of undefined` error.

Closes #1303