### PR TITLE
chore(ci): generate token for supabase repo

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -137,6 +137,8 @@ jobs:
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
+          owner: supabase
+          repositories: supabase, supabase-js
       - name: Trigger supabase/supabase update-js-libs workflow
         uses: actions/github-script@v7
         with:
@@ -165,6 +167,8 @@ jobs:
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
+          owner: supabase
+          repositories: supabase, supabase-js
 
       - name: Trigger supabase/supabase docs workflow
         uses: actions/github-script@v7


### PR DESCRIPTION
Generating token for both `supabase` and `supabase-js` repos, so that it can authenticate and trigger the workflow on the `supabase/supabase` repo.

This will not work yet, because:
1. The GitHub App needs to be installed on the `supabase/supabase` repository.
2. In the App settings, under "Repository permissions":
    - Workflows to Read and write
    - Actions to Read and write as well (optional but recommended by the github assistant)