### PR TITLE
fix(auth): make webauthn param optional and move register params to webauthn

### DIFF
--- a/packages/core/auth-js/src/lib/webauthn.ts
+++ b/packages/core/auth-js/src/lib/webauthn.ts
@@ -763,10 +763,10 @@ export class WebAuthnApi {
         rpId = typeof window !== 'undefined' ? window.location.hostname : undefined,
         rpOrigins = typeof window !== 'undefined' ? [window.location.origin] : undefined,
         signal,
-      },
+      } = {},
     }: {
       factorId: string
-      webauthn: {
+      webauthn?: {
         rpId?: string
         rpOrigins?: string[]
         signal?: AbortSignal
@@ -844,14 +844,18 @@ export class WebAuthnApi {
   public async _register(
     {
       friendlyName,
-      rpId = typeof window !== 'undefined' ? window.location.hostname : undefined,
-      rpOrigins = typeof window !== 'undefined' ? [window.location.origin] : undefined,
-      signal,
+      webauthn: {
+        rpId = typeof window !== 'undefined' ? window.location.hostname : undefined,
+        rpOrigins = typeof window !== 'undefined' ? [window.location.origin] : undefined,
+        signal,
+      } = {},
     }: {
       friendlyName: string
-      rpId?: string
-      rpOrigins?: string[]
-      signal?: AbortSignal
+      webauthn?: {
+        rpId?: string
+        rpOrigins?: string[]
+        signal?: AbortSignal
+      }
     },
     overrides?: Partial<PublicKeyCredentialCreationOptionsFuture>
   ): Promise<RequestResult<AuthMFAVerifyResponseData, WebAuthnError | AuthError>> {


### PR DESCRIPTION
Moved from: https://github.com/supabase/auth-js/pull/1125
Author: @Bewinxed 

## What kind of change does this PR introduce?

fix: make webauthn param optional in .authenticate() and .register() and move register params to webauthn: object for consistency

Bug fix / API improvement

## What is the current behavior?

The `webauthn` parameter in the `_authenticate()` method is required, and the `_register()` method has WebAuthn-related parameters (`rpId`, `rpOrigins`, `signal`) at the top level instead of being grouped under a `webauthn` object.

## What is the new behavior?

- Made the `webauthn` parameter optional in `_authenticate()` method with default empty object fallback
- Moved WebAuthn-related parameters in `_register()` method into a `webauthn` object for consistency with `_authenticate()` 
- Both methods now have consistent API signatures with optional `webauthn` parameter

## Additional context

None.
