### PR TITLE
fix: preserve path segments in supabaseUrl when constructing endpoints.

### DIFF
--- a/src/SupabaseClient.ts
+++ b/src/SupabaseClient.ts
@@ -19,7 +19,7 @@ import {
   DEFAULT_REALTIME_OPTIONS,
 } from './lib/constants'
 import { fetchWithAuth } from './lib/fetch'
-import { stripTrailingSlash, applySettingDefaults } from './lib/helpers'
+import { ensureTrailingSlash, applySettingDefaults } from './lib/helpers'
 import { SupabaseAuthClient } from './lib/SupabaseAuthClient'
 import { Fetch, GenericSchema, SupabaseClientOptions, SupabaseAuthClientOptions } from './lib/types'
 
@@ -75,7 +75,8 @@ export default class SupabaseClient<
     if (!supabaseUrl) throw new Error('supabaseUrl is required.')
     if (!supabaseKey) throw new Error('supabaseKey is required.')
 
-    const baseUrl = new URL(supabaseUrl)
+    const _supabaseUrl = ensureTrailingSlash(supabaseUrl)
+    const baseUrl = new URL(_supabaseUrl)
 
     this.realtimeUrl = new URL('realtime/v1', baseUrl)
     this.realtimeUrl.protocol = this.realtimeUrl.protocol.replace('http', 'ws')

--- a/src/SupabaseClient.ts
+++ b/src/SupabaseClient.ts
@@ -75,14 +75,13 @@ export default class SupabaseClient<
     if (!supabaseUrl) throw new Error('supabaseUrl is required.')
     if (!supabaseKey) throw new Error('supabaseKey is required.')
 
-    const _supabaseUrl = stripTrailingSlash(supabaseUrl)
-    const baseUrl = new URL(_supabaseUrl)
+    const baseUrl = new URL(supabaseUrl)
 
-    this.realtimeUrl = new URL('/realtime/v1', baseUrl)
+    this.realtimeUrl = new URL('realtime/v1', baseUrl)
     this.realtimeUrl.protocol = this.realtimeUrl.protocol.replace('http', 'ws')
-    this.authUrl = new URL('/auth/v1', baseUrl)
-    this.storageUrl = new URL('/storage/v1', baseUrl)
-    this.functionsUrl = new URL('/functions/v1', baseUrl)
+    this.authUrl = new URL('auth/v1', baseUrl)
+    this.storageUrl = new URL('storage/v1', baseUrl)
+    this.functionsUrl = new URL('functions/v1', baseUrl)
 
     // default storage key uses the supabase project ref as a namespace
     const defaultStorageKey = `sb-${baseUrl.hostname.split('.')[0]}-auth-token`
@@ -124,7 +123,7 @@ export default class SupabaseClient<
       accessToken: this._getAccessToken.bind(this),
       ...settings.realtime,
     })
-    this.rest = new PostgrestClient(`${_supabaseUrl}/rest/v1`, {
+    this.rest = new PostgrestClient(new URL('rest/v1', baseUrl).href, {
       headers: this.headers,
       schema: settings.db.schema,
       fetch: this.fetch,

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -9,8 +9,8 @@ export function uuid() {
   })
 }
 
-export function stripTrailingSlash(url: string): string {
-  return url.replace(/\/$/, '')
+export function ensureTrailingSlash(url: string): string {
+  return url.endsWith('/') ? url : url + '/'
 }
 
 export const isBrowser = () => typeof window !== 'undefined'

--- a/test/SupabaseClient.test.ts
+++ b/test/SupabaseClient.test.ts
@@ -45,6 +45,24 @@ describe('SupabaseClient', () => {
       expect(client.rest.url).toEqual('http://localhost:3000/rest/v1')
     })
 
+    test('should preserve paths in supabaseUrl', () => {
+      const baseUrlWithPath = 'http://localhost:3000/custom/base/'
+      const client = createClient(baseUrlWithPath, KEY)
+
+      // @ts-ignore
+      expect(client.authUrl.toString()).toEqual('http://localhost:3000/custom/base/auth/v1')
+      // @ts-ignore
+      expect(client.realtimeUrl.toString()).toEqual('ws://localhost:3000/custom/base/realtime/v1')
+      // @ts-ignore
+      expect(client.storageUrl.toString()).toEqual('http://localhost:3000/custom/base/storage/v1')
+      // @ts-ignore
+      expect(client.functionsUrl.toString()).toEqual(
+        'http://localhost:3000/custom/base/functions/v1'
+      )
+      // @ts-ignore
+      expect(client.rest.url).toEqual('http://localhost:3000/custom/base/rest/v1')
+    })
+
     test('should handle HTTPS URLs correctly', () => {
       const client = createClient('https://localhost:3000', KEY)
       // @ts-ignore
@@ -161,4 +179,4 @@ describe('SupabaseClient', () => {
       expect(rpcCall).toBeDefined()
     })
   })
-}) 
+})

