### PR TITLE
fix(auth): add providers type to UserAppMetadata interface

### DIFF
--- a/packages/core/auth-js/src/lib/types.ts
+++ b/packages/core/auth-js/src/lib/types.ts
@@ -346,7 +346,13 @@ export type Factor<
 }
 
 export interface UserAppMetadata {
+  /**
+   * The first provider that the user used to sign up with.
+   */
   provider?: string
+  /**
+   * A list of all providers that the user has linked to their account.
+   */
   providers?: string[]
   [key: string]: any
 }


### PR DESCRIPTION
Moved from https://github.com/supabase/auth-js/pull/1011
Author: @j4w8n 

## What kind of change does this PR introduce?

Minor type fix.

## What is the current behavior?

If a user has multiple providers associated with them, then Supabase adds a `providers` string array to their `user.app_metadata`, but this is missing from the `UserAppMetadata` type. I just happened to notice this while trying to work around an issue in a demo app, and there was no `providers` intellisense in my IDE.

![image](https://github.com/user-attachments/assets/744d51bf-e4a5-4f59-96ef-55222d984995)

## What is the new behavior?

A `providers?: string[]` type is added to the interface.

## Additional context

An example of multiple providers being associated to a user is if the user signs up with email/password, but then is allowed to add a phone number as well.
