### PR TITLE
chore(ci): fix releaser

### DIFF
--- a/scripts/release-canary.ts
+++ b/scripts/release-canary.ts
@@ -23,7 +23,8 @@ import { execSync } from 'child_process'
   // can be restored afterwards and used by releasePublish. We can't use the same
   // token, because releasePublish wants a token that has the id_token: write permission
   // so that we can use OIDC for trusted publishing
-
+  const gh_token_bak = process.env.GITHUB_TOKEN
+  process.env.GITHUB_TOKEN = process.env.RELEASE_GITHUB_TOKEN
   // backup original auth header
   const originalAuth = execSync('git config --local http.https://github.com/.extraheader')
     .toString()
@@ -42,6 +43,9 @@ import { execSync } from 'child_process'
   // npm publish with OIDC
   // not strictly necessary to restore the header but do it incase  we require it later
   execSync(`git config --local http.https://github.com/.extraheader "${originalAuth}"`)
+  // restore the GH token
+  process.env.GITHUB_TOKEN = gh_token_bak
+
   const publishResult = await releasePublish({
     registry: 'https://registry.npmjs.org/',
     access: 'public',

--- a/scripts/release-stable.ts
+++ b/scripts/release-stable.ts
@@ -61,7 +61,8 @@ if (!validSpecifiers.includes(versionSpecifier) && !isValidVersion) {
   // can be restored afterwards and used by releasePublish. We can't use the same
   // token, because releasePublish wants a token that has the id_token: write permission
   // so that we can use OIDC for trusted publishing
-
+  const gh_token_bak = process.env.GITHUB_TOKEN
+  process.env.GITHUB_TOKEN = process.env.RELEASE_GITHUB_TOKEN
   // backup original auth header
   const originalAuth = execSync('git config --local http.https://github.com/.extraheader')
     .toString()
@@ -81,6 +82,8 @@ if (!validSpecifiers.includes(versionSpecifier) && !isValidVersion) {
   // npm publish with OIDC
   // not strictly necessary to restore the header but do it incase  we require it later
   execSync(`git config --local http.https://github.com/.extraheader "${originalAuth}"`)
+  // restore the GH token
+  process.env.GITHUB_TOKEN = gh_token_bak
 
   const publishResult = await releasePublish({
     registry: 'https://registry.npmjs.org/',


### PR DESCRIPTION
The GITHUB_TOKEN must be updated to be the value of the RELEASE_GITHUB_TOKEN. Otherwise it will try use the default workflow GITHUB_TOKEN, which does not have permission to create a GH release. Ensure we switch back to the token before doing the releasePublish, which requires the original GITHUB_TOKEN to be set since it uses this for OIDC


