### PR TITLE
feat(types): add create client helper type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,23 +21,25 @@ export * from '@supabase/realtime-js'
 export { default as SupabaseClient } from './SupabaseClient'
 export type { SupabaseClientOptions, QueryResult, QueryData, QueryError } from './lib/types'
 
-/**
- * Creates a new Supabase Client.
- */
-export const createClient = <
+export type CreateClientHelper<AdditionalOptions = {}> = <
   Database = any,
   SchemaName extends string & keyof Database = 'public' extends keyof Database
     ? 'public'
     : string & keyof Database,
-  Schema extends GenericSchema = Database[SchemaName] extends GenericSchema
-    ? Database[SchemaName]
-    : any
+  Schema = Database[SchemaName] extends GenericSchema ? Database[SchemaName] : any
 >(
   supabaseUrl: string,
   supabaseKey: string,
-  options?: SupabaseClientOptions<SchemaName>
-): SupabaseClient<Database, SchemaName, Schema> => {
-  return new SupabaseClient<Database, SchemaName, Schema>(supabaseUrl, supabaseKey, options)
+  options?: SupabaseClientOptions<SchemaName> & AdditionalOptions
+) => SupabaseClient<Database, SchemaName, Schema extends GenericSchema ? Schema : any>
+
+export type GenericSupabaseClient = SupabaseClient<any, any, any>
+
+/**
+ * Creates a new Supabase Client.
+ */
+export const createClient: CreateClientHelper = (supabaseUrl, supabaseKey, options) => {
+  return new SupabaseClient(supabaseUrl, supabaseKey, options)
 }
 
 // Check for Node.js <= 18 deprecation

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -123,3 +123,4 @@ export type GenericSchema = {
 export type QueryResult<T> = T extends PromiseLike<infer U> ? U : never
 export type QueryData<T> = T extends PromiseLike<{ data: infer U }> ? Exclude<U, null> : never
 export type QueryError = PostgrestError
+export type ServicesOptions = {}

--- a/test/integration/next/app/layout.tsx
+++ b/test/integration/next/app/layout.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Supabase Integration Test',
+  description: 'Testing Supabase integration with Next.js',
+}
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/integration/next/package.json
+++ b/test/integration/next/package.json
@@ -7,7 +7,8 @@
     "lint": "next lint",
     "test": "playwright test",
     "test:ui": "playwright test --ui",
-    "test:debug": "playwright test --debug"
+    "test:debug": "playwright test --debug",
+    "test:types": "npx tsd --files tests/types/*.test-d.ts"
   },
   "dependencies": {
     "@radix-ui/react-checkbox": "^1.3.1",
@@ -37,6 +38,7 @@
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
     "tailwindcss-animate": "^1.0.7",
+    "tsd": "^0.33.0",
     "typescript": "^5"
   }
 }

