### PR TITLE
fix(realtime): send heartbeat for initial connection error

### DIFF
--- a/packages/core/realtime-js/src/RealtimeClient.ts
+++ b/packages/core/realtime-js/src/RealtimeClient.ts
@@ -777,6 +777,11 @@ export default class RealtimeClient {
     this.log('transport', `${error}`)
     this._triggerChanError()
     this._triggerStateCallbacks('error', error)
+    try {
+      this.heartbeatCallback('error')
+    } catch (e) {
+      this.log('error', 'error in heartbeat callback', e)
+    }
   }
 
   /** @internal */


### PR DESCRIPTION
Moved from: https://github.com/supabase/realtime-js/pull/507
Author: @bhavyasaggi

## What kind of change does this PR introduce?

Add missing heartbeat on connection error.

## What is the current behavior?

If the Supabase instance is unreachable during initial realtime connection, there is no status update available.

## What is the new behavior?

Trigger a heartbeat-callback with 'error' on connection-error.
