### PR TITLE
refactor(supabase): reduce codedup between PostgrestClient and Supaba…

### DIFF
--- a/packages/core/supabase-js/src/SupabaseClient.ts
+++ b/packages/core/supabase-js/src/SupabaseClient.ts
@@ -184,6 +184,7 @@ export default class SupabaseClient<
    *
    * @param relation - The table or view name to query
    */
+  // @jsr-ignore slow-type-missing-explicit-return-type
   from<RelationName extends string & (keyof Schema['Tables'] | keyof Schema['Views'])>(
     relation: RelationName
   ) {
@@ -198,6 +199,7 @@ export default class SupabaseClient<
    *
    * @param schema - The schema to query
    */
+  // @jsr-ignore slow-type-missing-explicit-return-type
   schema<DynamicSchema extends string & keyof Omit<Database, '__InternalSupabase'>>(
     schema: DynamicSchema
   ) {
@@ -228,6 +230,7 @@ export default class SupabaseClient<
    * `"estimated"`: Uses exact count for low numbers and planned count for high
    * numbers.
    */
+  // @jsr-ignore slow-type-missing-explicit-return-type
   rpc<
     FnName extends string & keyof Schema['Functions'],
     Args extends Schema['Functions'][FnName]['Args'] = never,


### PR DESCRIPTION
…seClient leverage inference

We currently duplicate a lot of the typing logic between postgrest-js and supabase-js This makes it very hard to change anything type-wise in postgrest-js without needing to update supabase-js as well. This is mainly because we re-declare functions type returns instead of relying over return type inference.

With this change, as long as the arguments passed to a rest function don't change, the result type will be infered from the this.rest call.

This will allows postgrest-js to alter the result types / implementation details without having to duplicate all changes over to supabase-js.