### PR TITLE
deps: Bump postgrest-js to 1.17.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@supabase/auth-js": "2.67.3",
         "@supabase/functions-js": "2.4.4",
         "@supabase/node-fetch": "2.6.15",
-        "@supabase/postgrest-js": "1.17.7",
+        "@supabase/postgrest-js": "1.17.9",
         "@supabase/realtime-js": "2.11.2",
         "@supabase/storage-js": "2.7.1"
       },
@@ -1196,9 +1196,9 @@
       }
     },
     "node_modules/@supabase/postgrest-js": {
-      "version": "1.17.7",
-      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.17.7.tgz",
-      "integrity": "sha512-aOzOYaTADm/dVTNksyqv9KsbhVa1gHz1Hoxb2ZEF2Ed9H7qlWOfptECQWmkEmrrFjtNaiPrgiSaPECvzI/seDA==",
+      "version": "1.17.9",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.17.9.tgz",
+      "integrity": "sha512-HyMOyy3t6K0/oFNDlHryOhnK4sfMNip8J0LrqJ/65NrBlHD3xOcDf4OV/5YCHI4g195ByuQ0wfmyFqIgMl3dxg==",
       "license": "MIT",
       "dependencies": {
         "@supabase/node-fetch": "^2.6.14"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@supabase/auth-js": "2.67.3",
     "@supabase/functions-js": "2.4.4",
     "@supabase/node-fetch": "2.6.15",
-    "@supabase/postgrest-js": "1.17.7",
+    "@supabase/postgrest-js": "1.17.9",
     "@supabase/realtime-js": "2.11.2",
     "@supabase/storage-js": "2.7.1"
   },


### PR DESCRIPTION
Not sure what's the release process for this SDK and where to mention the change introduced in https://github.com/supabase/postgrest-js/pull/589#discussion_r1903921838