### PR TITLE
fix: bump functions-js to 2.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@supabase/auth-js": "2.71.1",
-        "@supabase/functions-js": "2.4.6",
+        "@supabase/functions-js": "2.5.0",
         "@supabase/node-fetch": "2.6.15",
         "@supabase/postgrest-js": "1.21.4",
         "@supabase/realtime-js": "2.15.5",
@@ -1098,10 +1098,9 @@
       }
     },
     "node_modules/@supabase/functions-js": {
-      "version": "2.4.6",
-      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.4.6.tgz",
-      "integrity": "sha512-bhjZ7rmxAibjgmzTmQBxJU6ZIBCCJTc3Uwgvdi4FewueUTAGO5hxZT1Sj6tiD+0dSXf9XI87BDdJrg12z8Uaew==",
-      "license": "MIT",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.5.0.tgz",
+      "integrity": "sha512-SXBx6Jvp+MOBekeKFu+G11YLYPeVeGQl23eYyAG9+Ro0pQ1aIP0UZNIBxHKNHqxzR0L0n6gysNr2KT3841NATw==",
       "dependencies": {
         "@supabase/node-fetch": "^2.6.14"
       }

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   },
   "dependencies": {
     "@supabase/auth-js": "2.71.1",
-    "@supabase/functions-js": "2.4.6",
+    "@supabase/functions-js": "2.5.0",
     "@supabase/node-fetch": "2.6.15",
     "@supabase/postgrest-js": "1.21.4",
     "@supabase/realtime-js": "2.15.5",


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bump functions-js to latest release 2.5.0