### PR TITLE
fix(auth): use direct attestation for registration/authentication

### DIFF
--- a/packages/core/auth-js/src/lib/webauthn.ts
+++ b/packages/core/auth-js/src/lib/webauthn.ts
@@ -462,13 +462,14 @@ export const DEFAULT_CREATION_OPTIONS: Partial<PublicKeyCredentialCreationOption
     userVerification: 'preferred',
     residentKey: 'discouraged',
   },
-  attestation: 'none',
+  attestation: 'direct',
 }
 
 export const DEFAULT_REQUEST_OPTIONS: Partial<PublicKeyCredentialRequestOptionsFuture> = {
   /** set to preferred because older yubikeys don't have PIN/Biometric */
   userVerification: 'preferred',
   hints: ['security-key'],
+  attestation: 'direct',
 }
 
 function deepMerge<T>(...sources: Partial<T>[]): T {


### PR DESCRIPTION
Moved from: https://github.com/supabase/auth-js/pull/1126
Author: @Bewinxed 

## What kind of change does this PR introduce?

Fix/Enhancement

## What is the current behavior?

The WebAuthn implementation currently sets `attestation: 'none'` in the default creation options, which means the authenticator doesn't provide any attestation statement during registration.
As per [Yubico's Recommendation](https://developers.yubico.com/WebAuthn/WebAuthn_Developer_Guide/WebAuthn_Client_Registration.html), this should be set to `direct` to allow us access to the make/model/version of the security keys being used. [More Info](https://developers.yubico.com/WebAuthn/WebAuthn_Developer_Guide/Attestation.html)

- Whether the authenticator is genuine (not a software emulator)
- The authenticator's make/model/manufacturer
- Whether it meets security requirements for the application

## What is the new behavior?

Changed `attestation` from `'none'` to `'direct'` in `DEFAULT_CREATION_OPTIONS`.

## Additional context

With `attestation: 'direct'`, the server can Verify authenticator make/model and possibly reject unknown models using the AAGUID of the security key.﻿
