### PR TITLE
fix(auth): only warn if multiple clients share a storage-key

### DIFF
--- a/packages/core/auth-js/test/GoTrueClient.browser.test.ts
+++ b/packages/core/auth-js/test/GoTrueClient.browser.test.ts
@@ -2,7 +2,12 @@
  * @jest-environment jsdom
  */
 
-import { autoRefreshClient, getClientWithSpecificStorage, pkceClient } from './lib/clients'
+import {
+  autoRefreshClient,
+  getClientWithSpecificStorage,
+  getClientWithSpecificStorageKey,
+  pkceClient,
+} from './lib/clients'
 import { mockUserCredentials } from './lib/utils'
 import {
   supportsLocalStorage,
@@ -173,6 +178,94 @@ describe('Fetch resolution in browser environment', () => {
     const customFetch = jest.fn()
     const resolvedFetch = resolveFetch(customFetch)
     expect(typeof resolvedFetch).toBe('function')
+  })
+
+  it('should warn when two clients are created with the same storage key', () => {
+    let consoleWarnSpy
+    let consoleTraceSpy
+    try {
+      consoleWarnSpy = jest.spyOn(console, 'warn')
+      consoleTraceSpy = jest.spyOn(console, 'trace')
+      getClientWithSpecificStorageKey('same-storage-key')
+      getClientWithSpecificStorageKey('same-storage-key')
+      expect(consoleWarnSpy).toHaveBeenCalledTimes(1)
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringMatching(
+          /GoTrueClient@same-storage-key:1 .* Multiple GoTrueClient instances detected in the same browser context. It is not an error, but this should be avoided as it may produce undefined behavior when used concurrently under the same storage key./
+        )
+      )
+      expect(consoleTraceSpy).not.toHaveBeenCalled()
+    } finally {
+      consoleWarnSpy?.mockRestore()
+      consoleTraceSpy?.mockRestore()
+    }
+  })
+
+  it('should warn & trace when two clients are created with the same storage key and debug is enabled', () => {
+    let consoleWarnSpy
+    let consoleTraceSpy
+    try {
+      consoleWarnSpy = jest.spyOn(console, 'warn')
+      consoleTraceSpy = jest.spyOn(console, 'trace')
+      getClientWithSpecificStorageKey('identical-storage-key')
+      getClientWithSpecificStorageKey('identical-storage-key', { debug: true })
+      expect(consoleWarnSpy).toHaveBeenCalledTimes(1)
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringMatching(
+          /GoTrueClient@identical-storage-key:1 .* Multiple GoTrueClient instances detected in the same browser context. It is not an error, but this should be avoided as it may produce undefined behavior when used concurrently under the same storage key./
+        )
+      )
+      expect(consoleTraceSpy).toHaveBeenCalledWith(
+        expect.stringMatching(
+          /GoTrueClient@identical-storage-key:1 .* Multiple GoTrueClient instances detected in the same browser context. It is not an error, but this should be avoided as it may produce undefined behavior when used concurrently under the same storage key./
+        )
+      )
+    } finally {
+      consoleWarnSpy?.mockRestore()
+      consoleTraceSpy?.mockRestore()
+    }
+  })
+
+  it('should not warn when two clients are created with differing storage keys', () => {
+    let consoleWarnSpy
+    let consoleTraceSpy
+    try {
+      consoleWarnSpy = jest.spyOn(console, 'warn')
+      consoleTraceSpy = jest.spyOn(console, 'trace')
+      getClientWithSpecificStorageKey('first-storage-key')
+      getClientWithSpecificStorageKey('second-storage-key')
+      expect(consoleWarnSpy).not.toHaveBeenCalled()
+      expect(consoleTraceSpy).not.toHaveBeenCalled()
+    } finally {
+      consoleWarnSpy?.mockRestore()
+      consoleTraceSpy?.mockRestore()
+    }
+  })
+
+  it('should warn only when a second client with a duplicate key is created', () => {
+    let consoleWarnSpy
+    let consoleTraceSpy
+    try {
+      consoleWarnSpy = jest.spyOn(console, 'warn')
+      consoleTraceSpy = jest.spyOn(console, 'trace')
+      getClientWithSpecificStorageKey('test-storage-key1')
+      expect(consoleWarnSpy).not.toHaveBeenCalled()
+      getClientWithSpecificStorageKey('test-storage-key2')
+      expect(consoleWarnSpy).not.toHaveBeenCalled()
+      getClientWithSpecificStorageKey('test-storage-key3')
+      expect(consoleWarnSpy).not.toHaveBeenCalled()
+      getClientWithSpecificStorageKey('test-storage-key2')
+      expect(consoleWarnSpy).toHaveBeenCalledTimes(1)
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringMatching(
+          /GoTrueClient@test-storage-key2:1 .* Multiple GoTrueClient instances detected in the same browser context. It is not an error, but this should be avoided as it may produce undefined behavior when used concurrently under the same storage key./
+        )
+      )
+      expect(consoleTraceSpy).not.toHaveBeenCalled()
+    } finally {
+      consoleWarnSpy?.mockRestore()
+      consoleTraceSpy?.mockRestore()
+    }
   })
 })
 

