### PR TITLE
feat(docs): explicitly mark options as optional

### DIFF
--- a/packages/core/postgrest-js/src/PostgrestQueryBuilder.ts
+++ b/packages/core/postgrest-js/src/PostgrestQueryBuilder.ts
@@ -66,13 +66,10 @@ export default class PostgrestQueryBuilder<
     >,
   >(
     columns?: Query,
-    {
-      head = false,
-      count,
-    }: {
+    options?: {
       head?: boolean
       count?: 'exact' | 'planned' | 'estimated'
-    } = {}
+    }
   ): PostgrestFilterBuilder<
     ClientOptions,
     Schema,
@@ -82,6 +79,8 @@ export default class PostgrestQueryBuilder<
     Relationships,
     'GET'
   > {
+    const { head = false, count } = options ?? {}
+
     const method = head ? 'HEAD' : 'GET'
     // Remove whitespaces except when quoted
     let quoted = false


### PR DESCRIPTION
## 🔍 Description

Even though `options` parameter in `select()` function was optional, generated `spec.json` (via typedoc) was not adding `isOptional: true` flag for `options`. This is fixed by explicitly defining the `options?:` marking it as optional.

### What changed?

Change keeps the exact same behavior. Instead of destructuring the `options` in the parameter definition, it destructure it in the function body, keeping the `options` marked as optional for typedoc to read correctly.

### Why was this change needed?

Change is needed to make documentation compatible with the codebase as mentioned in issue: https://github.com/supabase/supabase/issues/30586

Closes https://github.com/supabase/supabase/issues/30586

## 🔄 Breaking changes

- [x] This PR contains no breaking changes

## 📋 Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/supabase/supabase-js/blob/master/CONTRIBUTING.md)
- [x] My PR title follows the [conventional commit format](https://www.conventionalcommits.org/): `<type>(<scope>): <description>`
- [x] I have run `npx nx format` to ensure consistent code formatting
- [x] I have added tests for new functionality (if applicable)
- [x] I have updated documentation (if applicable)
