### PR TITLE
fix: update auth-js to v2.67.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0-automated",
       "license": "MIT",
       "dependencies": {
-        "@supabase/auth-js": "2.67.1",
+        "@supabase/auth-js": "2.67.3",
         "@supabase/functions-js": "2.4.3",
         "@supabase/node-fetch": "2.6.15",
         "@supabase/postgrest-js": "1.17.7",
@@ -1169,9 +1169,9 @@
       }
     },
     "node_modules/@supabase/auth-js": {
-      "version": "2.67.1",
-      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.67.1.tgz",
-      "integrity": "sha512-1SRZG9VkLFz4rtiyEc1l49tMq9jTYu4wJt3pMQEWi7yshZFIBdVH1o5sshk1plQd5LY6GcrPIpCydM2gGDxchA==",
+      "version": "2.67.3",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.67.3.tgz",
+      "integrity": "sha512-NJDaW8yXs49xMvWVOkSIr8j46jf+tYHV0wHhrwOaLLMZSFO4g6kKAf+MfzQ2RaD06OCUkUHIzctLAxjTgEVpzw==",
       "dependencies": {
         "@supabase/node-fetch": "^2.6.14"
       }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "serve:coverage": "npm run test:coverage && serve test/coverage"
   },
   "dependencies": {
-    "@supabase/auth-js": "2.67.1",
+    "@supabase/auth-js": "2.67.3",
     "@supabase/functions-js": "2.4.3",
     "@supabase/node-fetch": "2.6.15",
     "@supabase/postgrest-js": "1.17.7",


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Upgrades auth-js to [v2.67.3](https://github.com/supabase/auth-js/releases/tag/v2.67.3)
