### PR TITLE
fix: bump auth-js to v2.69.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0-automated",
       "license": "MIT",
       "dependencies": {
-        "@supabase/auth-js": "2.68.0",
+        "@supabase/auth-js": "2.69.0",
         "@supabase/functions-js": "2.4.4",
         "@supabase/node-fetch": "2.6.15",
         "@supabase/postgrest-js": "1.19.2",
@@ -1169,9 +1169,9 @@
       }
     },
     "node_modules/@supabase/auth-js": {
-      "version": "2.68.0",
-      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.68.0.tgz",
-      "integrity": "sha512-odG7nb7aOmZPUXk6SwL2JchSsn36Ppx11i2yWMIc/meUO2B2HK9YwZHPK06utD9Ql9ke7JKDbwGin/8prHKxxQ==",
+      "version": "2.69.0",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.69.0.tgz",
+      "integrity": "sha512-y3x/oYxBVjEsM+YJCFDnPqB017pb8nBcC+E6ieUJmf7LtfkcqfeSo06ZqNIjVw3w0k1PJRiXwKvTxBhBTxrqPg==",
       "license": "MIT",
       "dependencies": {
         "@supabase/node-fetch": "^2.6.14"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "serve:coverage": "npm run test:coverage && serve test/coverage"
   },
   "dependencies": {
-    "@supabase/auth-js": "2.68.0",
+    "@supabase/auth-js": "2.69.0",
     "@supabase/functions-js": "2.4.4",
     "@supabase/node-fetch": "2.6.15",
     "@supabase/postgrest-js": "1.19.2",


### PR DESCRIPTION
* bumps auth-js to [v2.69.0](https://github.com/supabase/auth-js/releases/tag/v2.69.0)

