### PR TITLE
fix(storage): correct list v2 types to correctly match data returned from api

### DIFF
--- a/packages/core/storage-js/src/lib/types.ts
+++ b/packages/core/storage-js/src/lib/types.ts
@@ -143,10 +143,25 @@ export interface SearchV2Options {
   sortBy?: SortByV2
 }
 
+export interface SearchV2Object {
+  id: string
+  key: string
+  name: string
+  updated_at: string
+  created_at: string
+  metadata: Record<string, any>
+  /**
+   * @deprecated
+   */
+  last_accessed_at: string
+}
+
+export type SearchV2Folder = Omit<SearchV2Object, 'id' | 'metadata' | 'last_accessed_at'>
+
 export interface SearchV2Result {
   hasNext: boolean
-  folders: { name: string }[]
-  objects: FileObject[]
+  folders: SearchV2Folder[]
+  objects: SearchV2Object[]
   nextCursor?: string
 }
 


### PR DESCRIPTION
## 🔍 Description

Update list v2 types to correctly match data returned from api

### What changed?

The object/folder types used in the List V2 endpoint do not match the actual data returned

<img width="412" height="376" alt="Screenshot 2025-10-09 at 11 26 28 AM" src="https://github.com/user-attachments/assets/0ee5bb2f-8db0-40e4-ab66-56cb0675063d" />
