### PR TITLE
feat: reland postgrest 13 support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@supabase/auth-js": "2.71.1",
         "@supabase/functions-js": "2.4.5",
         "@supabase/node-fetch": "2.6.15",
-        "@supabase/postgrest-js": "https://pkg.pr.new/supabase/postgrest-js/@supabase/postgrest-js@78e9fcc",
+        "@supabase/postgrest-js": "1.21.3",
         "@supabase/realtime-js": "2.15.1",
         "@supabase/storage-js": "^2.10.4"
       },
@@ -1117,9 +1117,9 @@
       }
     },
     "node_modules/@supabase/postgrest-js": {
-      "version": "0.0.0-automated",
-      "resolved": "https://pkg.pr.new/supabase/postgrest-js/@supabase/postgrest-js@78e9fcc",
-      "integrity": "sha512-uZ7sMcECsmLK/+om0s8PXl0NfTYulYG/ga8PYIDz/vssawd3bSPK88uR2fUEpz+qp3a6iN1fC94r4gHOahn5Zw==",
+      "version": "1.21.3",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.21.3.tgz",
+      "integrity": "sha512-rg3DmmZQKEVCreXq6Am29hMVe1CzemXyIWVYyyua69y6XubfP+DzGfLxME/1uvdgwqdoaPbtjBDpEBhqxq1ZwA==",
       "license": "MIT",
       "dependencies": {
         "@supabase/node-fetch": "^2.6.14"

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@supabase/auth-js": "2.71.1",
         "@supabase/functions-js": "2.4.5",
         "@supabase/node-fetch": "2.6.15",
-        "@supabase/postgrest-js": "1.19.4",
+        "@supabase/postgrest-js": "file:../postgrest-js",
         "@supabase/realtime-js": "2.15.1",
         "@supabase/storage-js": "^2.10.4"
       },
@@ -38,6 +38,33 @@
         "typescript": "^4.5.5",
         "webpack": "^5.69.1",
         "webpack-cli": "^4.9.2"
+      }
+    },
+    "../postgrest-js": {
+      "name": "@supabase/postgrest-js",
+      "version": "0.0.0-automated",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      },
+      "devDependencies": {
+        "@types/jest": "^27.5.1",
+        "chokidar-cli": "^3.0.0",
+        "cpy-cli": "^5.0.0",
+        "jest": "^28.1.0",
+        "node-abort-controller": "^3.0.1",
+        "npm-run-all": "^4.1.5",
+        "prettier": "^2.6.2",
+        "rimraf": "^3.0.2",
+        "semantic-release-plugin-update-version-in-files": "^1.1.0",
+        "ts-expect": "^1.3.0",
+        "ts-jest": "^28.0.3",
+        "tsd": "^0.31.2",
+        "type-fest": "^4.32.0",
+        "typedoc": "^0.22.16",
+        "typescript": "^4.5.5",
+        "wait-for-localhost-cli": "^3.0.0",
+        "zod": "^3.25.76"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1117,13 +1144,8 @@
       }
     },
     "node_modules/@supabase/postgrest-js": {
-      "version": "1.19.4",
-      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.19.4.tgz",
-      "integrity": "sha512-O4soKqKtZIW3olqmbXXbKugUtByD2jPa8kL2m2c1oozAO11uCcGrRhkZL0kVxjBLrXHE0mdSkFsMj7jDSfyNpw==",
-      "license": "MIT",
-      "dependencies": {
-        "@supabase/node-fetch": "^2.6.14"
-      }
+      "resolved": "../postgrest-js",
+      "link": true
     },
     "node_modules/@supabase/realtime-js": {
       "version": "2.15.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@supabase/auth-js": "2.71.1",
         "@supabase/functions-js": "2.4.5",
         "@supabase/node-fetch": "2.6.15",
-        "@supabase/postgrest-js": "file:../postgrest-js",
+        "@supabase/postgrest-js": "https://pkg.pr.new/supabase/postgrest-js/@supabase/postgrest-js@78e9fcc",
         "@supabase/realtime-js": "2.15.1",
         "@supabase/storage-js": "^2.10.4"
       },
