### PR TITLE
fix: avoid Next.js Edge Runtime warnings in Node.js deprecation check

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -54,7 +54,7 @@ function shouldShowDeprecationWarning(): boolean {
 
   // Use dynamic property access to avoid Next.js Edge Runtime static analysis warnings
   const processVersion = (process as any)['version']
-  if (!processVersion) {
+  if (processVersion === undefined || processVersion === null) {
     return false
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,16 +42,23 @@ export const createClient = <
 
 // Check for Node.js <= 18 deprecation
 function shouldShowDeprecationWarning(): boolean {
-  if (
-    typeof window !== 'undefined' ||
-    typeof process === 'undefined' ||
-    process.version === undefined ||
-    process.version === null
-  ) {
+  // Skip in browser environments
+  if (typeof window !== 'undefined') {
     return false
   }
 
-  const versionMatch = process.version.match(/^v(\d+)\./)
+  // Skip if process is not available (e.g., Edge Runtime)
+  if (typeof process === 'undefined') {
+    return false
+  }
+
+  // Use dynamic property access to avoid Next.js Edge Runtime static analysis warnings
+  const processVersion = (process as any)['version']
+  if (!processVersion) {
+    return false
+  }
+
+  const versionMatch = processVersion.match(/^v(\d+)\./)
   if (!versionMatch) {
     return false
   }

--- a/test/unit/deprecation.test.ts
+++ b/test/unit/deprecation.test.ts
@@ -2,6 +2,9 @@
  * @jest-environment node
  */
 
+// Make this file a module to satisfy TypeScript's isolatedModules
+export {}
+
 describe('Node.js deprecation warning', () => {
   const originalProcess = global.process
   const originalWindow = global.window
@@ -31,14 +34,9 @@ describe('Node.js deprecation warning', () => {
     expect(console.warn).not.toHaveBeenCalled()
   })
 
-  it('should not show warning when process is undefined', () => {
-    // Simulate Edge Runtime environment where process doesn't exist
-    delete (global as any).process
-
-    require('../../src/index')
-
-    expect(console.warn).not.toHaveBeenCalled()
-  })
+  // Note: We can't easily test "process is undefined" because dependencies like ws require it
+  // The code handles it correctly with typeof process === 'undefined' check
+  // In real Edge Runtime, the module loading context is different
 
   it('should not show warning when process.version is undefined', () => {
     // Process exists but version is undefined

--- a/test/unit/deprecation.test.ts
+++ b/test/unit/deprecation.test.ts
@@ -1,0 +1,119 @@
+/**
+ * @jest-environment node
+ */
+
+describe('Node.js deprecation warning', () => {
+  const originalProcess = global.process
+  const originalWindow = global.window
+  const originalConsoleWarn = console.warn
+
+  beforeEach(() => {
+    // Reset modules to re-run the deprecation check
+    jest.resetModules()
+    // Mock console.warn
+    console.warn = jest.fn()
+  })
+
+  afterEach(() => {
+    // Restore original values
+    global.process = originalProcess
+    global.window = originalWindow
+    console.warn = originalConsoleWarn
+    jest.resetModules()
+  })
+
+  it('should not show warning in browser environment', () => {
+    // Simulate browser environment
+    global.window = {} as any
+
+    require('../../src/index')
+
+    expect(console.warn).not.toHaveBeenCalled()
+  })
+
+  it('should not show warning when process is undefined', () => {
+    // Simulate Edge Runtime environment where process doesn't exist
+    delete (global as any).process
+
+    require('../../src/index')
+
+    expect(console.warn).not.toHaveBeenCalled()
+  })
+
+  it('should not show warning when process.version is undefined', () => {
+    // Process exists but version is undefined
+    global.process = { ...originalProcess, version: undefined } as any
+
+    require('../../src/index')
+
+    expect(console.warn).not.toHaveBeenCalled()
+  })
+
+  it('should not show warning when process.version is null', () => {
+    // Process exists but version is null
+    global.process = { ...originalProcess, version: null } as any
+
+    require('../../src/index')
+
+    expect(console.warn).not.toHaveBeenCalled()
+  })
+
+  it('should show warning for Node.js 18', () => {
+    global.process = { ...originalProcess, version: 'v18.0.0' } as any
+    delete (global as any).window
+
+    require('../../src/index')
+
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Node.js 18 and below are deprecated')
+    )
+  })
+
+  it('should show warning for Node.js 16', () => {
+    global.process = { ...originalProcess, version: 'v16.14.0' } as any
+    delete (global as any).window
+
+    require('../../src/index')
+
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Node.js 18 and below are deprecated')
+    )
+  })
+
+  it('should not show warning for Node.js 20', () => {
+    global.process = { ...originalProcess, version: 'v20.0.0' } as any
+    delete (global as any).window
+
+    require('../../src/index')
+
+    expect(console.warn).not.toHaveBeenCalled()
+  })
+
+  it('should not show warning for Node.js 22', () => {
+    global.process = { ...originalProcess, version: 'v22.0.0' } as any
+    delete (global as any).window
+
+    require('../../src/index')
+
+    expect(console.warn).not.toHaveBeenCalled()
+  })
+
+  it('should handle invalid version format gracefully', () => {
+    global.process = { ...originalProcess, version: 'invalid-version' } as any
+    delete (global as any).window
+
+    require('../../src/index')
+
+    expect(console.warn).not.toHaveBeenCalled()
+  })
+
+  it('should handle version without v prefix', () => {
+    global.process = { ...originalProcess, version: '18.0.0' } as any
+    delete (global as any).window
+
+    require('../../src/index')
+
+    // Should not match the regex and thus not show warning
+    expect(console.warn).not.toHaveBeenCalled()
+  })
+})

--- a/test/unit/deprecation.test.ts
+++ b/test/unit/deprecation.test.ts
@@ -40,7 +40,11 @@ describe('Node.js deprecation warning', () => {
 
   it('should not show warning when process.version is undefined', () => {
     // Process exists but version is undefined
-    global.process = { ...originalProcess, version: undefined } as any
+    // Only mock the version property to avoid TTYWRAP warnings
+    Object.defineProperty(global.process, 'version', {
+      value: undefined,
+      configurable: true,
+    })
 
     require('../../src/index')
 
@@ -49,7 +53,11 @@ describe('Node.js deprecation warning', () => {
 
   it('should not show warning when process.version is null', () => {
     // Process exists but version is null
-    global.process = { ...originalProcess, version: null } as any
+    // Only mock the version property to avoid TTYWRAP warnings
+    Object.defineProperty(global.process, 'version', {
+      value: null,
+      configurable: true,
+    })
 
     require('../../src/index')
 
@@ -57,7 +65,10 @@ describe('Node.js deprecation warning', () => {
   })
 
   it('should show warning for Node.js 18', () => {
-    global.process = { ...originalProcess, version: 'v18.0.0' } as any
+    Object.defineProperty(global.process, 'version', {
+      value: 'v18.0.0',
+      configurable: true,
+    })
     delete (global as any).window
 
     require('../../src/index')
@@ -68,7 +79,10 @@ describe('Node.js deprecation warning', () => {
   })
 
   it('should show warning for Node.js 16', () => {
-    global.process = { ...originalProcess, version: 'v16.14.0' } as any
+    Object.defineProperty(global.process, 'version', {
+      value: 'v16.14.0',
+      configurable: true,
+    })
     delete (global as any).window
 
     require('../../src/index')
@@ -79,7 +93,10 @@ describe('Node.js deprecation warning', () => {
   })
 
   it('should not show warning for Node.js 20', () => {
-    global.process = { ...originalProcess, version: 'v20.0.0' } as any
+    Object.defineProperty(global.process, 'version', {
+      value: 'v20.0.0',
+      configurable: true,
+    })
     delete (global as any).window
 
     require('../../src/index')
@@ -88,7 +105,10 @@ describe('Node.js deprecation warning', () => {
   })
 
   it('should not show warning for Node.js 22', () => {
-    global.process = { ...originalProcess, version: 'v22.0.0' } as any
+    Object.defineProperty(global.process, 'version', {
+      value: 'v22.0.0',
+      configurable: true,
+    })
     delete (global as any).window
 
     require('../../src/index')
@@ -97,7 +117,10 @@ describe('Node.js deprecation warning', () => {
   })
 
   it('should handle invalid version format gracefully', () => {
-    global.process = { ...originalProcess, version: 'invalid-version' } as any
+    Object.defineProperty(global.process, 'version', {
+      value: 'invalid-version',
+      configurable: true,
+    })
     delete (global as any).window
 
     require('../../src/index')
@@ -106,7 +129,10 @@ describe('Node.js deprecation warning', () => {
   })
 
   it('should handle version without v prefix', () => {
-    global.process = { ...originalProcess, version: '18.0.0' } as any
+    Object.defineProperty(global.process, 'version', {
+      value: '18.0.0',
+      configurable: true,
+    })
     delete (global as any).window
 
     require('../../src/index')


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix - resolves Next.js Edge Runtime compatibility warnings

## What is the current behavior?

The Node.js deprecation warning introduced in v2.52.1 causes Next.js Edge Runtime build warnings when using `@supabase/supabase-js` in middleware, even though the code is properly guarded and won't execute in Edge Runtime.

The warnings appear as:
```
A Node.js API is used (process.version at line: 17) which is not supported in the Edge Runtime.
Learn more: https://nextjs.org/docs/api-reference/edge-runtime
```

## What is the new behavior?

This PR modifies the deprecation warning check to use dynamic property access (`process['version']`) instead of direct property access (`process.version`). This prevents Next.js static analysis from flagging the code as incompatible with Edge Runtime while maintaining the exact same runtime behavior.

Key changes:
- Use dynamic property access to avoid static analysis warnings
- Improved code comments for clarity
- No functional changes - the deprecation warning still works exactly as intended

## Additional context

- Fixes #1515
- The deprecation warning logic remains unchanged - it only runs in actual Node.js environments
- The code is still properly guarded against Edge Runtime execution
- This is a minimal change that only affects how the property is accessed, not the logic itself

## Testing

- [x] All unit tests pass
- [x] Build completes successfully
- [x] The fix should prevent Next.js Edge Runtime warnings (to be verified in Next.js projects)