### PR TITLE
chore(repo): update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -13,7 +13,7 @@
 
 # Core packages - each library has specific owners
 /packages/core/auth-js/ @supabase/client-libs @supabase/auth
-/packages/core/functions-js/ @supabase/client-libs @supabase/edge-functions @supabase/pg-functions
+/packages/core/functions-js/ @supabase/client-libs @supabase/edge-functions
 /packages/core/postgrest-js/ @supabase/client-libs @supabase/postgrest
 /packages/core/realtime-js/ @supabase/client-libs @supabase/realtime
 /packages/core/storage-js/ @supabase/client-libs @supabase/storage


### PR DESCRIPTION
`functions-js` is owned by Edge Functions, @supabase/pg-functions doesn't maintain any client lib