### PR TITLE
ci: fix coveralls parallel builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,19 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: ./test/coverage/lcov.info
+          parallel: true
+          flag-name: node-${{ matrix.node }}-${{ matrix.os }}
+
+  coveralls-finish:
+    name: Coveralls Finished
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - name: Coveralls Finished
+        uses: coverallsapp/github-action@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          parallel-finished: true
 
   deno-tests:
     name: Deno Tests / ${{ matrix.deno }}


### PR DESCRIPTION
## Summary
- Fix coveralls parallel builds by adding parallel configuration
- Add coveralls-finish job to properly finalize parallel coverage reporting

## Test plan
- [x] CI passes with proper coverage reporting
- [x] Coveralls correctly aggregates coverage from parallel jobs

🤖 Generated with [Claude Code](https://claude.ai/code)