### PR TITLE
fix: Realtime optional ws

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@supabase/functions-js": "2.4.4",
     "@supabase/node-fetch": "2.6.15",
     "@supabase/postgrest-js": "1.17.7",
-    "@supabase/realtime-js": "2.11.2",
+    "@supabase/realtime-js": "git://github.com/supabase/realtime-js.git#fix/selective-import-of-ws",
     "@supabase/storage-js": "2.7.1"
   },
   "devDependencies": {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Realtime version that allows optional ws dependency
