### PR TITLE
fix(auth): code verifier remains in storage during edge cases

### DIFF
--- a/packages/core/auth-js/src/GoTrueClient.ts
+++ b/packages/core/auth-js/src/GoTrueClient.ts
@@ -635,6 +635,7 @@ export default class GoTrueClient {
       const { data, error } = res
 
       if (error || !data) {
+        await removeItemAsync(this.storage, `${this.storageKey}-code-verifier`)
         return this._returnResult({ data: { user: null, session: null }, error: error })
       }
 
@@ -648,6 +649,7 @@ export default class GoTrueClient {
 
       return this._returnResult({ data: { user, session }, error: null })
     } catch (error) {
+      await removeItemAsync(this.storage, `${this.storageKey}-code-verifier`)
       if (isAuthError(error)) {
         return this._returnResult({ data: { user: null, session: null }, error })
       }
@@ -1138,13 +1140,13 @@ export default class GoTrueClient {
       }
       return this._returnResult({ data: { ...data, redirectType: redirectType ?? null }, error })
     } catch (error) {
+      await removeItemAsync(this.storage, `${this.storageKey}-code-verifier`)
       if (isAuthError(error)) {
         return this._returnResult({
           data: { user: null, session: null, redirectType: null },
           error,
         })
       }
-
       throw error
     }
   }
@@ -1251,6 +1253,7 @@ export default class GoTrueClient {
       }
       throw new AuthInvalidCredentialsError('You must provide either an email or phone number.')
     } catch (error) {
+      await removeItemAsync(this.storage, `${this.storageKey}-code-verifier`)
       if (isAuthError(error)) {
         return this._returnResult({ data: { user: null, session: null }, error })
       }
@@ -1357,6 +1360,7 @@ export default class GoTrueClient {
 
       return this._returnResult(result)
     } catch (error) {
+      await removeItemAsync(this.storage, `${this.storageKey}-code-verifier`)
       if (isAuthError(error)) {
         return this._returnResult({ data: null, error })
       }
@@ -1820,6 +1824,7 @@ export default class GoTrueClient {
         return this._returnResult({ data: { user: session.user }, error: null })
       })
     } catch (error) {
+      await removeItemAsync(this.storage, `${this.storageKey}-code-verifier`)
       if (isAuthError(error)) {
         return this._returnResult({ data: { user: null }, error })
       }
@@ -2272,6 +2277,7 @@ export default class GoTrueClient {
         redirectTo: options.redirectTo,
       })
     } catch (error) {
+      await removeItemAsync(this.storage, `${this.storageKey}-code-verifier`)
       if (isAuthError(error)) {
         return this._returnResult({ data: null, error })
       }
@@ -2401,6 +2407,7 @@ export default class GoTrueClient {
         }
         return this._returnResult({ data, error })
       } catch (error) {
+        await removeItemAsync(this.storage, `${this.storageKey}-code-verifier`)
         if (isAuthError(error)) {
           return this._returnResult({ data: { user: null, session: null }, error })
         }
@@ -2749,7 +2756,7 @@ export default class GoTrueClient {
     // _saveSession is always called whenever a new session has been acquired
     // so we can safely suppress the warning returned by future getSession calls
     this.suppressGetSessionWarning = true
-
+    await removeItemAsync(this.storage, `${this.storageKey}-code-verifier`)
     // Create a shallow copy to work with, to avoid mutating the original session object if it's used elsewhere
     const sessionToProcess = { ...session }
 


### PR DESCRIPTION
Moved from: https://github.com/supabase/auth-js/pull/986

Author: @j4w8n 

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

In some scenarios, the `sb-<project-id>-auth-token-code-verifier` will get created in storage, but is either not used or an error will happen during calls like `updateUser()`, etc. In these cases, the code verifier remains in storage, which can cause issues if ~~third-party code~~ any non-Supabase code uses the `code` search param in a url later on. See issue https://github.com/supabase/supabase-js/issues/1704 for an example.

This requires a client-side supabase client to be running on the page that recieves the `code` param.

## What is the new behavior?

When the code verifier is set, and the function throws an error or returns an error (in one case), we now remove the code verifier from storage. To cover success scenarios, we remove any potential code verifier whenever a session is saved; as I wasn't sure where else to handle this.

This should resolve the issue when strictly using supabase-js, but this is not necessarily the case for the ssr library because it only enforces storage changes when a whitelisted auth event also occurs (e.g. SIGNED_IN, TOKEN_REFRESHED). Since none of the existing events seem relevant in this case, I created a new one called `STORAGE_UPDATED`, although this might be too generic. I tried to ensure that the session is passed along with the event; so we hopefully don't disrupt any action logic within `onAuthStateChange()` that a lot of devs put there. The ssr PR that coincides with this is https://github.com/supabase/ssr/pull/82.

I'm not sure if this is how the team wants to resolve this issue or not. Feel free to delete this PR or slice and dice it; as it didn't spend too much time on it.

UPDATE: Noting this PR will no longer resolve this issue for users of the ssr library. I've also closed the related ssr PR.

## Alternatives Considered

After some short discussion with @silentworks, one thing which could be done is renaming `code`; which would be breaking of course.

One other idea is to somehow introduce a new name while keeping the old name. Might be a bit complicated, even if it is possible. Then, deprecate the old usage and remove in auth-js v3.

Or, you could implement something like I've proposed here, as a temporary fix, then deprecate `code` in favor of something else in auth-js v3, and then roll my proposed changes back. Although, if one of the goals is to resolve the "orphaned" code verifier, then you may want to keep some of the changes.

Also, to make my proposed change a bit smaller, perhaps the ssr library can be tweaked to where storage changes are written immediately, instead of waiting for an auth state change event. That would allow you to remove the `STORAGE_UPDATED` event proposed here.

## Additional context

fixes supabase/supabase-js#1704
fixes supabase/supabase-js#1697

https://discord.com/channels/839993398554656828/1312930639066169365

As seen here, https://github.com/supabase/auth-js/blob/master/src/GoTrueClient.ts#L1535, the `_isPKCEFlow()` check only returns `true` if there is a `code` search param in the url and the code verifier is in storage. So, if we can cleanup the code verifier once it's no longer needed in these edge cases, this resolves the issue.
