### PR TITLE
chore(ci): fix publish

### DIFF
--- a/scripts/release-canary.ts
+++ b/scripts/release-canary.ts
@@ -24,9 +24,13 @@ import { execSync } from 'child_process'
   // token, because releasePublish wants a token that has the id_token: write permission
   // so that we can use OIDC for trusted publishing
 
-  const gh_token_bak = process.env.GITHUB_TOKEN
-  process.env.GITHUB_TOKEN = process.env.RELEASE_GITHUB_TOKEN
-
+  // backup original auth header
+  const originalAuth = execSync('git config --local http.https://github.com/.extraheader')
+    .toString()
+    .trim()
+  // switch the token used
+  const authHeader = `AUTHORIZATION: basic ${Buffer.from(`x-access-token:${process.env.RELEASE_GITHUB_TOKEN}`).toString('base64')}`
+  execSync(`git config --local http.https://github.com/.extraheader "${authHeader}"`)
   await releaseChangelog({
     versionData: projectsVersionData,
     version: workspaceVersion,
@@ -36,7 +40,8 @@ import { execSync } from 'child_process'
   })
 
   // npm publish with OIDC
-  process.env.GITHUB_TOKEN = gh_token_bak
+  // not strictly necessary to restore the header but do it incase  we require it later
+  execSync(`git config --local http.https://github.com/.extraheader "${originalAuth}"`)
   const publishResult = await releasePublish({
     registry: 'https://registry.npmjs.org/',
     access: 'public',


### PR DESCRIPTION
nx shells out to git, which uses the authorization configured on the repo that was checkedout. update the repo authorization when switching between auth tokens


