### PR TITLE
feat(types): export more PostgrestResponse, PostgrestBuilder and PostgrestClient types from postgrest-js

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,8 +5,15 @@ export * from '@supabase/auth-js'
 export type { User as AuthUser, Session as AuthSession } from '@supabase/auth-js'
 export {
   type PostgrestResponse,
+  type PostgrestResponseFailure,
+  type PostgrestResponseSuccess,
   type PostgrestSingleResponse,
   type PostgrestMaybeSingleResponse,
+  type PostgrestClient,
+  type PostgrestQueryBuilder,
+  type PostgrestFilterBuilder,
+  type PostgrestTransformBuilder,
+  type PostgrestBuilder,
   PostgrestError,
 } from '@supabase/postgrest-js'
 export {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Export more `PostgrestResponse`, `PostgrestBuilder` and `PostgrestClient` types from postgrest-js

As the return type of, among others, the filter methods of the `PostgrestFilterBuilder` class, the types are significant if one wants to type the response when calling the filter methods.

## What is the current behavior?

Currently, one has to have postgrest-js as a dependency just for the `PostgrestResponse`, `PostgrestBuilder` and `PostgrestClient` types.