@@ -38,33 +38,6 @@
         "typescript": "^4.5.5",
         "webpack": "^5.69.1",
         "webpack-cli": "^4.9.2"
-      }
-    },
-    "../postgrest-js": {
-      "name": "@supabase/postgrest-js",
-      "version": "0.0.0-automated",
-      "license": "MIT",
-      "dependencies": {
-        "@supabase/node-fetch": "^2.6.14"
-      },
-      "devDependencies": {
-        "@types/jest": "^27.5.1",
-        "chokidar-cli": "^3.0.0",
-        "cpy-cli": "^5.0.0",
-        "jest": "^28.1.0",
-        "node-abort-controller": "^3.0.1",
-        "npm-run-all": "^4.1.5",
-        "prettier": "^2.6.2",
-        "rimraf": "^3.0.2",
-        "semantic-release-plugin-update-version-in-files": "^1.1.0",
-        "ts-expect": "^1.3.0",
-        "ts-jest": "^28.0.3",
-        "tsd": "^0.31.2",
-        "type-fest": "^4.32.0",
-        "typedoc": "^0.22.16",
-        "typescript": "^4.5.5",
-        "wait-for-localhost-cli": "^3.0.0",
-        "zod": "^3.25.76"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1144,8 +1117,13 @@
       }
     },
     "node_modules/@supabase/postgrest-js": {
-      "resolved": "../postgrest-js",
-      "link": true
+      "version": "0.0.0-automated",
+      "resolved": "https://pkg.pr.new/supabase/postgrest-js/@supabase/postgrest-js@78e9fcc",
+      "integrity": "sha512-uZ7sMcECsmLK/+om0s8PXl0NfTYulYG/ga8PYIDz/vssawd3bSPK88uR2fUEpz+qp3a6iN1fC94r4gHOahn5Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
     },
     "node_modules/@supabase/realtime-js": {
       "version": "2.15.1",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@supabase/auth-js": "2.71.1",
     "@supabase/functions-js": "2.4.5",
     "@supabase/node-fetch": "2.6.15",
-    "@supabase/postgrest-js": "1.19.4",
+    "@supabase/postgrest-js": "file:../postgrest-js",
     "@supabase/realtime-js": "2.15.1",
     "@supabase/storage-js": "^2.10.4"
   },

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@supabase/auth-js": "2.71.1",
     "@supabase/functions-js": "2.4.5",
     "@supabase/node-fetch": "2.6.15",
-    "@supabase/postgrest-js": "https://pkg.pr.new/supabase/postgrest-js/@supabase/postgrest-js@78e9fcc",
+    "@supabase/postgrest-js": "1.21.3",
     "@supabase/realtime-js": "2.15.1",
     "@supabase/storage-js": "^2.10.4"
   },

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@supabase/auth-js": "2.71.1",
     "@supabase/functions-js": "2.4.5",
     "@supabase/node-fetch": "2.6.15",
-    "@supabase/postgrest-js": "file:../postgrest-js",
+    "@supabase/postgrest-js": "https://pkg.pr.new/supabase/postgrest-js/@supabase/postgrest-js@78e9fcc",
     "@supabase/realtime-js": "2.15.1",
     "@supabase/storage-js": "^2.10.4"
   },

--- a/src/SupabaseClient.ts
+++ b/src/SupabaseClient.ts
@@ -52,7 +52,11 @@ export default class SupabaseClient<
     : never,
   ClientOptions extends { PostgrestVersion: string } = SchemaNameOrClientOptions extends string &
     keyof Omit<Database, '__InternalSupabase'>
