### PR TITLE
feat(storage): expose purgeCache

### DIFF
--- a/packages/core/storage-js/src/packages/StorageFileApi.ts
+++ b/packages/core/storage-js/src/packages/StorageFileApi.ts
@@ -1,4 +1,4 @@
-import { isStorageError, StorageError, StorageUnknownError } from '../lib/errors'
+import { isStorageError, StorageError, StorageApiError, StorageUnknownError } from '../lib/errors'
 import { Fetch, get, head, post, put, remove } from '../lib/fetch'
 import { recursiveToCamel, resolveFetch } from '../lib/helpers'
 import {
@@ -828,6 +828,215 @@ export default class StorageFileApi {
         return { data: null, error }
       }
 
+      throw error
+    }
+  }
+
+  /**
+   * Purges the cache for a specific object from the CDN.
+   * Note: This method only works with individual file paths.
+   * Use purgeCacheByPrefix() to purge multiple objects or entire folders.
+   *
+   * @param path The specific file path to purge from cache. Cannot be empty or contain wildcards.
+   * @param parameters Optional fetch parameters like AbortController signal.
+   */
+  async purgeCache(
+    path: string,
+    parameters?: FetchParameters
+  ): Promise<
+    | {
+        data: { message: string; purgedPath: string }
+        error: null
+      }
+    | {
+        data: null
+        error: StorageError
+      }
+  > {
+    try {
+      // Validate input
+      if (!path || path.trim() === '') {
+        return {
+          data: null,
+          error: new StorageError(
+            'Path is required for cache purging. Use purgeCacheByPrefix() to purge folders or entire buckets.'
+          ),
+        }
+      }
+
+      // Check for wildcards
+      if (path.includes('*')) {
+        return {
+          data: null,
+          error: new StorageError(
+            'Wildcard purging is not supported. Please specify an exact file path.'
+          ),
+        }
+      }
+
+      const cleanPath = this._removeEmptyFolders(path)
+      const cdnPath = `${this.bucketId}/${cleanPath}`
+
+      const data = await remove(
+        this.fetch,
+        `${this.url}/cdn/${cdnPath}`,
+        {},
+        { headers: this.headers },
+        parameters
+      )
+
+      return {
+        data: {
+          message: data?.message || 'success',
+          purgedPath: cleanPath,
+        },
+        error: null,
+      }
+    } catch (error) {
+      if (isStorageError(error)) {
+        return { data: null, error }
+      }
+
+      throw error
+    }
+  }
+
+  /**
+   * Purges the cache for all objects in a folder or entire bucket.
+   * This method lists objects first, then purges each individually.
+   *
+   * Note: This operation can take a very long time for large numbers of objects.
+   * Each object purge takes between 300ms and 600ms, so purging 200+ objects
+   * could take several minutes.
+   *
+   * @param prefix The folder prefix to purge (empty string for entire bucket)
+   * @param options Optional configuration for listing and purging
+   * @param options.limit Maximum number of objects to list (default: 1000)
+   * @param options.batchSize Number of objects to process in each batch (default: 100)
+   * @param options.batchDelayMs Delay in milliseconds between batches (default: 0)
+   * @param parameters Optional fetch parameters
+   */
+  async purgeCacheByPrefix(
+    prefix: string = '',
+    options?: {
+      limit?: number
+      batchSize?: number
+      batchDelayMs?: number
+    },
+    parameters?: FetchParameters
+  ): Promise<
+    | {
+        data: { message: string; purgedPaths: string[]; warnings?: string[] }
+        error: null
+      }
+    | {
+        data: null
+        error: StorageError
+      }
+  > {
+    try {
+      const batchSize = options?.batchSize || 100
+      const batchDelayMs = options?.batchDelayMs || 0
+      const purgedPaths: string[] = []
+      const warnings: string[] = []
+
+      // List all objects with the given prefix
+      const { data: objects, error: listError } = await this.list(prefix, {
+        limit: options?.limit || 1000,
+        offset: 0,
+        sortBy: {
+          column: 'name',
+          order: 'asc',
+        },
+      })
+
+      if (listError) {
+        return { data: null, error: listError }
+      }
+
+      if (!objects || objects.length === 0) {
+        return {
+          data: {
+            message: 'No objects found to purge',
+            purgedPaths: [],
+          },
+          error: null,
+        }
+      }
+
+      // Extract file paths and filter out folders (folders have id === null)
+      const filePaths = objects
+        .filter((obj) => obj.id !== null) // Only files, not folders
+        .map((obj) => (prefix ? `${prefix}/${obj.name}` : obj.name))
+
+      if (filePaths.length === 0) {
+        return {
+          data: {
+            message: 'No files found to purge (only folders detected)',
+            purgedPaths: [],
+          },
+          error: null,
+        }
+      }
+      for (let i = 0; i < filePaths.length; i += batchSize) {
+        const batch = filePaths.slice(i, i + batchSize)
+
+        for (const filePath of batch) {
+          try {
+            const { error: purgeError } = await this.purgeCache(filePath, parameters)
+
+            if (purgeError) {
+              warnings.push(`Failed to purge ${filePath}: ${purgeError.message}`)
+            } else {
+              purgedPaths.push(filePath)
+            }
+          } catch (error) {
+            warnings.push(`Failed to purge ${filePath}: ${(error as Error).message}`)
+          }
+        }
+
+        // Add delay between batches if specified and not the last batch
+        if (batchDelayMs > 0 && i + batchSize < filePaths.length) {
+          await new Promise((resolve) => setTimeout(resolve, batchDelayMs))
+        }
+      }
+
+      // If all paths failed, return error
+      if (purgedPaths.length === 0 && warnings.length > 0) {
+        return {
+          data: null,
+          error: new StorageError(
+            `All purge operations failed: ${warnings.slice(0, 3).join(', ')}${
+              warnings.length > 3 ? '...' : ''
+            }`
+          ),
+        }
+      }
+
+      const message =
+        purgedPaths.length > 0
+          ? `Successfully purged ${purgedPaths.length} object(s)${
+              warnings.length > 0 ? ` (${warnings.length} failed)` : ''
+            }`
+          : 'No objects were purged'
+
+      const result: { message: string; purgedPaths: string[]; warnings?: string[] } = {
+        message,
+        purgedPaths,
+      }
+
+      if (warnings.length > 0) {
+        result.warnings = warnings
+      }
+
+      return {
+        data: result,
+        error: null,
+      }
+    } catch (error) {
+      if (isStorageError(error)) {
+        return { data: null, error }
+      }
       throw error
     }
   }

