### PR TITLE
fix: bump realtime-js to 2.15.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@supabase/functions-js": "2.4.5",
         "@supabase/node-fetch": "2.6.15",
         "@supabase/postgrest-js": "1.21.3",
-        "@supabase/realtime-js": "2.15.4",
+        "@supabase/realtime-js": "2.15.5",
         "@supabase/storage-js": "^2.10.4"
       },
       "devDependencies": {
@@ -1126,9 +1126,9 @@
       }
     },
     "node_modules/@supabase/realtime-js": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.15.4.tgz",
-      "integrity": "sha512-e/FYIWjvQJHOCNACWehnKvg26zosju3694k0NMUNb+JGLdvHJzEa29ZVVLmawd2kvx4hdbv8mxSqfttRnH3+DA==",
+      "version": "2.15.5",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.15.5.tgz",
+      "integrity": "sha512-/Rs5Vqu9jejRD8ZeuaWXebdkH+J7V6VySbCZ/zQM93Ta5y3mAmocjioa/nzlB6qvFmyylUgKVS1KpE212t30OA==",
       "license": "MIT",
       "dependencies": {
         "@supabase/node-fetch": "^2.6.13",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@supabase/functions-js": "2.4.5",
     "@supabase/node-fetch": "2.6.15",
     "@supabase/postgrest-js": "1.21.3",
-    "@supabase/realtime-js": "2.15.4",
+    "@supabase/realtime-js": "2.15.5",
     "@supabase/storage-js": "^2.10.4"
   },
   "devDependencies": {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bump `realtime-js` to `2.15.5` to get the changes introduced in [this PR](https://github.com/supabase/realtime-js/pull/533).

## Additional context

- https://github.com/supabase/supabase-js/pull/1520
- https://github.com/supabase/supabase-js/issues/1515
- https://github.com/supabase/realtime-js/issues/523