--- a/packages/core/auth-js/test/lib/clients.ts
+++ b/packages/core/auth-js/test/lib/clients.ts
@@ -1,5 +1,5 @@
 import jwt from 'jsonwebtoken'
-import { GoTrueAdminApi, GoTrueClient } from '../../src/index'
+import { GoTrueAdminApi, GoTrueClient, type GoTrueClientOptions } from '../../src/index'
 import { SupportedStorage } from '../../src/lib/types'
 
 export const SIGNUP_ENABLED_AUTO_CONFIRM_OFF_PORT = 9999
@@ -154,5 +154,18 @@ export function getClientWithSpecificStorage(storage: SupportedStorage) {
     autoRefreshToken: false,
     persistSession: true,
     storage,
+  })
+}
+
+export function getClientWithSpecificStorageKey(
+  storageKey: string,
+  opts: GoTrueClientOptions = {}
+) {
+  return new GoTrueClient({
+    url: GOTRUE_URL_SIGNUP_ENABLED_AUTO_CONFIRM_ON,
+    autoRefreshToken: false,
+    persistSession: true,
+    storageKey,
+    ...opts,
   })
 }


### PR DESCRIPTION
<!-- Your PR title should follow the conventional commit format:
<type>(<scope>): <description> -->

## 🔍 Description

This allows use of multiple clients with different storage-keys, without the `Multiple GoTrueClient instances detected in the same browser context. It is not an error, but this should be avoided as it may produce undefined behavior when used concurrently under the same storage key.` warning appearing.