--- a/packages/core/storage-js/test/storageFileApiErrorHandling.test.ts
+++ b/packages/core/storage-js/test/storageFileApiErrorHandling.test.ts
@@ -279,4 +279,363 @@ describe('File API Error Handling', () => {
       mockFn.mockRestore()
     })
   })
+
+  describe('purgeCache', () => {
+    it('wraps non-Response errors as StorageUnknownError', async () => {
+      const nonResponseError = new TypeError('Invalid copy operation')
+      global.fetch = jest.fn().mockImplementation(() => Promise.reject(nonResponseError))
+      const storage = new StorageClient(URL, { apikey: KEY })
+      const { data, error } = await storage.from(BUCKET_ID).purgeCache('test.png')
+      expect(data).toBeNull()
+      expect(error).not.toBeNull()
+      expect(error?.message).toBe('Invalid copy operation')
+    })
+
+    it('rejects empty paths', async () => {
+      const storage = new StorageClient(URL, { apikey: KEY })
+      const { data, error } = await storage.from(BUCKET_ID).purgeCache('')
+      expect(data).toBeNull()
+      expect(error).not.toBeNull()
+      expect(error?.message).toBe(
+        'Path is required for cache purging. Use purgeCacheByPrefix() to purge folders or entire buckets.'
+      )
+    })
+
+    it('rejects wildcard paths', async () => {
+      const storage = new StorageClient(URL, { apikey: KEY })
+      const { data, error } = await storage.from(BUCKET_ID).purgeCache('folder/*')
+      expect(data).toBeNull()
+      expect(error).not.toBeNull()
+      expect(error?.message).toBe(
+        'Wildcard purging is not supported. Please specify an exact file path.'
+      )
+    })
+
+    it('wraps non-Response errors as StorageUnknownError', async () => {
+      const nonResponseError = new TypeError('Invalid purge operation')
+      global.fetch = jest.fn().mockImplementation(() => Promise.reject(nonResponseError))
+
+      const storage = new StorageClient(URL, { apikey: KEY })
+
+      const { data, error } = await storage.from(BUCKET_ID).purgeCache('test.png')
+      expect(data).toBeNull()
+      expect(error).toBeInstanceOf(StorageUnknownError)
+      expect(error?.message).toBe('Invalid purge operation')
+    })
+
+    it('throws non-StorageError exceptions', async () => {
+      const storage = new StorageClient(URL, { apikey: KEY })
+
+      const mockFn = jest.spyOn(global, 'fetch').mockImplementationOnce(() => {
+        const error = new Error('Unexpected error in purgeCache')
+        Object.defineProperty(error, 'name', { value: 'CustomError' })
+        throw error
+      })
+
+      await expect(storage.from(BUCKET_ID).purgeCache('test.png')).rejects.toThrow(
+        'Unexpected error in purgeCache'
+      )
+
+      mockFn.mockRestore()
+    })
+  })
+
+  describe('purgeCacheByPrefix', () => {
+    beforeEach(() => {
+      // Mock Response constructor globally
+      global.Response = jest.fn().mockImplementation((body, init) => ({
+        json: () => Promise.resolve(JSON.parse(body)),
+        status: init?.status || 200,
+        headers: new Map(Object.entries(init?.headers || {})),
+        ok: init?.status ? init.status >= 200 && init.status < 300 : true,
+      })) as unknown as typeof Response
+    })
+
+    it('handles StorageError during list operation', async () => {
+      const mockResponse = {
+        ok: false,
+        status: 403,
+        json: () =>
+          Promise.resolve({
+            statusCode: '403',
+            error: 'Forbidden',
+            message: 'Access denied to list objects',
+          }),
+        headers: new Map([['Content-Type', 'application/json']]),
+      }
+      global.fetch = jest.fn().mockImplementation(() => Promise.resolve(mockResponse))
+      const storage = new StorageClient(URL, { apikey: KEY })
+      const { data, error } = await storage.from(BUCKET_ID).purgeCacheByPrefix('folder')
+      expect(data).toBeNull()
+      expect(error).not.toBeNull()
+      expect(error?.message).toContain(':403')
+    })
+
+    it('handles mixed success and failure during purge operations', async () => {
+      // Mock successful list response
+      const listResponse = new Response(
+        JSON.stringify([
+          { name: 'file1.jpg', id: '1' },
+          { name: 'file2.png', id: '2' },
+          { name: 'file3.gif', id: '3' },
+        ]),
+        {
+          status: 200,
+          statusText: 'OK',
+          headers: { 'Content-Type': 'application/json' },
+        }
+      )
+
+      // Mock purge responses - some succeed, some fail
+      const successResponse = new Response(JSON.stringify({ message: 'success' }), {
+        status: 200,
+        statusText: 'OK',
+        headers: { 'Content-Type': 'application/json' },
+      })
+
+      const errorResponse = new Response(
+        JSON.stringify({
+          statusCode: '404',
+          error: 'Not Found',
+          message: 'Object not found',
+        }),
+        {
+          status: 404,
+          statusText: 'Not Found',
+          headers: { 'Content-Type': 'application/json' },
+        }
+      )
+
+      global.fetch = jest
+        .fn()
+        .mockResolvedValueOnce(listResponse) // List succeeds
+        .mockResolvedValueOnce(successResponse) // First purge succeeds
+        .mockResolvedValueOnce(errorResponse) // Second purge fails
+        .mockResolvedValueOnce(successResponse) // Third purge succeeds
+
+      const storage = new StorageClient(URL, { apikey: KEY })
+
+      const { data, error } = await storage.from(BUCKET_ID).purgeCacheByPrefix('folder')
+      expect(error).toBeNull()
+      expect(data?.purgedPaths).toHaveLength(2)
+      expect(data?.warnings).toHaveLength(1)
+      expect(data?.warnings?.[0]).toContain('Failed to purge folder/file2.png')
+      expect(data?.message).toContain('Successfully purged 2 object(s) (1 failed)')
+    })
+
+    it('handles all purge operations failing', async () => {
+      // Mock successful list response
+      const listResponse = new Response(
+        JSON.stringify([
+          { name: 'file1.jpg', id: '1' },
+          { name: 'file2.png', id: '2' },
+        ]),
+        {
+          status: 200,
+          statusText: 'OK',
+          headers: { 'Content-Type': 'application/json' },
+        }
+      )
+
+      const errorResponse = new Response(
+        JSON.stringify({
+          statusCode: '404',
+          error: 'Not Found',
+          message: 'Object not found',
+        }),
+        {
+          status: 404,
+          statusText: 'Not Found',
+          headers: { 'Content-Type': 'application/json' },
+        }
+      )
+
+      global.fetch = jest
+        .fn()
+        .mockResolvedValueOnce(listResponse) // List succeeds
+        .mockResolvedValue(errorResponse) // All purge operations fail
+
+      const storage = new StorageClient(URL, { apikey: KEY })
+
+      const { data, error } = await storage.from(BUCKET_ID).purgeCacheByPrefix('folder')
+      expect(data).toBeNull()
+      expect(error).not.toBeNull()
+      expect(error?.message).toContain('All purge operations failed')
+    })
+
+    it('handles non-StorageError exceptions during individual purge operations', async () => {
+      // Mock successful list response
+      const listResponse = new Response(
+        JSON.stringify([
+          { name: 'file1.jpg', id: '1' },
+          { name: 'file2.png', id: '2' },
+        ]),
+        {
+          status: 200,
+          statusText: 'OK',
+          headers: { 'Content-Type': 'application/json' },
+        }
+      )
+
+      const successResponse = new Response(JSON.stringify({ message: 'success' }), {
+        status: 200,
+        statusText: 'OK',
+        headers: { 'Content-Type': 'application/json' },
+      })
+
+      global.fetch = jest
+        .fn()
+        .mockResolvedValueOnce(listResponse) // List succeeds
+        .mockResolvedValueOnce(successResponse) // First purge succeeds
+        .mockImplementationOnce(() => {
+          const error = new Error('Unexpected network error')
+          Object.defineProperty(error, 'name', { value: 'CustomError' })
+          throw error
+        }) // Second purge throws non-StorageError
+
+      const storage = new StorageClient(URL, { apikey: KEY })
+
+      const { data, error } = await storage.from(BUCKET_ID).purgeCacheByPrefix('folder')
+      expect(error).toBeNull()
+      expect(data?.purgedPaths).toHaveLength(1)
+      expect(data?.warnings).toHaveLength(1)
+      expect(data?.warnings?.[0]).toContain(
+        'Failed to purge folder/file2.png: Unexpected network error'
+      )
+      expect(data?.message).toContain('Successfully purged 1 object(s) (1 failed)')
+    })
+
+    it('throws non-StorageError exceptions at top level', async () => {
+      const storage = new StorageClient(URL, { apikey: KEY })
+
+      const mockFn = jest.spyOn(global, 'fetch').mockImplementationOnce(() => {
+        const error = new Error('Unexpected error in purgeCacheByPrefix')
+        Object.defineProperty(error, 'name', { value: 'CustomError' })
+        throw error
+      })
+
+      await expect(storage.from(BUCKET_ID).purgeCacheByPrefix('folder')).rejects.toThrow(
+        'Unexpected error in purgeCacheByPrefix'
+      )
+
+      mockFn.mockRestore()
+    })
+
+    it('handles empty list response', async () => {
+      const listResponse = new Response(JSON.stringify([]), {
+        status: 200,
+        statusText: 'OK',
+        headers: { 'Content-Type': 'application/json' },
+      })
+
+      global.fetch = jest.fn().mockResolvedValue(listResponse)
+      const storage = new StorageClient(URL, { apikey: KEY })
+
+      const { data, error } = await storage.from(BUCKET_ID).purgeCacheByPrefix('empty-folder')
+      expect(error).toBeNull()
+      expect(data?.purgedPaths).toHaveLength(0)
+      expect(data?.message).toEqual('No objects found to purge')
+    })
+
+    it('handles list response with only folders', async () => {
+      const listResponse = new Response(
+        JSON.stringify([
+          { name: 'subfolder1/', id: null },
+          { name: 'subfolder2/', id: null },
+        ]),
+        {
+          status: 200,
+          statusText: 'OK',
+          headers: { 'Content-Type': 'application/json' },
+        }
+      )
+
+      global.fetch = jest.fn().mockResolvedValue(listResponse)
+      const storage = new StorageClient(URL, { apikey: KEY })
+
+      const { data, error } = await storage.from(BUCKET_ID).purgeCacheByPrefix('folder')
+      expect(error).toBeNull()
+      expect(data?.purgedPaths).toHaveLength(0)
+      expect(data?.message).toEqual('No files found to purge (only folders detected)')
+    })
+
+    it('wraps non-Response errors from list as StorageUnknownError', async () => {
+      const nonResponseError = new TypeError('Invalid list operation during purge')
+      global.fetch = jest.fn().mockImplementation(() => Promise.reject(nonResponseError))
+
+      const storage = new StorageClient(URL, { apikey: KEY })
+
+      const { data, error } = await storage.from(BUCKET_ID).purgeCacheByPrefix('folder')
+      expect(data).toBeNull()
+      expect(error).toBeInstanceOf(StorageUnknownError)
+      expect(error?.message).toBe('Invalid list operation during purge')
+    })
+
+    it('handles partial success with many warnings', async () => {
+      // Create many files to test warning truncation
+      const files = Array.from({ length: 10 }, (_, i) => ({ name: `file${i}.jpg`, id: String(i) }))
+      const listResponse = new Response(JSON.stringify(files), {
+        status: 200,
+        statusText: 'OK',
+        headers: { 'Content-Type': 'application/json' },
+      })
+
+      const errorResponse = new Response(
+        JSON.stringify({
+          statusCode: '404',
+          error: 'Not Found',
+          message: 'Object not found',
+        }),
+        {
+          status: 404,
+          statusText: 'Not Found',
+          headers: { 'Content-Type': 'application/json' },
+        }
+      )
+
+      global.fetch = jest
+        .fn()
+        .mockResolvedValueOnce(listResponse) // List succeeds
+        .mockResolvedValue(errorResponse) // All purge operations fail
+
+      const storage = new StorageClient(URL, { apikey: KEY })
+
+      const { data, error } = await storage.from(BUCKET_ID).purgeCacheByPrefix('folder')
+      expect(data).toBeNull()
+      expect(error).not.toBeNull()
+      expect(error?.message).toContain('All purge operations failed')
+      // Should truncate the error message to avoid extremely long messages
+      expect(error?.message.length).toBeLessThan(1000)
+    })
+
+    it('handles AbortController signal properly', async () => {
+      const listResponse = {
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve([{ name: 'file1.jpg', id: '1' }]),
+      }
+
+      const purgeResponse = {
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ message: 'success' }),
+      }
+
+      global.fetch = jest
+        .fn()
+        .mockResolvedValueOnce(listResponse)
+        .mockResolvedValueOnce(purgeResponse)
+
+      const storage = new StorageClient(URL, { apikey: KEY })
+      const abortController = new AbortController()
+
+      const { data, error } = await storage
+        .from(BUCKET_ID)
+        .purgeCacheByPrefix('folder', { batchDelayMs: 10 }, { signal: abortController.signal })
+      expect(error).toBeNull()
+      expect(data?.purgedPaths).toHaveLength(1)
+      expect(data?.purgedPaths).toEqual(['folder/file1.jpg'])
+      expect(data?.message).toContain('Successfully purged 1 object(s)')
+    })
+  })
 })


