### PR TITLE
feat(storage): add support for sorting to list v2

### DIFF
--- a/packages/core/storage-js/infra/postgres/dummy-data.sql
+++ b/packages/core/storage-js/infra/postgres/dummy-data.sql
@@ -40,6 +40,7 @@ INSERT INTO "storage"."objects" ("id", "bucket_id", "name", "owner", "created_at
 -- allows user to CRUD all buckets
 CREATE POLICY crud_buckets ON storage.buckets for all USING (auth.uid() = '317eadce-631a-4429-a0bb-f19a7a517b4a');
 CREATE POLICY crud_objects ON storage.objects for all USING (auth.uid() = '317eadce-631a-4429-a0bb-f19a7a517b4a');
+CREATE POLICY crud_prefixes ON storage.prefixes for all USING (auth.uid() = '317eadce-631a-4429-a0bb-f19a7a517b4a');
 
 -- allow public CRUD acccess to the public folder in bucket2
 CREATE POLICY crud_public_folder ON storage.objects for all USING (bucket_id='bucket2' and (storage.foldername(name))[1] = 'public');

--- a/packages/core/storage-js/infra/storage/Dockerfile
+++ b/packages/core/storage-js/infra/storage/Dockerfile
@@ -1,3 +1,3 @@
-FROM supabase/storage-api:v1.19.1
+FROM supabase/storage-api:v1.27.4
 
 RUN apk add curl --no-cache

--- a/packages/core/storage-js/src/lib/types.ts
+++ b/packages/core/storage-js/src/lib/types.ts
@@ -103,17 +103,51 @@ export interface SearchOptions {
   search?: string
 }
 
+export interface SortByV2 {
+  column: 'name' | 'updated_at' | 'created_at'
+  order?: 'asc' | 'desc'
+}
+
 export interface SearchV2Options {
+  /**
+   * The number of files you want to be returned.
+   * @default 1000
+   */
   limit?: number
+
+  /**
+   * The prefix search string to filter files by.
+   */
   prefix?: string
+
+  /**
+   * The cursor used for pagination. Pass the value received from nextCursor of the previous request.
+   */
   cursor?: string
+
+  /**
+   * Whether to emulate a hierarchical listing of objects using delimiters.
+   *
+   * - When `false` (default), all objects are listed as flat key/value pairs.
+   * - When `true`, the response groups objects by delimiter, making it appear
+   *   like a file/folder hierarchy.
+   *
+   * @default false
+   */
   with_delimiter?: boolean
+
+  /**
+   * The column and order to sort by
+   * @default 'name asc'
+   */
+  sortBy?: SortByV2
 }
 
 export interface SearchV2Result {
   hasNext: boolean
   folders: { name: string }[]
   objects: FileObject[]
+  nextCursor?: string
 }
 
 export interface FetchParameters {

--- a/packages/core/storage-js/test/__snapshots__/storageApi.test.ts.snap
+++ b/packages/core/storage-js/test/__snapshots__/storageApi.test.ts.snap
@@ -23,7 +23,7 @@ exports[`bucket api delete bucket 1`] = `
 
 exports[`bucket api empty bucket 1`] = `
 {
-  "message": "Successfully emptied",
+  "message": "Empty bucket has been queued. Completion may take up to an hour.",
 }
 `;
 


### PR DESCRIPTION
## 🔍 Description

Feature - Add support for sorting to storage list v2 

### What changed?

List V2 does not support specifying sorting

- Add ability to sort List V2 by name, created_at, updated_at
- More test coverage for List V2
- Update storage used in tests to latest version
- Add crud_prefixes policy to support listing folders
- fix: add nextCursor to return type definition

This is a PR that I forgot to merge in the old repo: https://github.com/supabase/storage-js/pull/254