### PR TITLE
feat: bump storage version, and expose StorageClientOptions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@supabase/node-fetch": "2.6.15",
         "@supabase/postgrest-js": "1.19.4",
         "@supabase/realtime-js": "2.11.15",
-        "@supabase/storage-js": "2.7.1"
+        "@supabase/storage-js": "^2.10.4"
       },
       "devDependencies": {
         "@sebbo2002/semantic-release-jsr": "^1.0.0",
@@ -1139,9 +1139,10 @@
       }
     },
     "node_modules/@supabase/storage-js": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.7.1.tgz",
-      "integrity": "sha512-asYHcyDR1fKqrMpytAS1zjyEfvxuOIp1CIXX7ji4lHHcJKqyk+sLl/Vxgm4sN6u8zvuUtae9e4kDxQP2qrwWBA==",
+      "version": "2.10.4",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.10.4.tgz",
+      "integrity": "sha512-cvL02GarJVFcNoWe36VBybQqTVRq6wQSOCvTS64C+eyuxOruFIm1utZAY0xi2qKtHJO3EjKaj8iWJKySusDmAQ==",
+      "license": "MIT",
       "dependencies": {
         "@supabase/node-fetch": "^2.6.14"
       }

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@supabase/node-fetch": "2.6.15",
     "@supabase/postgrest-js": "1.19.4",
     "@supabase/realtime-js": "2.11.15",
-    "@supabase/storage-js": "2.7.1"
+    "@supabase/storage-js": "^2.10.4"
   },
   "devDependencies": {
     "@sebbo2002/semantic-release-jsr": "^1.0.0",

--- a/src/SupabaseClient.ts
+++ b/src/SupabaseClient.ts
@@ -42,6 +42,10 @@ export default class SupabaseClient<
    */
   auth: SupabaseAuthClient
   realtime: RealtimeClient
+  /**
+   * Supabase Storage allows you to manage user-generated content, such as photos or videos.
+   */
+  storage: SupabaseStorageClient
 
   protected realtimeUrl: URL
   protected authUrl: URL
@@ -64,6 +68,7 @@ export default class SupabaseClient<
    * @param options.auth.persistSession Set to "true" if you want to automatically save the user session into local storage.
    * @param options.auth.detectSessionInUrl Set to "true" if you want to automatically detects OAuth grants in the URL and signs in the user.
    * @param options.realtime Options passed along to realtime-js constructor.
+   * @param options.storage Options passed along to the storage-js constructor.
    * @param options.global.fetch A custom fetch implementation.
    * @param options.global.headers Any additional headers to send with each network request.
    */
@@ -130,6 +135,13 @@ export default class SupabaseClient<
       fetch: this.fetch,
     })
 
+    this.storage = new SupabaseStorageClient(
+      this.storageUrl.href,
+      this.headers,
+      this.fetch,
+      options?.storage
+    )
+
     if (!settings.accessToken) {
       this._listenForAuthEvents()
     }
@@ -143,13 +155,6 @@ export default class SupabaseClient<
       headers: this.headers,
       customFetch: this.fetch,
     })
-  }
-
-  /**
-   * Supabase Storage allows you to manage user-generated content, such as photos or videos.
-   */
-  get storage(): SupabaseStorageClient {
-    return new SupabaseStorageClient(this.storageUrl.href, this.headers, this.fetch)
   }
 
   // NOTE: signatures must be kept in sync with PostgrestClient.from

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -50,6 +50,7 @@ export function applySettingDefaults<
       ...DEFAULT_REALTIME_OPTIONS,
       ...realtimeOptions,
     },
+    storage: {},
     global: {
       ...DEFAULT_GLOBAL_OPTIONS,
       ...globalOptions,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,6 +1,7 @@
 import { AuthClient } from '@supabase/auth-js'
 import { RealtimeClientOptions } from '@supabase/realtime-js'
 import { PostgrestError } from '@supabase/postgrest-js'
+import { StorageClientOptions } from '@supabase/storage-js/dist/module/StorageClient'
 
 type AuthClientOptions = ConstructorParameters<typeof AuthClient>[0]
 
@@ -56,6 +57,7 @@ export type SupabaseClientOptions<SchemaName> = {
    * Options passed to the realtime-js instance
    */
   realtime?: RealtimeClientOptions
+  storage?: StorageClientOptions
   global?: {
     /**
      * A custom `fetch` implementation.


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## Changes

- Update [storage-js version ](https://github.com/supabase/storage-js/releases) to `v2.10.4`
  - Includes `StorageClientOptions` in constructor
  - Allows using direct storage host to optimize large uploads
  - Adds support for Analytics Buckets
  - Normalizes error handling when uploading objects
- Expose `StorageClientOptions` to allow passing storage specific settings to the storage client
