### PR TITLE
fix: update import of storageClientOptions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@supabase/node-fetch": "2.6.15",
         "@supabase/postgrest-js": "1.21.4",
         "@supabase/realtime-js": "2.15.5",
-        "@supabase/storage-js": "https://pkg.pr.new/@supabase/storage-js@255"
+        "@supabase/storage-js": "2.12.1"
       },
       "devDependencies": {
         "@sebbo2002/semantic-release-jsr": "^1.0.0",
@@ -1123,9 +1123,9 @@
       }
     },
     "node_modules/@supabase/storage-js": {
-      "version": "0.0.0",
-      "resolved": "https://pkg.pr.new/@supabase/storage-js@255",
-      "integrity": "sha512-aq2zHxVzSHjVfxjcrcPFWPBlQVsyQRL3QTV1bB8ElVNklPPxmRWYCF0fGIOPAXig0ePpf9D9x4zIfogEIV/AKg==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.12.1.tgz",
+      "integrity": "sha512-QWg3HV6Db2J81VQx0PqLq0JDBn4Q8B1FYn1kYcbla8+d5WDmTdwwMr+EJAxNOSs9W4mhKMv+EYCpCrTFlTj4VQ==",
       "license": "MIT",
       "dependencies": {
         "@supabase/node-fetch": "^2.6.14"

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@supabase/node-fetch": "2.6.15",
         "@supabase/postgrest-js": "1.21.4",
         "@supabase/realtime-js": "2.15.5",
-        "@supabase/storage-js": "2.12.1"
+        "@supabase/storage-js": "2.12.2"
       },
       "devDependencies": {
         "@sebbo2002/semantic-release-jsr": "^1.0.0",
@@ -1123,9 +1123,9 @@
       }
     },
     "node_modules/@supabase/storage-js": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.12.1.tgz",
-      "integrity": "sha512-QWg3HV6Db2J81VQx0PqLq0JDBn4Q8B1FYn1kYcbla8+d5WDmTdwwMr+EJAxNOSs9W4mhKMv+EYCpCrTFlTj4VQ==",
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.12.2.tgz",
+      "integrity": "sha512-SiySHxi3q7gia7NBYpsYRu8gyI0NhFwSORMxbZIxJ/zAVkN6QpwDRan158CJ+UdzD4WB/rQMAGRqIJQP+7ccAQ==",
       "license": "MIT",
       "dependencies": {
         "@supabase/node-fetch": "^2.6.14"

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@supabase/node-fetch": "2.6.15",
         "@supabase/postgrest-js": "1.21.4",
         "@supabase/realtime-js": "2.15.5",
-        "@supabase/storage-js": "2.12.1"
+        "@supabase/storage-js": "https://pkg.pr.new/@supabase/storage-js@255"
       },
       "devDependencies": {
         "@sebbo2002/semantic-release-jsr": "^1.0.0",
@@ -1123,9 +1123,9 @@
       }
     },
     "node_modules/@supabase/storage-js": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.12.1.tgz",
-      "integrity": "sha512-QWg3HV6Db2J81VQx0PqLq0JDBn4Q8B1FYn1kYcbla8+d5WDmTdwwMr+EJAxNOSs9W4mhKMv+EYCpCrTFlTj4VQ==",
+      "version": "0.0.0",
+      "resolved": "https://pkg.pr.new/@supabase/storage-js@255",
+      "integrity": "sha512-aq2zHxVzSHjVfxjcrcPFWPBlQVsyQRL3QTV1bB8ElVNklPPxmRWYCF0fGIOPAXig0ePpf9D9x4zIfogEIV/AKg==",
       "license": "MIT",
       "dependencies": {
         "@supabase/node-fetch": "^2.6.14"

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@supabase/node-fetch": "2.6.15",
     "@supabase/postgrest-js": "1.21.4",
     "@supabase/realtime-js": "2.15.5",
-    "@supabase/storage-js": "2.12.1"
+    "@supabase/storage-js": "https://pkg.pr.new/@supabase/storage-js@255"
   },
   "devDependencies": {
     "@sebbo2002/semantic-release-jsr": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@supabase/node-fetch": "2.6.15",
     "@supabase/postgrest-js": "1.21.4",
     "@supabase/realtime-js": "2.15.5",
-    "@supabase/storage-js": "2.12.1"
+    "@supabase/storage-js": "2.12.2"
   },
   "devDependencies": {
     "@sebbo2002/semantic-release-jsr": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@supabase/node-fetch": "2.6.15",
     "@supabase/postgrest-js": "1.21.4",
     "@supabase/realtime-js": "2.15.5",
-    "@supabase/storage-js": "https://pkg.pr.new/@supabase/storage-js@255"
+    "@supabase/storage-js": "2.12.1"
   },
   "devDependencies": {
     "@sebbo2002/semantic-release-jsr": "^1.0.0",

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,7 +1,7 @@
 import { AuthClient } from '@supabase/auth-js'
 import { RealtimeClientOptions } from '@supabase/realtime-js'
 import { PostgrestError } from '@supabase/postgrest-js'
-import { StorageClientOptions } from '@supabase/storage-js/dist/module/StorageClient'
+import type { StorageClientOptions } from '@supabase/storage-js'
 
 type AuthClientOptions = ConstructorParameters<typeof AuthClient>[0]
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Change import. Goes together with this fix: https://github.com/supabase/storage-js/pull/255

## What is the current behavior?

Release breaks due to 

```
error: [ERR_MODULE_NOT_FOUND] Cannot find module 'file:///home/runner/work/supabase-js/supabase-js/node_modules/@supabase/storage-js/dist/module/StorageClient' imported from 'file:///home/runner/work/supabase-js/supabase-js/src/lib/types.ts'
Did you mean to import with the ".js" extension?
    at file:///home/runner/work/supabase-js/supabase-js/src/lib/types.ts:4:38
[1:19:18 PM] [semantic-release] [@sebbo2002/semantic-release-jsr] › ℹ  jsr publish failed after 2593 ms:
[1:19:18 PM] [semantic-release] [@sebbo2002/semantic-release-jsr] › ✖  Error: Child process exited with: 1
    at ChildProcess.<anonymous> (/home/runner/work/supabase-js/supabase-js/node_modules/@sebbo2002/semantic-release-jsr/node_modules/jsr/dist/utils.js:221:24)
    at ChildProcess.emit (node:events:524:28)
    at ChildProcess._handle.onexit (node:internal/child_process:293:12)
[1:19:18 PM] [semantic-release] › ✖  Failed step "verifyConditions" of plugin "@sebbo2002/semantic-release-jsr"
[1:19:18 PM] [semantic-release] › ✖  An error occurred while running semantic-release: ExecError: Child process exited with: 1
    at ChildProcess.<anonymous> (/home/runner/work/supabase-js/supabase-js/node_modules/@sebbo2002/semantic-release-jsr/node_modules/jsr/dist/utils.js:221:24)
    at ChildProcess.emit (node:events:524:28)
    at ChildProcess._handle.onexit (node:internal/child_process:293:12) {
  code: 1,
  pluginName: '@sebbo2002/semantic-release-jsr'
}
```

## What is the new behavior?

Does not break.

## Additional context

First broke here: https://github.com/supabase/supabase-js/actions/runs/17734108834/job/50392646422 possibly due to `package-lock.json` changes.