### PR TITLE
DRAFT: (breaking change) createAdminClient()

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,8 +21,46 @@ export * from '@supabase/realtime-js'
 export { default as SupabaseClient } from './SupabaseClient'
 export type { SupabaseClientOptions, QueryResult, QueryData, QueryError } from './lib/types'
 
+interface JwtPayload {
+  role: string
+  iss: string
+  iat: number
+  exp: number
+}
+
+function decodeJWT(jwt: string): JwtPayload | null {
+  try {
+    const base64Url = jwt.split('.')[1]
+    if (!base64Url) return null
+
+    const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/')
+    const jsonPayload = decodeURIComponent(
+      atob(base64)
+        .split('')
+        .map((c) => '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2))
+        .join('')
+    )
+
+    return JSON.parse(jsonPayload)
+  } catch (e) {
+    return null
+  }
+}
+
+const isServiceKey = (supabaseKey: string): boolean => {
+  // First try to decode the JWT
+  const payload = decodeJWT(supabaseKey)
+  if (payload) {
+    return payload.role === 'service_role'
+  }
+
+  // Fallback to string matching if JWT parsing fails
+  return supabaseKey.includes('service_role')
+}
+
 /**
- * Creates a new Supabase Client.
+ * Creates a new Supabase Client for public usage.
+ * @throws Error if a service role key is used
  */
 export const createClient = <
   Database = any,
@@ -37,5 +75,37 @@ export const createClient = <
   supabaseKey: string,
   options?: SupabaseClientOptions<SchemaName>
 ): SupabaseClient<Database, SchemaName, Schema> => {
+  if (isServiceKey(supabaseKey)) {
+    throw new Error(
+      'Service role API keys should only be used with createAdminClient(). ' +
+        'Use createClient() with an anon key when authenticating users.'
+    )
+  }
+  return new SupabaseClient<Database, SchemaName, Schema>(supabaseUrl, supabaseKey, options)
+}
+
+/**
+ * Creates a new Supabase Admin Client with service role privileges.
+ * @throws Error if a non-service-role key is used
+ */
+export const createAdminClient = <
+  Database = any,
+  SchemaName extends string & keyof Database = 'public' extends keyof Database
+    ? 'public'
+    : string & keyof Database,
+  Schema extends GenericSchema = Database[SchemaName] extends GenericSchema
+    ? Database[SchemaName]
+    : any
+>(
+  supabaseUrl: string,
+  supabaseKey: string,
+  options?: SupabaseClientOptions<SchemaName>
+): SupabaseClient<Database, SchemaName, Schema> => {
+  if (!isServiceKey(supabaseKey)) {
+    throw new Error(
+      'createAdminClient() requires a service role API key. ' +
+        'Use createClient() for non-admin operations.'
+    )
+  }
   return new SupabaseClient<Database, SchemaName, Schema>(supabaseUrl, supabaseKey, options)
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,8 +77,7 @@ export const createClient = <
 ): SupabaseClient<Database, SchemaName, Schema> => {
   if (isServiceKey(supabaseKey)) {
     throw new Error(
-      'Service role API keys should only be used with createAdminClient(). ' +
-        'Use createClient() with an anon key when authenticating users.'
+      'createClient() requires an public API key. You are using an admin key. Admin keys should only be used with createAdminClient().'
     )
   }
   return new SupabaseClient<Database, SchemaName, Schema>(supabaseUrl, supabaseKey, options)
@@ -102,10 +101,7 @@ export const createAdminClient = <
   options?: SupabaseClientOptions<SchemaName>
 ): SupabaseClient<Database, SchemaName, Schema> => {
   if (!isServiceKey(supabaseKey)) {
-    throw new Error(
-      'createAdminClient() requires a service role API key. ' +
-        'Use createClient() for non-admin operations.'
-    )
+    throw new Error('createAdminClient() requires an admin API key.')
   }
   return new SupabaseClient<Database, SchemaName, Schema>(supabaseUrl, supabaseKey, options)
 }

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -1,9 +1,11 @@
 import { PostgrestClient } from '@supabase/postgrest-js'
-import { createClient, SupabaseClient } from '../src/index'
+import { createClient, createAdminClient, SupabaseClient } from '../src/index'
 import { Database } from './types'
 
 const URL = 'http://localhost:3000'
 const KEY = 'some.fake.key'
+const FAKE_ADMIN_KEY =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.ewogICJyb2xlIjogInNlcnZpY2Vfcm9sZSIsCiAgImlzcyI6ICJzdXBhYmFzZSIsCiAgImlhdCI6IDE3MzQ0NzY0MDAsCiAgImV4cCI6IDE4OTIyNDI4MDAKfQ.rasWvv_ZRzGaptpahkSyL9R9L6NuEeCUQ45j6_VfYds'
 
 const supabase = createClient(URL, KEY)
 
@@ -17,6 +19,18 @@ test('it should create a client with third-party auth accessToken', async () => 
   expect(() => client.auth.getUser()).toThrowError(
     '@supabase/supabase-js: Supabase Client is configured with the accessToken option, accessing supabase.auth.getUser is not possible'
   )
+})
+
+// Check that it throws an error if a service key is used
+test('createClient() should throw an error if a service key is used', () => {
+  expect(() => createClient(URL, FAKE_ADMIN_KEY)).toThrowError(
+    'createClient() requires an public API key. You are using an admin key. Admin keys should only be used with createAdminClient().'
+  )
+})
+
+// Check that it doesn't throw an error if a service key is used
+test('createAdminClient() should not throw an error if a service key is used', () => {
+  expect(() => createAdminClient(URL, FAKE_ADMIN_KEY)).not.toThrow()
 })
 
 test('it should create the client connection', async () => {


### PR DESCRIPTION
throws an error if the user runs createClient() with a service_role key

This is a spike for internal discussion. It would be considered a breaking change as developers would need to change their Adming init code from

```js
import { createClient } from '@supabase/supabase-js'

const admin = createClient('SUPABASE_URL', 'SERVICE_ROLE_KEY')
```
to 

```js
import { createAdminClient } from '@supabase/supabase-js'

const admin = createAdminClient('SUPABASE_URL', 'SERVICE_ROLE_KEY')
```