-    ? { PostgrestVersion: '12' }
+    ? // If the version isn't explicitly set, look for it in the __InternalSupabase object to infer the right version
+      Database extends { __InternalSupabase: { PostgrestVersion: string } }
+      ? Database['__InternalSupabase']
+      : // otherwise default to 12
+        { PostgrestVersion: '12' }
     : SchemaNameOrClientOptions extends { PostgrestVersion: string }
     ? SchemaNameOrClientOptions
     : never

--- a/src/SupabaseClient.ts
+++ b/src/SupabaseClient.ts
@@ -34,10 +34,10 @@ export default class SupabaseClient<
   // support both cases.
   // TODO: Allow setting db_schema from ClientOptions.
   SchemaNameOrClientOptions extends
-    | (string & keyof Database)
-    | { PostgrestVersion: string } = 'public' extends keyof Database
+    | (string & keyof Omit<Database, '__InternalSupabase'>)
+    | { PostgrestVersion: string } = 'public' extends keyof Omit<Database, '__InternalSupabase'>
     ? 'public'
-    : string & keyof Database,
+    : string & keyof Omit<Database, '__InternalSupabase'>,
   SchemaName extends string &
     keyof Omit<Database, '__InternalSupabase'> = SchemaNameOrClientOptions extends string &
     keyof Omit<Database, '__InternalSupabase'>

