### PR TITLE
docs(storage): mark last_accessed_at field as deprecated

### DIFF
--- a/packages/core/storage-js/src/lib/types.ts
+++ b/packages/core/storage-js/src/lib/types.ts
@@ -21,6 +21,7 @@ export interface FileObject {
   id: string
   updated_at: string
   created_at: string
+  /** @deprecated */
   last_accessed_at: string
   metadata: Record<string, any>
   buckets: Bucket
@@ -33,6 +34,7 @@ export interface FileObjectV2 {
   bucket_id: string
   updated_at: string
   created_at: string
+  /** @deprecated */
   last_accessed_at: string
   size?: number
   cache_control?: string


### PR DESCRIPTION
## What kind of change does this PR introduce?
Mark some fields as deprecated. According to this comment by fenos https://github.com/supabase/storage/pull/620#issuecomment-2602346959 these fields are deprecated.

## What is the current behavior?
Last accessed is not marked deprecated

## What is the new behavior?
Last accessed marked deprecated.

## Additional context

Moved from here: https://github.com/supabase/storage-js/pull/218

was already approved by @fenos 