### PR TITLE
fix: restore webpack plugin

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -26,5 +26,9 @@ module.exports = (env) => ({
   resolve: {
     extensions: ['.ts', '.js', '.json'],
   },
-  plugins: [],
+  plugins: [
+    new webpack.DefinePlugin({
+      process: 'process/browser',
+    }),
+  ],
 })


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix - restores process polyfill for webpack UMD build to fix Realtime presence functionality when using CDN-hosted versions.

## What is the current behavior?

Realtime presence functionality is broken in supabase-js versions 2.54.0+ when loaded from CDNs like `jsDelivr`.

**Issue:** #1536 - Presence not working as of supabase-js 2.54

The issue occurs because:
1. In PR #1521, we removed the webpack `process` polyfill as part of modernization efforts
2. CDNs detect `process` references in our code (from environment checks in `realtime-js`)
3. CDNs automatically add minimal process polyfills to prevent runtime errors
4. These CDN-injected polyfills provide mock process objects with empty/undefined values
5. `realtime-js` gets confused by these mock process objects and fails to properly initialize WebSocket connections for presence functionality

## What is the new behavior?

This PR restores the webpack DefinePlugin configuration that explicitly polyfills `process` with the `process/browser` package in our UMD builds.

```json
plugins: [
  new webpack.DefinePlugin({
    process: 'process/browser',
  }),
],
```

This ensures:
- We control what `process` is in browser environments
- CDNs won't inject their own problematic polyfills since `process` is already defined
- Realtime presence functionality works correctly again from CDN-hosted builds
- The behavior is consistent with versions prior to 2.54.0

## Additional context

While removing the process polyfill was the right modernization step in principle, the JavaScript ecosystem reality is that:
- CDNs transform code in not always consistent ways
- Many CDNs auto-inject polyfills when they detect Node.js global references
- These auto-injected polyfills can be incomplete or problematic

By explicitly defining `process` ourselves, we prevent CDNs from adding their own versions and ensure consistent behavior across all distribution methods.

### Why not fix the environment detection in `realtime-js` instead?

While we could improve the environment detection in `realtime-js` to better handle CDN-injected polyfills, this would only address one symptom of a larger issue. CDNs like jsDelivr automatically inject process polyfills whenever they detect process references in code - not just in realtime-js, but also in supabase-js's deprecation warnings and potentially in other dependencies. Providing a centralized controlled `process` polyfill ensures consistent behavior across all code paths and prevents CDNs from injecting their unpredictable mock implementations.

Fixes #1536