### PR TITLE
fix: make Authorization header check case-insensitive

### DIFF
--- a/src/SupabaseClient.ts
+++ b/src/SupabaseClient.ts
@@ -315,7 +315,9 @@ export default class SupabaseClient<
       fetch,
       // auth checks if there is a custom authorizaiton header using this flag
       // so it knows whether to return an error when getUser is called with no session
-      hasCustomAuthorizationHeader: 'Authorization' in this.headers,
+      hasCustomAuthorizationHeader: Object.keys(this.headers).some(
+        (key) => key.toLowerCase() === 'authorization'
+      ),
     })
   }
 


### PR DESCRIPTION
## Summary
Fixes #1043

This PR makes the Authorization header detection case-insensitive, which is the correct behavior according to HTTP RFC standards. Previously, the code only checked for the exact string 'Authorization' in headers, but HTTP headers should be case-insensitive.

## Changes Made
- Replace case-sensitive `'Authorization' in this.headers` check with case-insensitive `Object.keys(this.headers).some(key => key.toLowerCase() === 'authorization')`
- This allows headers like 'authorization', 'Authorization', 'AUTHORIZATION' to all work correctly

## Testing
- [x] All existing unit tests pass
- [x] Build completes successfully
- [x] Manual testing with various header case combinations (lowercase, uppercase, mixed case)
- [x] Verified that no authorization header case still works correctly

## Root Cause
The issue was introduced in the hasCustomAuthorizationHeader check which was meant to detect custom auth headers but was using case-sensitive string matching instead of proper case-insensitive header handling.

## Additional Notes
This is a small but important fix that improves compatibility with various HTTP client implementations that may use different casing for the Authorization header.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>