### PR TITLE
fix: bump realtime-js to 2.11.15

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@supabase/functions-js": "2.4.4",
         "@supabase/node-fetch": "2.6.15",
         "@supabase/postgrest-js": "1.19.4",
-        "@supabase/realtime-js": "2.11.13",
+        "@supabase/realtime-js": "2.11.15",
         "@supabase/storage-js": "2.7.1"
       },
       "devDependencies": {
@@ -1110,14 +1110,16 @@
       }
     },
     "node_modules/@supabase/realtime-js": {
-      "version": "2.11.13",
-      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.11.13.tgz",
-      "integrity": "sha512-X2Gs+f0qjLr/60UTCidxRj+FCI/ABNar93aeMQj+v/7sm4RYOWlKNw46xmwWXL8zAL30wsHG2jD7ZvCH6zDv1A==",
+      "version": "2.11.15",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.11.15.tgz",
+      "integrity": "sha512-HQKRnwAqdVqJW/P9TjKVK+/ETpW4yQ8tyDPPtRMKOH4Uh3vQD74vmj353CYs8+YwVBKubeUOOEpI9CT8mT4obw==",
       "license": "MIT",
       "dependencies": {
         "@supabase/node-fetch": "^2.6.13",
         "@types/phoenix": "^1.6.6",
-        "isows": "^1.0.7"
+        "@types/ws": "^8.18.1",
+        "isows": "^1.0.7",
+        "ws": "^8.18.2"
       }
     },
     "node_modules/@supabase/storage-js": {
@@ -1279,8 +1281,7 @@
     "node_modules/@types/node": {
       "version": "20.1.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.1.3.tgz",
-      "integrity": "sha512-NP2yfZpgmf2eDRPmgGq+fjGjSwFgYbihA8/gK+ey23qT9RkxsgNTZvGOEpXgzIGqesTYkElELLgtKoMQTys5vA==",
-      "dev": true
+      "integrity": "sha512-NP2yfZpgmf2eDRPmgGq+fjGjSwFgYbihA8/gK+ey23qT9RkxsgNTZvGOEpXgzIGqesTYkElELLgtKoMQTys5vA=="
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.4",
@@ -1311,6 +1312,15 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
       "dev": true
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/yargs": {
       "version": "17.0.24",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@supabase/functions-js": "2.4.4",
     "@supabase/node-fetch": "2.6.15",
     "@supabase/postgrest-js": "1.19.4",
-    "@supabase/realtime-js": "2.11.13",
+    "@supabase/realtime-js": "2.11.15",
     "@supabase/storage-js": "2.7.1"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,8 +20,8 @@ importers:
         specifier: 1.19.4
         version: 1.19.4
       '@supabase/realtime-js':
-        specifier: 2.11.13
-        version: 2.11.13(ws@8.18.2)
+        specifier: 2.11.15
+        version: 2.11.15
       '@supabase/storage-js':
         specifier: 2.7.1
         version: 2.7.1
@@ -625,10 +625,10 @@ packages:
         integrity: sha512-O4soKqKtZIW3olqmbXXbKugUtByD2jPa8kL2m2c1oozAO11uCcGrRhkZL0kVxjBLrXHE0mdSkFsMj7jDSfyNpw==,
       }
 
-  '@supabase/realtime-js@2.11.13':
+  '@supabase/realtime-js@2.11.15':
     resolution:
       {
-        integrity: sha512-X2Gs+f0qjLr/60UTCidxRj+FCI/ABNar93aeMQj+v/7sm4RYOWlKNw46xmwWXL8zAL30wsHG2jD7ZvCH6zDv1A==,
+        integrity: sha512-HQKRnwAqdVqJW/P9TjKVK+/ETpW4yQ8tyDPPtRMKOH4Uh3vQD74vmj353CYs8+YwVBKubeUOOEpI9CT8mT4obw==,
       }
 
   '@supabase/storage-js@2.7.1':
@@ -792,6 +792,12 @@ packages:
     resolution:
       {
         integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==,
+      }
+
+  '@types/ws@8.18.1':
+    resolution:
+      {
+        integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==,
       }
 
   '@types/yargs-parser@21.0.3':
@@ -5600,13 +5606,16 @@ snapshots:
     dependencies:
       '@supabase/node-fetch': 2.6.15
 
-  '@supabase/realtime-js@2.11.13(ws@8.18.2)':
+  '@supabase/realtime-js@2.11.15':
     dependencies:
       '@supabase/node-fetch': 2.6.15
       '@types/phoenix': 1.6.6
+      '@types/ws': 8.18.1
       isows: 1.0.7(ws@8.18.2)
+      ws: 8.18.2
     transitivePeerDependencies:
-      - ws
+      - bufferutil
+      - utf-8-validate
 
   '@supabase/storage-js@2.7.1':
     dependencies:
@@ -5696,6 +5705,10 @@ snapshots:
   '@types/phoenix@1.6.6': {}
 
   '@types/stack-utils@2.0.3': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 22.14.1
 
   '@types/yargs-parser@21.0.3': {}
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Close https://github.com/supabase/supabase-js/issues/1462

## Additional context

### Bug Fixes

- soft deprecation of headers and simplify ws socket connection (https://github.com/supabase/realtime-js/issues/494) ([7123690](https://github.com/supabase/realtime-js/commit/71236904b722dddaa3c6231e18b677c1047f0d84))
- resolve 'ws' peer dependency (https://github.com/supabase/realtime-js/issues/495) ([a9c0955](https://github.com/supabase/realtime-js/commit/a9c0955e6e650aa4ce4c74fcb3a6abbb5b08b850))