--- a/test/SupabaseClient.test.ts
+++ b/test/SupabaseClient.test.ts
@@ -46,7 +46,7 @@ describe('SupabaseClient', () => {
     })
 
     test('should preserve paths in supabaseUrl', () => {
-      const baseUrlWithPath = 'http://localhost:3000/custom/base/'
+      const baseUrlWithPath = 'http://localhost:3000/custom/base'
       const client = createClient(baseUrlWithPath, KEY)
 
       // @ts-ignore

--- a/test/helper.test.ts
+++ b/test/helper.test.ts
@@ -1,13 +1,25 @@
-import { stripTrailingSlash } from '../src/lib/helpers'
+import { ensureTrailingSlash } from '../src/lib/helpers'
 
-test('Strip trailing slash from URL', () => {
-  const URL = 'http://localhost:3000/'
-  const expectedURL = URL.slice(0, -1)
-  expect(stripTrailingSlash(URL)).toBe(expectedURL)
+test('Adds trailing slash to URL if missing', () => {
+  const input = 'http://localhost:3000'
+  const expected = 'http://localhost:3000/'
+  expect(ensureTrailingSlash(input)).toBe(expected)
 })
 
-test('Return the original URL if there is no slash at the end', () => {
-  const URL = 'http://localhost:3000'
-  const expectedURL = URL
-  expect(stripTrailingSlash(URL)).toBe(expectedURL)
+test('Keeps trailing slash of URL if already present', () => {
+  const input = 'http://localhost:3000/'
+  const expected = 'http://localhost:3000/'
+  expect(ensureTrailingSlash(input)).toBe(expected)
+})
+
+test('Adds trailing slash to URL with path if missing', () => {
+  const input = 'http://localhost:3000/path/to/supabase'
+  const expected = 'http://localhost:3000/path/to/supabase/'
+  expect(ensureTrailingSlash(input)).toBe(expected)
+})
+
+test('Keeps trailing slash of URL with path if already present', () => {
+  const input = 'http://localhost:3000/path/to/supabase/'
+  const expected = 'http://localhost:3000/path/to/supabase/'
+  expect(ensureTrailingSlash(input)).toBe(expected)
 })


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR ensures that path segments in the `supabaseUrl` are preserved when constructing service endpoint URLs (e.g., auth, realtime, etc.). 

Fixes #1421.

## What is the current behavior?

Currently, any path component in the supabaseUrl is discarded when constructing endpoint URLs using the URL constructor.

Example:  `const supabase = createClient('https://example.com/path/to/supabase/', 'public-anon-key')` the resulting endpoint is incorrectly resolved as `https://example.com/realtime/v1`.

See #1421 for more context.


## What is the new behavior?

This fix preserves the full path in supabaseUrl when resolving endpoint URLs.
For example, if `supabaseUrl` is `https://example.com/path/to/supabase/`, the realtime endpoint will now correctly resolve to `https://example.com/path/to/supabase/realtime/v1`.