--- a/test/integration/next/tests/types/types.test-d.ts
+++ b/test/integration/next/tests/types/types.test-d.ts
@@ -1,0 +1,129 @@
+import { createServerClient, createBrowserClient } from '@supabase/ssr'
+import { expectType } from 'tsd'
+
+// Copied from ts-expect
+// https://github.com/TypeStrong/ts-expect/blob/master/src/index.ts#L23-L27
+export type TypeEqual<Target, Value> = (<T>() => T extends Target ? 1 : 2) extends <
+  T
+>() => T extends Value ? 1 : 2
+  ? true
+  : false
+
+type Database = {
+  public: {
+    Tables: {
+      shops: {
+        Row: {
+          address: string | null
+          id: number
+          shop_geom: unknown | null
+        }
+        Insert: {
+          address?: string | null
+          id: number
+          shop_geom?: unknown | null
+        }
+        Update: {
+          address?: string | null
+          id?: number
+          shop_geom?: unknown | null
+        }
+        Relationships: []
+      }
+    }
+    Views: {
+      [_ in never]: never
+    }
+    Functions: {
+      [_ in never]: never
+    }
+    Enums: {
+      [_ in never]: never
+    }
+    CompositeTypes: {
+      [_ in never]: never
+    }
+  }
+}
+
+{
+  // createBrowserClient should return a typed client
+  const pg12Client = createBrowserClient<Database>('HTTP://localhost:3000', '')
+  const res12 = await pg12Client.from('shops').select('*')
+  expectType<
+    TypeEqual<
+      | {
+          address: string | null
+          id: number
+          shop_geom: unknown | null
+        }[]
+      | null,
+      typeof res12.data
+    >
+  >(true)
+}
+
+{
+  // createBrowserClient should infer everything to any without types provided
+  const pg12Client = createBrowserClient('HTTP://localhost:3000', '')
+  const res12 = await pg12Client.from('shops').select('address, id, relation(field)')
+  expectType<
+    TypeEqual<
+      | {
+          address: any
+          id: any
+          relation: {
+            field: any
+          }[]
+        }[]
+      | null,
+      typeof res12.data
+    >
+  >(true)
+}
+
+{
+  // createServerClient should return a typed client
+  const pg12Server = createServerClient<Database>('HTTP://localhost:3000', '')
+  const res12 = await pg12Server.from('shops').select('*')
+  expectType<
+    TypeEqual<
+      | {
+          address: string | null
+          id: number
+          shop_geom: unknown | null
+        }[]
+      | null,
+      typeof res12.data
+    >
+  >(true)
+}
+
+{
+  // createServerClient should infer everything to any without types provided
+  const pg12Server = createServerClient('HTTP://localhost:3000', '')
+  const res12 = await pg12Server.from('shops').select('address, id, relation(field)')
+  expectType<
+    TypeEqual<
+      | {
+          address: any
+          id: any
+          relation: {
+            field: any
+          }[]
+        }[]
+      | null,
+      typeof res12.data
+    >
+  >(true)
+}
+
+//  should default to postgrest 12 for untyped client
+{
+  const pg12ServerClient = createServerClient('HTTP://localhost:3000', '')
+  const res12Server = await pg12ServerClient.from('shops').update({ id: 21 }).maxAffected(1)
+  const pg12BrowserClient = createBrowserClient('HTTP://localhost:3000', '')
+  const res12Browser = await pg12BrowserClient.from('shops').update({ id: 21 }).maxAffected(1)
+  expectType<typeof res12Server.Error>('maxAffected method only available on postgrest 13+')
+  expectType<typeof res12Browser.Error>('maxAffected method only available on postgrest 13+')
+}

--- a/test/integration/next/tests/types/types.test-d.ts
+++ b/test/integration/next/tests/types/types.test-d.ts
@@ -117,13 +117,3 @@ type Database = {
     >
   >(true)
 }
-
-//  should default to postgrest 12 for untyped client
-{
-  const pg12ServerClient = createServerClient('HTTP://localhost:3000', '')
-  const res12Server = await pg12ServerClient.from('shops').update({ id: 21 }).maxAffected(1)
-  const pg12BrowserClient = createBrowserClient('HTTP://localhost:3000', '')
-  const res12Browser = await pg12BrowserClient.from('shops').update({ id: 21 }).maxAffected(1)
-  expectType<typeof res12Server.Error>('maxAffected method only available on postgrest 13+')
-  expectType<typeof res12Browser.Error>('maxAffected method only available on postgrest 13+')
-}

--- a/test/integration/next/tsconfig.json
+++ b/test/integration/next/tsconfig.json
@@ -24,5 +24,5 @@
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "test/types/*.test-d.ts"]
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

- In an attempt to clear: https://github.com/supabase/supabase-js/pull/1491 breaking down `postgrest-js` upgrade and extracting the `createClient` into an helper type to be used in: https://github.com/supabase/ssr/pull/119

- Once this get released we can change the PR on `ssr` to specify that it require the latest `supabase-js` version (the one with the helper).

When both get released, we should be able to upgrade `postgrest-js` to latest version without any changes to the `ssr` repo typing wise.