### PR TITLE
feat: bump auth-js to 2.71.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0-automated",
       "license": "MIT",
       "dependencies": {
-        "@supabase/auth-js": "2.70.0",
+        "@supabase/auth-js": "2.71.0",
         "@supabase/functions-js": "2.4.5",
         "@supabase/node-fetch": "2.6.15",
         "@supabase/postgrest-js": "1.19.4",
@@ -1089,9 +1089,9 @@
       }
     },
     "node_modules/@supabase/auth-js": {
-      "version": "2.70.0",
-      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.70.0.tgz",
-      "integrity": "sha512-BaAK/tOAZFJtzF1sE3gJ2FwTjLf4ky3PSvcvLGEgEmO4BSBkwWKu8l67rLLIBZPDnCyV7Owk2uPyKHa0kj5QGg==",
+      "version": "2.71.0",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.71.0.tgz",
+      "integrity": "sha512-OMYNbhGa1Cj4stalJq0VoHm5l7Sj/xY0j9CiYEQCikbQmtiDG3c27EIFA4OD+NxuoHTZmjaW8VJlS3SP+yasEA==",
       "license": "MIT",
       "dependencies": {
         "@supabase/node-fetch": "^2.6.14"

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "update:test-deps:bun": "npm run build && npm pack && cp supabase-supabase-js-*.tgz test/integration/bun/supabase-supabase-js-0.0.0-automated.tgz && cd test/integration/bun && bun install"
   },
   "dependencies": {
-    "@supabase/auth-js": "2.70.0",
+    "@supabase/auth-js": "2.71.0",
     "@supabase/functions-js": "2.4.5",
     "@supabase/node-fetch": "2.6.15",
     "@supabase/postgrest-js": "1.19.4",


### PR DESCRIPTION
Releases `supabase.auth.getClaims()` as a non-experimental function.