### PR TITLE
chore: do not fail on coveralls error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,10 +90,12 @@ jobs:
       - name: Upload coverage results to Coveralls
         uses: coverallsapp/github-action@v2
         with:
+          fail-on-error: false
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: ./test/coverage/lcov.info
           parallel: true
           flag-name: node-${{ matrix.node }}-${{ matrix.os }}
+        continue-on-error: true
 
   coveralls-finish:
     name: Coveralls Finished
@@ -103,8 +105,10 @@ jobs:
       - name: Coveralls Finished
         uses: coverallsapp/github-action@v2
         with:
+          fail-on-error: false
           github-token: ${{ secrets.GITHUB_TOKEN }}
           parallel-finished: true
+        continue-on-error: true
 
   deno-tests:
     name: Deno Tests / ${{ matrix.deno }}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Add a `fail-on-error: false` to `coveralls` uploads. 

## What is the current behavior?

Coveralls seems to be failing, and being flaky. 

## What is the new behavior?

If `coveralls` upload fails, the CI will not fail.