### PR TITLE
fix: Bump postgrest-js to 1.17.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@supabase/auth-js": "2.67.3",
         "@supabase/functions-js": "2.4.4",
         "@supabase/node-fetch": "2.6.15",
-        "@supabase/postgrest-js": "1.17.9",
+        "@supabase/postgrest-js": "1.17.10",
         "@supabase/realtime-js": "2.11.2",
         "@supabase/storage-js": "2.7.1"
       },
@@ -1196,9 +1196,9 @@
       }
     },
     "node_modules/@supabase/postgrest-js": {
-      "version": "1.17.9",
-      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.17.9.tgz",
-      "integrity": "sha512-HyMOyy3t6K0/oFNDlHryOhnK4sfMNip8J0LrqJ/65NrBlHD3xOcDf4OV/5YCHI4g195ByuQ0wfmyFqIgMl3dxg==",
+      "version": "1.17.10",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.17.10.tgz",
+      "integrity": "sha512-GlcwOjEmPcXfaEU0wHg1MgHU+peR+zZFyaEWjr7a7EOCB1gCtw3nW7ABfnPPH411coXHV90eb/isDgT9HRshLg==",
       "license": "MIT",
       "dependencies": {
         "@supabase/node-fetch": "^2.6.14"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@supabase/auth-js": "2.67.3",
     "@supabase/functions-js": "2.4.4",
     "@supabase/node-fetch": "2.6.15",
-    "@supabase/postgrest-js": "1.17.9",
+    "@supabase/postgrest-js": "1.17.10",
     "@supabase/realtime-js": "2.11.2",
     "@supabase/storage-js": "2.7.1"
   },


### PR DESCRIPTION
Includes https://github.com/supabase/postgrest-js/pull/591