### PR TITLE
feat(auth): add OAuth 2.1 authorization consent management API calls

### DIFF
--- a/packages/core/auth-js/src/lib/types.ts
+++ b/packages/core/auth-js/src/lib/types.ts
@@ -1590,3 +1590,103 @@ export interface GoTrueAdminOAuthApi {
    */
   regenerateClientSecret(clientId: string): Promise<OAuthClientResponse>
 }
+
+/**
+ * OAuth client details in an authorization request.
+ * Only relevant when the OAuth 2.1 server is enabled in Supabase Auth.
+ */
+export type OAuthAuthorizationClient = {
+  /** Unique identifier for the OAuth client (UUID) */
+  client_id: string
+  /** Human-readable name of the OAuth client */
+  client_name: string
+  /** URI of the OAuth client's website */
+  client_uri: string
+  /** URI of the OAuth client's logo */
+  logo_uri: string
+}
+
+/**
+ * OAuth authorization details for the consent flow.
+ * Only relevant when the OAuth 2.1 server is enabled in Supabase Auth.
+ */
+export type OAuthAuthorizationDetails = {
+  /** The authorization ID */
+  authorization_id: string
+  /** Redirect URI - present if user already consented (can be used to trigger immediate redirect) */
+  redirect_uri?: string
+  /** OAuth client requesting authorization */
+  client: OAuthAuthorizationClient
+  /** User object associated with the authorization */
+  user: {
+    /** User ID (UUID) */
+    id: string
+    /** User email */
+    email: string
+  }
+  /** Space-separated list of requested scopes */
+  scope: string
+}
+
+/**
+ * Response type for getting OAuth authorization details.
+ * Only relevant when the OAuth 2.1 server is enabled in Supabase Auth.
+ */
+export type AuthOAuthAuthorizationDetailsResponse = RequestResult<OAuthAuthorizationDetails>
+
+/**
+ * Response type for OAuth consent decision (approve/deny).
+ * Only relevant when the OAuth 2.1 server is enabled in Supabase Auth.
+ */
+export type AuthOAuthConsentResponse = RequestResult<{
+  /** URL to redirect the user back to the OAuth client */
+  redirect_url: string
+}>
+
+/**
+ * Contains all OAuth 2.1 authorization server user-facing methods.
+ * Only relevant when the OAuth 2.1 server is enabled in Supabase Auth.
+ *
+ * These methods are used to implement the consent page.
+ */
+export interface AuthOAuthServerApi {
+  /**
+   * Retrieves details about an OAuth authorization request.
+   * Used to display consent information to the user.
+   * Only relevant when the OAuth 2.1 server is enabled in Supabase Auth.
+   *
+   * @param authorizationId - The authorization ID from the authorization request
+   * @param options - Optional parameters including skipBrowserRedirect
+   * @returns Authorization details including client info and requested scopes
+   */
+  getAuthorizationDetails(
+    authorizationId: string,
+    options?: { skipBrowserRedirect?: boolean }
+  ): Promise<AuthOAuthAuthorizationDetailsResponse>
+
+  /**
+   * Approves an OAuth authorization request.
+   * Only relevant when the OAuth 2.1 server is enabled in Supabase Auth.
+   *
+   * @param authorizationId - The authorization ID to approve
+   * @param options - Optional parameters including skipBrowserRedirect
+   * @returns Redirect URL to send the user back to the OAuth client
+   */
+  approveAuthorization(
+    authorizationId: string,
+    options?: { skipBrowserRedirect?: boolean }
+  ): Promise<AuthOAuthConsentResponse>
+
+  /**
+   * Denies an OAuth authorization request.
+   * Only relevant when the OAuth 2.1 server is enabled in Supabase Auth.
+   *
+   * @param authorizationId - The authorization ID to deny
+   * @param options - Optional parameters including skipBrowserRedirect
+   * @returns Redirect URL to send the user back to the OAuth client
+   */
+  denyAuthorization(
+    authorizationId: string,
+    options?: { skipBrowserRedirect?: boolean }
+  ): Promise<AuthOAuthConsentResponse>
+}


### PR DESCRIPTION
## Summary

  Adds user-facing OAuth authorization methods to `@supabase/auth-js` for building consent pages when Supabase Auth acts as an OAuth 2.1 authorization server.

  Implements the **consent flow** where users approve/deny OAuth client authorization requests.

  ## New API

  ### Namespace: `auth.oauth.*`

  Three new methods for managing OAuth authorization consent:

  ```typescript
  // Get authorization details (client info, scopes, user)
  const { data, error } = await supabase.auth.oauth.getAuthorizationDetails(
    authorizationId,
    { skipBrowserRedirect?: boolean }
  )

  // Approve authorization request
  const { data, error } = await supabase.auth.oauth.approveAuthorization(
    authorizationId,
    { skipBrowserRedirect?: boolean }
  )

  // Deny authorization request
  const { data, error } = await supabase.auth.oauth.denyAuthorization(
    authorizationId,
    { skipBrowserRedirect?: boolean }
  )
```

## Use Case

Enables developers to build custom OAuth consent pages for their Supabase projects when acting as an OAuth 2.1 authorization server. Example flow:

  1. User is redirected to consent page with `authorization_id` in URL
  2. App calls `getAuthorizationDetails(authorizationId)` to fetch client and scope info
  3. User reviews and clicks "Approve" or "Deny"
  4. App calls `approveAuthorization()` or `denyAuthorization()`
  5. SDK auto-redirects back to OAuth client with authorization code/error

## What's NOT Included

Third-party OAuth client integration (calling `/oauth/authorize` and `/oauth/token` from external apps) is intentionally not included in this PR.

Rationale:
  - Standard OAuth 2.1 client libraries already handle this well
  - Would require full OAuth client lifecycle (refresh tokens, expiration, storage)
  - Better served by documentation + existing OAuth libraries
  - This PR focuses on the unique Supabase-specific consent management API, utilizing the existing Supabase session

Third-party integration will be addressed through comprehensive documentation showing how to use standard OAuth client libraries with Supabase Auth endpoints.

## Breaking Changes

None. This is a purely additive change with zero breaking changes to existing APIs