### PR TITLE
fix: Make the return value of accessToken nullable

### DIFF
--- a/src/SupabaseClient.ts
+++ b/src/SupabaseClient.ts
@@ -51,7 +51,7 @@ export default class SupabaseClient<
   protected storageKey: string
   protected fetch?: Fetch
   protected changedAccessToken?: string
-  protected accessToken?: () => Promise<string>
+  protected accessToken?: () => Promise<string | null>
 
   protected headers: Record<string, string>
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -77,7 +77,7 @@ export type SupabaseClientOptions<SchemaName> = {
    * Create another client if you wish to use Supabase Auth and third-party
    * authentications concurrently in the same application.
    */
-  accessToken?: () => Promise<string>
+  accessToken?: () => Promise<string | null>
 }
 
 export type GenericTable = {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

Reading through [the documentation](https://supabase.com/docs/guides/auth/third-party/firebase-auth?queryGroups=firebase-create-client&firebase-create-client=ts#setup-the-supabase-client-library), it looks like the return value of the `accessToken` should allow `null` to be returned, but the current type doesn't allow null to be returned. This PR updates the return type of the `accessToken` function to allow null to be returned.

## What is the current behavior?

The code sample from the docs has type error, because `null` cannot be returned from `accessToken` function.
```ts
import { createClient } from '@supabase/supabase-js'

const supabase = createClient('https://<supabase-project>.supabase.co', 'SUPABASE_ANON_KEY', {
  accessToken: async () => {
    return await firebase.auth().currentUser?.getIdToken(/* forceRefresh */ false)) ?? null
  },
})
```

## What is the new behavior?

`null` can be returned from the function if no users are found.