### PR TITLE
fix(storage): error message analytics bucket

### DIFF
--- a/packages/core/storage-js/src/lib/fetch.ts
+++ b/packages/core/storage-js/src/lib/fetch.ts
@@ -15,7 +15,11 @@ export interface FetchOptions {
 export type RequestMethodType = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'HEAD'
 
 const _getErrorMessage = (err: any): string =>
-  err.msg || err.message || err.error_description || (typeof err.error === 'string' ? err.error : err.error?.message ) || JSON.stringify(err)
+  err.msg ||
+  err.message ||
+  err.error_description ||
+  (typeof err.error === 'string' ? err.error : err.error?.message) ||
+  JSON.stringify(err)
 
 const handleError = async (
   error: unknown,


### PR DESCRIPTION
### Error handling

- Fix error message for analytics buckets. The analytics bucket spec adds an error: to level field.