### PR TITLE
feat(types): also export type FunctionsResponse from functions-js

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ export {
   FunctionsError,
   type FunctionInvokeOptions,
   FunctionRegion,
+  type FunctionsResponse,
 } from '@supabase/functions-js'
 export * from '@supabase/realtime-js'
 export { default as SupabaseClient } from './SupabaseClient'


### PR DESCRIPTION
## What kind of change does this PR introduce?

Also export type `FunctionsResponse` from functions-js

As the return type of the `invoke` method of the `FunctionsClient` class, the `FunctionsResponse` type is significant if one wants to type the response when calling the `invoke` method.

## What is the current behavior?

Currently, one has to have functions-js as a dependency just for the `FunctionsResponse` type.
