### PR TITLE
fix: export PostgrestError as a class

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,10 +3,10 @@ import type { GenericSchema, SupabaseClientOptions } from './lib/types'
 
 export * from '@supabase/auth-js'
 export type { User as AuthUser, Session as AuthSession } from '@supabase/auth-js'
-export type {
-  PostgrestResponse,
-  PostgrestSingleResponse,
-  PostgrestMaybeSingleResponse,
+export {
+  type PostgrestResponse,
+  type PostgrestSingleResponse,
+  type PostgrestMaybeSingleResponse,
   PostgrestError,
 } from '@supabase/postgrest-js'
 export {


### PR DESCRIPTION
Follow up to https://github.com/supabase/postgrest-js/pull/555