### PR TITLE
fix(auth): handle 204 No Content response in OAuth client delete

### DIFF
--- a/packages/core/auth-js/src/GoTrueAdminApi.ts
+++ b/packages/core/auth-js/src/GoTrueAdminApi.ts
@@ -463,7 +463,9 @@ export default class GoTrueAdminApi {
    *
    * This function should only be called on a server. Never expose your `service_role` key in the browser.
    */
-  private async _deleteOAuthClient(clientId: string): Promise<OAuthClientResponse> {
+  private async _deleteOAuthClient(
+    clientId: string
+  ): Promise<{ data: null; error: AuthError | null }> {
     try {
       await _request(
         this.fetch,

--- a/packages/core/auth-js/src/lib/types.ts
+++ b/packages/core/auth-js/src/lib/types.ts
@@ -1580,7 +1580,7 @@ export interface GoTrueAdminOAuthApi {
    *
    * This function should only be called on a server. Never expose your `service_role` key in the browser.
    */
-  deleteClient(clientId: string): Promise<OAuthClientResponse>
+  deleteClient(clientId: string): Promise<{ data: null; error: AuthError | null }>
 
   /**
    * Regenerates the secret for an OAuth client.


### PR DESCRIPTION
Fixes OAuth client delete endpoint attempting to parse empty 204 No Content response body. Follows same pattern as `signOut` method