### What changed?
- The storageKey has also been added to the prefix of the debug messages to help with tracing.
```diff
- GoTrueClient@0 (0.0.0) 2025-08-13T21:51:25.839Z #_acquireLock begin -1
+ GoTrueClient@sb-127-auth-token:0 (0.0.0) 2025-08-13T21:51:25.839Z #_acquireLock begin -1
```
- The same prefix has been added to the warning for consistency.
```diff
- Multiple GoTrueClient instances detected in the same browser context. It is not an error, but this should be avoided as it may produce undefined behavior when used concurrently under the same storage key.
+ GoTrueClient@sb-127-auth-token:1 (0.0.0) 2025-08-13T21:51:26.455Z Multiple GoTrueClient instances detected in the same browser context. It is not an error, but this should be avoided as it may produce undefined behavior when used concurrently under the same storage key.
```
- If debug messages are enabled, the warning will also output a trace in addition to the warning to assist the user in tracking down where their multiple instances are being created from.
```diff
- Multiple GoTrueClient instances detected in the same browser context. It is not an error, but this should be avoided as it may produce undefined behavior when used concurrently under the same storage key.
+ GoTrueClient@sb-127-auth-token:1 (0.0.0) 2025-08-13T21:51:26.455Z Multiple GoTrueClient instances detected in the same browser context. It is not an error, but this should be avoided as it may produce undefined behavior when used concurrently under the same storage key.
+ Trace: GoTrueClient@sb-127-auth-token:1 (0.0.0) 2025-08-13T21:51:26.455Z Multiple GoTrueClient instances detected in the same browser context. It is not an error, but this should be avoided as it may produce undefined behavior when used concurrently under the same storage key.
+    at new GoTrueClient (/home/user/dev/auth-js/src/GoTrueClient.ts:256:17)
+    at new SupabaseAuthClient (/home/user/dev/node_modules/.pnpm/@supabase+supabase-js@2.55.0/node_modules/@supabase/supabase-js/src/lib/SupabaseAuthClient.ts:6:5)
+    at SupabaseClient._initSupabaseAuthClient (/home/user/dev/node_modules/.pnpm/@supabase+supabase-js@2.55.0/node_modules/@supabase/supabase-js/src/SupabaseClient.ts:304:12)
+    at new SupabaseClient (/home/user/dev/node_modules/.pnpm/@supabase+supabase-js@2.55.0/node_modules/@supabase/supabase-js/src/SupabaseClient.ts:107:24)
+    at createClient (/home/user/dev/node_modules/.pnpm/@supabase+supabase-js@2.55.0/node_modules/@supabase/supabase-js/src/index.ts:40:10)
+    at createBrowserClient (/home/user/dev/node_modules/.pnpm/@supabase+ssr@0.6.1_@supabase+supabase-js@2.55.0/node_modules/@supabase/ssr/src/createBrowserClient.ts:121:30)
+    at createBrowserClient (/home/user/dev/lib/supabase/client.ts:16:10)
+    at /home/user/dev/mycode/thatCreatesAClient.ts:16:29
+    at processTicksAndRejections (node:internal/process/task_queues:105:5)
+    at file:///home/user/dev/node_modules/.pnpm/@vitest+runner@3.2.4/node_modules/@vitest/runner/dist/chunk-hooks.js:752:20
```

### Why was this change needed?

My specific use case for this is in tests where I want to have multiple clients running in parallel. One of them sets up fixtures and uses the service role, others represent different users. The nature of the tests is that they all run in the same instance, so the warning was appearing. Now I can instantiate the clients with unique storage keys and the warning will only appear if I actually have multiple clients that share those storage keys.

Closes [#(issue_number)](https://github.com/supabase/auth-js/issues/725#issuecomment-1656702626) <!-- If applicable -->
[PR in old repo](https://github.com/supabase/auth-js/pull/1100)
## 📸 Screenshots/Examples

```typescript
// example with supabase-js / ssr
import { createClient  } from "@supabase/supabase-js";
import { createBrowserClient  } from "@supabase/supabase-ssr";
const fixturesClient = createClient(supabaseUrl, serviceRoleKey, { auth: { storageKey: "FIXTURES_CLIENT"}});
// create fixtures
const userClient = createBrowserClient(supabaseUrl, anonKey, { auth: { storageKey: "USER"}});
// login user 
await userClient.auth.signInWithPassword({ email, password})
```


## 🔄 Breaking changes

<!-- If this PR contains breaking changes, describe them here -->

- [x] This PR contains no breaking changes

## 📋 Checklist

<!-- Ensure all items are checked before submitting -->

- [x] I have read the [Contributing Guidelines](https://github.com/supabase/supabase-js/blob/master/CONTRIBUTING.md)
- [x] My PR title follows the [conventional commit format](https://www.conventionalcommits.org/): `<type>(<scope>): <description>`
- [x] I have run `npx nx format` to ensure consistent code formatting
- [x] I have added tests for new functionality (if applicable)
- [x] I have updated documentation (if applicable)

## 📝 Additional notes

<!-- Add any additional notes, context, or concerns for reviewers -->

<!-- Thank you for contributing to Supabase! 💚 -->
