### PR TITLE
fix: bump auth version to v2.67.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0-automated",
       "license": "MIT",
       "dependencies": {
-        "@supabase/auth-js": "2.66.1",
+        "@supabase/auth-js": "2.67.0",
         "@supabase/functions-js": "2.4.3",
         "@supabase/node-fetch": "2.6.15",
         "@supabase/postgrest-js": "1.16.3",
@@ -1169,9 +1169,9 @@
       }
     },
     "node_modules/@supabase/auth-js": {
-      "version": "2.66.1",
-      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.66.1.tgz",
-      "integrity": "sha512-kOW+04SuDXmP2jRX9JL1Rgzduj8BcOG1qC3RaWdZsxnv89svNCdLRv8PfXW3QPKJdw0k1jF30OlQDPkzbDEL9w==",
+      "version": "2.67.0",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.67.0.tgz",
+      "integrity": "sha512-zbyxFWJmdkQalnDr4vYNtxh//NLBwjPgggZ0hcoY/Ry8c5p9gZV6v972uz/wRxiRSGyNt9xnxbXKLQkDsqEMkQ==",
       "dependencies": {
         "@supabase/node-fetch": "^2.6.14"
       }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "serve:coverage": "npm run test:coverage && serve test/coverage"
   },
   "dependencies": {
-    "@supabase/auth-js": "2.66.1",
+    "@supabase/auth-js": "2.67.0",
     "@supabase/functions-js": "2.4.3",
     "@supabase/node-fetch": "2.6.15",
     "@supabase/postgrest-js": "1.16.3",


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Bumps auth version to [v2.67.0](https://github.com/supabase/auth-js/releases/tag/v2.67.0) 
