### PR TITLE
feat(auth): add filter support to listUsers

### DIFF
--- a/packages/core/auth-js/test/GoTrueApi.test.ts
+++ b/packages/core/auth-js/test/GoTrueApi.test.ts
@@ -114,6 +114,28 @@ describe('GoTrueAdminApi', () => {
       expect(emails).toContain(email)
     })
 
+    test('listUsers() should support filter property', async () => {
+      const { email } = mockUserCredentials()
+      const { error: createError, data: createdUser } = await createNewUserWithEmail({ email })
+      expect(createError).toBeNull()
+      expect(createdUser.user).not.toBeUndefined()
+
+      const { error: listUserError, data: userList } = await serviceRoleApiClient.listUsers({
+        filter: email,
+      })
+      expect(listUserError).toBeNull()
+      expect(userList).toHaveProperty('users')
+      expect(userList).toHaveProperty('aud')
+
+      const emails =
+        userList.users?.map((user: User) => {
+          return user.email
+        }) || []
+
+      expect(emails.length).toEqual(1)
+      expect(emails).toContain(email)
+    })
+
     test('listUsers() returns AuthError when page is invalid', async () => {
       const { error, data } = await serviceRoleApiClient.listUsers({
         page: -1,


### PR DESCRIPTION
## What kind of change does this PR introduce?

There is already support for a `filter=xyz` query param for the listUsers endpoint, but it is not exposed on the client. This PR adds support for the filter, which allows users to filter the respond of listUsers by a partial or full email address. 

This PR also fixes pagination metadata for page values >9. This was originally proposed in #793, but changes were requested and that PR is now stale so I have implemented those changes here too.

## What is the current behavior?

It is not possible to filter users via the SDK.

## What is the new behavior?

You can now filter users.

## Additional context

https://github.com/supabase/gotrue/issues/880

## 📝 Additional notes

Bring over from the `auth-js` repo. Original here: https://github.com/supabase/auth-js/pull/865