--- a/src/SupabaseClient.ts
+++ b/src/SupabaseClient.ts
@@ -30,12 +30,32 @@ import { Fetch, GenericSchema, SupabaseClientOptions, SupabaseAuthClientOptions 
  */
 export default class SupabaseClient<
   Database = any,
-  SchemaName extends string & keyof Database = 'public' extends keyof Database
+  // The second type parameter is also used for specifying db_schema, so we
+  // support both cases.
+  // TODO: Allow setting db_schema from ClientOptions.
+  SchemaNameOrClientOptions extends
+    | (string & keyof Database)
+    | { PostgrestVersion: string } = 'public' extends keyof Database
     ? 'public'
     : string & keyof Database,
-  Schema extends GenericSchema = Database[SchemaName] extends GenericSchema
-    ? Database[SchemaName]
-    : any
+  SchemaName extends string &
+    keyof Omit<Database, '__InternalSupabase'> = SchemaNameOrClientOptions extends string &
+    keyof Omit<Database, '__InternalSupabase'>
+    ? SchemaNameOrClientOptions
+    : 'public' extends keyof Omit<Database, '__InternalSupabase'>
+    ? 'public'
+    : string & keyof Omit<Omit<Database, '__InternalSupabase'>, '__InternalSupabase'>,
+  Schema extends Omit<Database, '__InternalSupabase'>[SchemaName] extends GenericSchema
+    ? Omit<Database, '__InternalSupabase'>[SchemaName]
+    : never = Omit<Database, '__InternalSupabase'>[SchemaName] extends GenericSchema
+    ? Omit<Database, '__InternalSupabase'>[SchemaName]
+    : never,
+  ClientOptions extends { PostgrestVersion: string } = SchemaNameOrClientOptions extends string &
+    keyof Omit<Database, '__InternalSupabase'>
+    ? { PostgrestVersion: '12' }
+    : SchemaNameOrClientOptions extends { PostgrestVersion: string }
+    ? SchemaNameOrClientOptions
+    : never
 > {
   /**
    * Supabase Auth allows you to create and manage user sessions for access to data that is secured by access policies.
@@ -51,7 +71,7 @@ export default class SupabaseClient<
   protected authUrl: URL
   protected storageUrl: URL
   protected functionsUrl: URL
-  protected rest: PostgrestClient<Database, SchemaName, Schema>
+  protected rest: PostgrestClient<Database, ClientOptions, SchemaName>
   protected storageKey: string
   protected fetch?: Fetch
   protected changedAccessToken?: string
@@ -161,16 +181,16 @@ export default class SupabaseClient<
   from<
     TableName extends string & keyof Schema['Tables'],
     Table extends Schema['Tables'][TableName]
-  >(relation: TableName): PostgrestQueryBuilder<Schema, Table, TableName>
+  >(relation: TableName): PostgrestQueryBuilder<ClientOptions, Schema, Table, TableName>
   from<ViewName extends string & keyof Schema['Views'], View extends Schema['Views'][ViewName]>(
     relation: ViewName
-  ): PostgrestQueryBuilder<Schema, View, ViewName>
+  ): PostgrestQueryBuilder<ClientOptions, Schema, View, ViewName>
   /**
    * Perform a query on a table or a view.
    *
    * @param relation - The table or view name to query
    */
-  from(relation: string): PostgrestQueryBuilder<Schema, any, any> {
+  from(relation: string): PostgrestQueryBuilder<ClientOptions, Schema, any> {
     return this.rest.from(relation)
   }
 
@@ -182,10 +202,11 @@ export default class SupabaseClient<
    *
    * @param schema - The schema to query
    */
-  schema<DynamicSchema extends string & keyof Database>(
+  schema<DynamicSchema extends string & keyof Omit<Database, '__InternalSupabase'>>(
     schema: DynamicSchema
   ): PostgrestClient<
     Database,
+    ClientOptions,
     DynamicSchema,
     Database[DynamicSchema] extends GenericSchema ? Database[DynamicSchema] : any
   > {
@@ -225,6 +246,7 @@ export default class SupabaseClient<
       count?: 'exact' | 'planned' | 'estimated'
     } = {}
   ): PostgrestFilterBuilder<
+    ClientOptions,
     Schema,
     Fn['Returns'] extends any[]
       ? Fn['Returns'][number] extends Record<string, unknown>
@@ -233,7 +255,8 @@ export default class SupabaseClient<
       : never,
     Fn['Returns'],
     FnName,
-    null
+    null,
+    'RPC'
   > {
     return this.rest.rpc(fn, args, options)
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,10 +27,10 @@ export type { SupabaseClientOptions, QueryResult, QueryData, QueryError } from '
 export const createClient = <
   Database = any,
   SchemaNameOrClientOptions extends
-    | (string & keyof Database)
-    | { PostgrestVersion: string } = 'public' extends keyof Database
+    | (string & keyof Omit<Database, '__InternalSupabase'>)
+    | { PostgrestVersion: string } = 'public' extends keyof Omit<Database, '__InternalSupabase'>
     ? 'public'
-    : string & keyof Database,
+    : string & keyof Omit<Database, '__InternalSupabase'>,
   SchemaName extends string &
     keyof Omit<Database, '__InternalSupabase'> = SchemaNameOrClientOptions extends string &
     keyof Omit<Database, '__InternalSupabase'>

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import SupabaseClient from './SupabaseClient'
-import type { GenericSchema, SupabaseClientOptions } from './lib/types'
+import type { SupabaseClientOptions } from './lib/types'
 
 export * from '@supabase/auth-js'
 export type { User as AuthUser, Session as AuthSession } from '@supabase/auth-js'
@@ -26,18 +26,28 @@ export type { SupabaseClientOptions, QueryResult, QueryData, QueryError } from '
  */
 export const createClient = <
   Database = any,
-  SchemaName extends string & keyof Database = 'public' extends keyof Database
+  SchemaNameOrClientOptions extends
+    | (string & keyof Database)
+    | { PostgrestVersion: string } = 'public' extends keyof Database
     ? 'public'
     : string & keyof Database,
-  Schema extends GenericSchema = Database[SchemaName] extends GenericSchema
-    ? Database[SchemaName]
-    : any
+  SchemaName extends string &
+    keyof Omit<Database, '__InternalSupabase'> = SchemaNameOrClientOptions extends string &
+    keyof Omit<Database, '__InternalSupabase'>
+    ? SchemaNameOrClientOptions
+    : 'public' extends keyof Omit<Database, '__InternalSupabase'>
+    ? 'public'
+    : string & keyof Omit<Omit<Database, '__InternalSupabase'>, '__InternalSupabase'>
 >(
   supabaseUrl: string,
   supabaseKey: string,
   options?: SupabaseClientOptions<SchemaName>
-): SupabaseClient<Database, SchemaName, Schema> => {
-  return new SupabaseClient<Database, SchemaName, Schema>(supabaseUrl, supabaseKey, options)
+): SupabaseClient<Database, SchemaNameOrClientOptions, SchemaName> => {
+  return new SupabaseClient<Database, SchemaNameOrClientOptions, SchemaName>(
+    supabaseUrl,
+    supabaseKey,
+    options
+  )
 }
 
 // Check for Node.js <= 18 deprecation

--- a/test/integration/next/app/layout.tsx
+++ b/test/integration/next/app/layout.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Supabase Integration Test',
+  description: 'Testing Supabase integration with Next.js',
+}
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/integration/next/package.json
+++ b/test/integration/next/package.json
@@ -7,7 +7,8 @@
     "lint": "next lint",
     "test": "playwright test",
     "test:ui": "playwright test --ui",
-    "test:debug": "playwright test --debug"
+    "test:debug": "playwright test --debug",
+    "test:types": "npx tsd --files tests/types/*.test-d.ts"
   },
   "dependencies": {
     "@radix-ui/react-checkbox": "^1.3.1",
@@ -37,6 +38,7 @@
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
     "tailwindcss-animate": "^1.0.7",
+    "tsd": "^0.33.0",
     "typescript": "^5"
   }
 }

--- a/test/integration/next/tests/types/types.test-d.ts
+++ b/test/integration/next/tests/types/types.test-d.ts
@@ -1,0 +1,180 @@
+import { createServerClient, createBrowserClient } from '@supabase/ssr'
+import { expectType } from 'tsd'
+
+// Copied from ts-expect
+// https://github.com/TypeStrong/ts-expect/blob/master/src/index.ts#L23-L27
+export type TypeEqual<Target, Value> = (<T>() => T extends Target ? 1 : 2) extends <
+  T
+>() => T extends Value ? 1 : 2
+  ? true
+  : false
+
+type Database = {
+  public: {
+    Tables: {
+      shops: {
+        Row: {
+          address: string | null
+          id: number
+          shop_geom: unknown | null
+        }
+        Insert: {
+          address?: string | null
+          id: number
+          shop_geom?: unknown | null
+        }
+        Update: {
+          address?: string | null
+          id?: number
+          shop_geom?: unknown | null
+        }
+        Relationships: []
+      }
+    }
+    Views: {
+      [_ in never]: never
+    }
+    Functions: {
+      [_ in never]: never
+    }
+    Enums: {
+      [_ in never]: never
+    }
+    CompositeTypes: {
+      [_ in never]: never
+    }
+  }
+}
+
+{
+  // createBrowserClient should return a typed client
+  const pg12Client = createBrowserClient<Database>('HTTP://localhost:3000', '')
+  const res12 = await pg12Client.from('shops').select('*')
+  expectType<
+    TypeEqual<
+      | {
+          address: string | null
+          id: number
+          shop_geom: unknown | null
+        }[]
+      | null,
+      typeof res12.data
+    >
+  >(true)
+}
+
+{
+  // createBrowserClient should infer everything to any without types provided
+  const pg12Client = createBrowserClient('HTTP://localhost:3000', '')
+  const res12 = await pg12Client.from('shops').select('address, id, relation(field)')
+  expectType<
+    TypeEqual<
+      | {
+          address: any
+          id: any
+          relation: {
+            field: any
+          }[]
+        }[]
+      | null,
+      typeof res12.data
+    >
+  >(true)
+}
+
+{
+  // createServerClient should return a typed client
+  const pg12Server = createServerClient<Database>('HTTP://localhost:3000', '')
+  const res12 = await pg12Server.from('shops').select('*')
+  expectType<
+    TypeEqual<
+      | {
+          address: string | null
+          id: number
+          shop_geom: unknown | null
+        }[]
+      | null,
+      typeof res12.data
+    >
+  >(true)
+}
+
+{
+  // createServerClient should infer everything to any without types provided
+  const pg12Server = createServerClient('HTTP://localhost:3000', '')
+  const res12 = await pg12Server.from('shops').select('address, id, relation(field)')
+  expectType<
+    TypeEqual<
+      | {
+          address: any
+          id: any
+          relation: {
+            field: any
+          }[]
+        }[]
+      | null,
+      typeof res12.data
+    >
+  >(true)
+}
+// Should be able to get a PostgrestVersion 13 client from __InternalSupabase
+{
+  type DatabaseWithInternals = {
+    __InternalSupabase: {
+      PostgrestVersion: '13'
+    }
+    public: {
+      Tables: {
+        shops: {
+          Row: {
+            address: string | null
+            id: number
+            shop_geom: unknown | null
+          }
+          Insert: {
+            address?: string | null
+            id: number
+            shop_geom?: unknown | null
+          }
+          Update: {
+            address?: string | null
+            id?: number
+            shop_geom?: unknown | null
+          }
+          Relationships: []
+        }
+      }
+      Views: {
+        [_ in never]: never
+      }
+      Functions: {
+        [_ in never]: never
+      }
+      Enums: {
+        [_ in never]: never
+      }
+      CompositeTypes: {
+        [_ in never]: never
+      }
+    }
+  }
+  const pg13BrowserClient = createBrowserClient<DatabaseWithInternals>('HTTP://localhost:3000', '')
+  const pg13ServerClient = createServerClient<DatabaseWithInternals>('HTTP://localhost:3000', '', {
+    cookies: { getAll: () => [], setAll: () => {} },
+  })
+  const res13 = await pg13BrowserClient.from('shops').update({ id: 21 }).maxAffected(1)
+  expectType<typeof res13.data>(null)
+  const res13Server = await pg13ServerClient.from('shops').update({ id: 21 }).maxAffected(1)
+  expectType<typeof res13Server.data>(null)
+}
+{
+  // Should default to PostgrestVersion 12
+  const pg12BrowserClient = createBrowserClient<Database>('HTTP://localhost:3000', '')
+  const pg12ServerClient = createServerClient<Database>('HTTP://localhost:3000', '', {
+    cookies: { getAll: () => [], setAll: () => {} },
+  })
+  const res12 = await pg12BrowserClient.from('shops').update({ id: 21 }).maxAffected(1)
+  expectType<typeof res12.Error>('maxAffected method only available on postgrest 13+')
+  const res12Server = await pg12ServerClient.from('shops').update({ id: 21 }).maxAffected(1)
+  expectType<typeof res12Server.Error>('maxAffected method only available on postgrest 13+')
+}

--- a/test/integration/next/tsconfig.json
+++ b/test/integration/next/tsconfig.json
@@ -24,5 +24,5 @@
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "test/types/*.test-d.ts"]
 }