### PR DESCRIPTION
Authored by @mansueli 
Moved from here: https://github.com/supabase/storage-js/pull/229

## What kind of change does this PR introduce?

The goal is to expose the purgeCache operation from the [API](https://supabase.github.io/storage/#/object/delete_cdn__bucketName___wildcard_) to the client libraries.

```
        "/cdn/{bucketName}/{wildcard}": {
            "delete": {
                "summary": "Purge cache for an object",
                "tags": [
                    "object"
                ],
                "parameters": [
                    {
                        "schema": {
                            "type": "string"
                        },
                        "example": "avatars",
                        "in": "path",
                        "name": "bucketName",
                        "required": true
                    },
                    {
                        "schema": {
                            "type": "string"
                        },
                        "example": "folder/cat.png",
                        "in": "path",
                        "name": "*",
                        "required": true
                    },
                    {
                        "schema": {
                            "type": "string"
                        },
                        "example": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24ifQ.625_WdcF3KHqz5amU0x2X5WWHP-OEs_4qj0ssLNHzTs",
                        "in": "header",
                        "name": "authorization",
                        "required": true
                    }
                ],
                "responses": {
                    "200": {
                        "description": "Successful response",
                        "content": {
                            "application/json": {
                                "schema": {
                                    "description": "Successful response",
                                    "type": "object",
                                    "properties": {
                                        "message": {
                                            "type": "string",
                                            "examples": [
                                                "success"
                                            ]
                                        }
                                    }
                                }
                            }
                        }
                    },
                    "4XX": {
                        "description": "Error response",
                        "content": {
                            "application/json": {
                                "schema": {
                                    "description": "Error response",
                                    "$ref": "#/components/schemas/def-1"
                                }
                            }
                        }
                    }
                }
            }
        },
```

## What is the current behavior?

There's no support this in the client libraries. 

## What is the new behavior?

The goal is to allow this to be exposed in the supabase-js client e.g:

```
storage.from(BUCKET_ID).purgeCache('test.png')
```

