### PR TITLE
feat(realtime): realtime explicit REST call

### DIFF
--- a/packages/core/realtime-js/src/RealtimeChannel.ts
+++ b/packages/core/realtime-js/src/RealtimeChannel.ts
@@ -436,6 +436,68 @@ export default class RealtimeChannel {
     return this._on(type, filter, callback)
   }
   /**
+   * Sends a broadcast message explicitly via REST API.
+   *
+   * This method always uses the REST API endpoint regardless of WebSocket connection state.
+   * Useful when you want to guarantee REST delivery or when gradually migrating from implicit REST fallback.
+   *
+   * @param event The name of the broadcast event
+   * @param payload Payload to be sent (required)
+   * @param opts Options including timeout
+   * @returns Promise resolving to object with success status, and error details if failed
+   */
+  async httpSend(
+    event: string,
+    payload: any,
+    opts: { timeout?: number } = {}
+  ): Promise<{ success: true } | { success: false; status: number; error: string }> {
+    const authorization = this.socket.accessTokenValue
+      ? `Bearer ${this.socket.accessTokenValue}`
+      : ''
+
+    if (payload === undefined || payload === null) {
+      return Promise.reject('Payload is required for httpSend()')
+    }
+
+    const options = {
+      method: 'POST',
+      headers: {
+        Authorization: authorization,
+        apikey: this.socket.apiKey ? this.socket.apiKey : '',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        messages: [
+          {
+            topic: this.subTopic,
+            event,
+            payload: payload,
+            private: this.private,
+          },
+        ],
+      }),
+    }
+
+    const response = await this._fetchWithTimeout(
+      this.broadcastEndpointURL,
+      options,
+      opts.timeout ?? this.timeout
+    )
+
+    if (response.status === 202) {
+      return { success: true }
+    }
+
+    let errorMessage = response.statusText
+    try {
+      const errorBody = await response.json()
+      errorMessage = errorBody.error || errorBody.message || errorMessage
+    } catch {}
+
+    return Promise.reject(new Error(errorMessage))
+  }
+
+  /**
    * Sends a message into the channel.
    *
    * @param args Arguments to send to channel
@@ -454,6 +516,12 @@ export default class RealtimeChannel {
     opts: { [key: string]: any } = {}
   ): Promise<RealtimeChannelSendResponse> {
     if (!this._canPush() && args.type === 'broadcast') {
+      console.warn(
+        'Realtime send() is automatically falling back to REST API. ' +
+          'This behavior will be deprecated in the future. ' +
+          'Please use httpSend() explicitly for REST delivery.'
+      )
+
       const { event, payload: endpoint_payload } = args
       const authorization = this.socket.accessTokenValue
         ? `Bearer ${this.socket.accessTokenValue}`


### PR DESCRIPTION
<!-- Your PR title should follow the conventional commit format:
<type>(<scope>): <description> -->

## 🔍 Description

Added new public method for explicit usage of REST API for broadcast 
### What changed?

New method `httpSend` added

### Why was this change needed?
Our current approach leads users to use broadcast without knowing.
<!-- Explain the motivation behind this change. Link any related issues. -->

## 🔄 Breaking changes

<!-- If this PR contains breaking changes, describe them here -->

- [ ] New log warning to inform that users are using REST when using `send` while not connected.

## 📋 Checklist

<!-- Ensure all items are checked before submitting -->

- [X] I have read the [Contributing Guidelines](https://github.com/supabase/supabase-js/blob/master/CONTRIBUTING.md)
- [X] My PR title follows the [conventional commit format](https://www.conventionalcommits.org/): `<type>(<scope>): <description>`
- [X] I have run `npx nx format` to ensure consistent code formatting
- [X] I have added tests for new functionality (if applicable)
- [ ] I have updated documentation (if applicable)

