### PR TITLE
feat(realtime): add support to configure Broadcast Replay

### DIFF
--- a/packages/core/realtime-js/test/RealtimeClient.channels.test.ts
+++ b/packages/core/realtime-js/test/RealtimeClient.channels.test.ts
@@ -14,6 +14,31 @@ afterEach(() => {
 
 describe('channel', () => {
   let channel
+  test('throws error on replay for a public channel', () => {
+    expect(() => {
+      channel = testSetup.socket.channel('topic', {
+        config: { broadcast: { replay: { since: 0 } } },
+      })
+    }).toThrow(
+      "tried to use replay on public channel 'realtime:topic'. It must be a private channel."
+    )
+  })
+
+  test('returns channel with private channel using replay', () => {
+    channel = testSetup.socket.channel('topic', {
+      config: { private: true, broadcast: { replay: { since: 0 } } },
+    })
+
+    assert.deepStrictEqual(channel.socket, testSetup.socket)
+    assert.equal(channel.topic, 'realtime:topic')
+    assert.deepEqual(channel.params, {
+      config: {
+        broadcast: { replay: { since: 0 } },
+        presence: { key: '', enabled: false },
+        private: true,
+      },
+    })
+  })
 
   test('returns channel with given topic and params', () => {
     channel = testSetup.socket.channel('topic')


### PR DESCRIPTION
## 🔍 Description

Add support to replay broadcast messages.

Related to https://github.com/supabase/realtime/pull/1526

Moving original PR from realtime-js: https://github.com/supabase/realtime-js/pull/540

### What changed?

A new replay option is available for private channels

### Why was this change needed?

New feature!

## 📸 Screenshots/Examples

<!-- If applicable, add screenshots or code examples to help explain your changes -->

## 🔄 Breaking changes

<!-- If this PR contains breaking changes, describe them here -->

- [x] This PR contains no breaking changes

## 📋 Checklist

<!-- Ensure all items are checked before submitting -->

- [x] I have read the [Contributing Guidelines](https://github.com/supabase/supabase-js/blob/master/CONTRIBUTING.md)
- [x] My PR title follows the [conventional commit format](https://www.conventionalcommits.org/): `<type>(<scope>): <description>`
- [x] I have run `npx nx format` to ensure consistent code formatting
- [x] I have added tests for new functionality (if applicable)
- [x] I have updated documentation (if applicable)

## 📝 Additional notes

<!-- Add any additional notes, context, or concerns for reviewers -->

<!-- Thank you for contributing to Supabase! 💚 -->