--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -195,8 +195,19 @@ const supabase = createClient<Database>(URL, KEY)
   const pg12Client = createClient<Database>('HTTP://localhost:3000', KEY)
   const res13 = await pg13Client.from('shops').update({ id: 21 }).maxAffected(1)
   const res12 = await pg12Client.from('shops').update({ id: 21 }).maxAffected(1)
+  const pg13ClientNew = new SupabaseClient<DatabaseWithInternals>('HTTP://localhost:3000', KEY)
+  const res13New = await pg13ClientNew.from('shops').update({ id: 21 }).maxAffected(1)
   expectType<typeof res13.data>(null)
+  expectType<typeof res13New.data>(null)
   expectType<typeof res12.Error>('maxAffected method only available on postgrest 13+')
+  // Explicitly set PostgrestVersion should override the inferred __InternalSupabase schema version
+  const internal13Set12 = new SupabaseClient<DatabaseWithInternals, { PostgrestVersion: '12' }>(
+    URL,
+    KEY
+  )
+  const resinternal13Set12 = await internal13Set12.from('shops').update({ id: 21 }).maxAffected(1)
+  // The explicitly set PostgrestVersion should override the inferred __InternalSupabase schema version
+  expectType<typeof resinternal13Set12.Error>('maxAffected method only available on postgrest 13+')
 }
 
 // createClient with custom schema

