### PR TITLE
chore(ci): remove concurrency from workflows

### DIFF
--- a/.github/workflows/ci-auth-js-node18.yml
+++ b/.github/workflows/ci-auth-js-node18.yml
@@ -15,10 +15,6 @@ on:
       - '!packages/core/auth-js/*ignore'
   workflow_call:
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
-
 permissions:
   actions: read
   contents: read

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -19,10 +19,6 @@ on:
       - '!packages/**/*ignore'
   workflow_call:
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
-
 permissions:
   actions: read
   contents: read

--- a/.github/workflows/ci-supabase-js.yml
+++ b/.github/workflows/ci-supabase-js.yml
@@ -15,10 +15,6 @@ on:
       - '!packages/**/*ignore'
   workflow_call:
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
-
 env:
   NODE_VERSION: '20'
 


### PR DESCRIPTION
Concurrency cancelled workflows on `master`. Need to read a bit more on how to configure it correctly. We can skip it for now.