### PR TITLE
feat: use dedicated storage host for storage lib (allows >50GB uploads)

### DIFF
--- a/src/SupabaseClient.ts
+++ b/src/SupabaseClient.ts
@@ -81,8 +81,15 @@ export default class SupabaseClient<
     this.realtimeUrl = new URL('realtime/v1', baseUrl)
     this.realtimeUrl.protocol = this.realtimeUrl.protocol.replace('http', 'ws')
     this.authUrl = new URL('auth/v1', baseUrl)
-    this.storageUrl = new URL('storage/v1', baseUrl)
     this.functionsUrl = new URL('functions/v1', baseUrl)
+
+    const isPlatform = /supabase\.(co|in|red)$/.test(baseUrl.hostname)
+    if (isPlatform) {
+      this.storageUrl = new URL('v1', baseUrl)
+      this.storageUrl.hostname = baseUrl.hostname.replace('supabase.', 'storage.supabase.')
+    } else {
+      this.storageUrl = new URL('storage/v1', baseUrl)
+    }
 
     // default storage key uses the supabase project ref as a namespace
     const defaultStorageKey = `sb-${baseUrl.hostname.split('.')[0]}-auth-token`

--- a/test/unit/SupabaseClient.test.ts
+++ b/test/unit/SupabaseClient.test.ts
@@ -68,6 +68,21 @@ describe('SupabaseClient', () => {
       // @ts-ignore
       expect(client.realtimeUrl.toString()).toEqual('wss://localhost:3000/realtime/v1')
     })
+
+    test('should use storage zone for platform hosts', () => {
+      const client = createClient('https://blah.supabase.co', KEY)
+
+      // @ts-ignore
+      expect(client.authUrl.toString()).toEqual('https://blah.supabase.co/auth/v1')
+      // @ts-ignore
+      expect(client.realtimeUrl.toString()).toEqual('wss://blah.supabase.co/realtime/v1')
+      // @ts-ignore
+      expect(client.storageUrl.toString()).toEqual('https://blah.storage.supabase.co/v1')
+      // @ts-ignore
+      expect(client.functionsUrl.toString()).toEqual('https://blah.supabase.co/functions/v1')
+      // @ts-ignore
+      expect(client.rest.url).toEqual('https://blah.supabase.co/rest/v1')
+    })
   })
 
   describe('Custom Headers', () => {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

Storage lib is initialized using the same host as all other Supabase APIs. This zone does not allow uploading of large files.

## What is the new behavior?

Initialize storage lib using new `project-ref.storage.supabase.co/v1` URI which supports uploads up to 500GB

## Additional context

This is specific to the Supabase infrastructure

`project-ref.supabase.co/storage/v1` -> `project-ref.storage.supabase.co/v1`