--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -1,10 +1,16 @@
 import { expectError, expectType } from 'tsd'
-import { PostgrestSingleResponse, createClient } from '../../src/index'
+import { PostgrestSingleResponse, createClient, SupabaseClient } from '../../src/index'
 import { Database, Json } from '../types'
 
 const URL = 'http://localhost:3000'
 const KEY = 'some.fake.key'
 const supabase = createClient<Database>(URL, KEY)
+
+// createClient with custom schema
+{
+  createClient<Database, 'personal'>(URL, KEY, { db: { schema: 'personal' } })
+  new SupabaseClient<Database, 'personal'>(URL, KEY, { db: { schema: 'personal' } })
+}
 
 // table invalid type
 {

--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -188,6 +188,10 @@ const supabase = createClient<Database>(URL, KEY)
   // Note: The template argument properties (PostgrestVersion) will not be autocompleted
   // due to a Typescript bug tracked here: https://github.com/microsoft/TypeScript/issues/56299
   const pg13Client = createClient<DatabaseWithInternals>('HTTP://localhost:3000', KEY)
+  // @ts-expect-error should raise error if providing __InternalSupabase as schema name
+  createClient<DatabaseWithInternals, '__InternalSupabase'>('HTTP://localhost:3000', KEY)
+  // @ts-expect-error should raise error if providing __InternalSupabase as schema name
+  new SupabaseClient<DatabaseWithInternals, '__InternalSupabase'>('HTTP://localhost:3000', KEY)
   const pg12Client = createClient<Database>('HTTP://localhost:3000', KEY)
   const res13 = await pg13Client.from('shops').update({ id: 21 }).maxAffected(1)
   const res12 = await pg12Client.from('shops').update({ id: 21 }).maxAffected(1)

--- a/test/unit/SupabaseClient.test.ts
+++ b/test/unit/SupabaseClient.test.ts
@@ -74,18 +74,20 @@ describe('SupabaseClient', () => {
     test('should have custom header set', () => {
       const customHeader = { 'X-Test-Header': 'value' }
       const request = createClient(URL, KEY, { global: { headers: customHeader } }).rpc('')
-      // @ts-ignore
-      const getHeaders = request.headers
-      expect(getHeaders).toHaveProperty('X-Test-Header', 'value')
+      //@ts-expect-error headers is protected attribute
+      const requestHeader = request.headers.get('X-Test-Header')
+      expect(requestHeader).toBe(customHeader['X-Test-Header'])
     })
 
     test('should merge custom headers with default headers', () => {
       const customHeader = { 'X-Test-Header': 'value' }
-      const client = createClient(URL, KEY, { global: { headers: customHeader } })
-      // @ts-ignore
-      expect(client.headers).toHaveProperty('X-Test-Header', 'value')
-      // @ts-ignore
-      expect(client.headers).toHaveProperty('X-Client-Info')
+      const request = createClient(URL, KEY, { global: { headers: customHeader } }).rpc('')
+
+      //@ts-expect-error headers is protected attribute
+      const requestHeader = request.headers.get('X-Test-Header')
+      expect(requestHeader).toBe(customHeader['X-Test-Header'])
+      //@ts-expect-error headers is protected attribute
+      expect(request.headers.get('X-Client-Info')).not.toBeNull()
     })
   })
 


### PR DESCRIPTION
pending on https://github.com/supabase/postgrest-js/pull/637

Additionally reimplement support for accepting a schema name in the second type param (e.g. `SupabaseClient<Database, 'my_schema'>`. We have a lot of users doing this: https://github.com/search?q=createClient%3CDatabase%2C+%22&type=code