### PR TITLE
fix(functions): missing body when Content-Type header supplied by dev

### DIFF
--- a/packages/core/functions-js/src/FunctionsClient.ts
+++ b/packages/core/functions-js/src/FunctionsClient.ts
@@ -89,6 +89,9 @@ export class FunctionsClient {
           _headers['Content-Type'] = 'application/json'
           body = JSON.stringify(functionArgs)
         }
+      } else {
+        // if the Content-Type was supplied, simply set the body
+        body = functionArgs
       }
 
       const response = await this.fetch(url.toString(), {


### PR DESCRIPTION
Moved from: https://github.com/supabase/functions-js/pull/90
Author: @ggaabe

## What kind of change does this PR introduce?

Fixes null body when user supplies `Content-Type` in headers of `supabase.functions.invoke`, ie: invoked like this

```js
  const response = await supabase.functions.invoke("stripe-webhook", {
    method: "POST",
    headers: {
   // this causes the body to be null
      "Content-Type": "application/json",
    },
    body: JSON.stringify({
      action: "finalizeClinicSetup",
      stripeSessionId,
      userId,
    }),
  });
```

## What is the current behavior?

The request `body` sent over the network will be null, instead of the supplied body value, if a Content-Type header is supplied

Please link any relevant issues here.

## What is the new behavior?

If user supplies a `Content-Type` header, the body will contain its original value supplied by the developer
