### PR TITLE
feat(auth): add OAuth client update support

### DIFF
--- a/packages/core/auth-js/src/GoTrueAdminApi.ts
+++ b/packages/core/auth-js/src/GoTrueAdminApi.ts
@@ -23,6 +23,7 @@ import {
   SignOutScope,
   GoTrueAdminOAuthApi,
   CreateOAuthClientParams,
+  UpdateOAuthClientParams,
   OAuthClientResponse,
   OAuthClientListResponse,
 } from './lib/types'
@@ -66,6 +67,7 @@ export default class GoTrueAdminApi {
       listClients: this._listOAuthClients.bind(this),
       createClient: this._createOAuthClient.bind(this),
       getClient: this._getOAuthClient.bind(this),
+      updateClient: this._updateOAuthClient.bind(this),
       deleteClient: this._deleteOAuthClient.bind(this),
       regenerateClientSecret: this._regenerateOAuthClientSecret.bind(this),
     }
@@ -414,9 +416,7 @@ export default class GoTrueAdminApi {
    *
    * This function should only be called on a server. Never expose your `service_role` key in the browser.
    */
-  private async _createOAuthClient(
-    params: CreateOAuthClientParams
-  ): Promise<OAuthClientResponse> {
+  private async _createOAuthClient(params: CreateOAuthClientParams): Promise<OAuthClientResponse> {
     try {
       return await _request(this.fetch, 'POST', `${this.url}/admin/oauth/clients`, {
         body: params,
@@ -458,6 +458,33 @@ export default class GoTrueAdminApi {
   }
 
   /**
+   * Updates an existing OAuth client.
+   * Only relevant when the OAuth 2.1 server is enabled in Supabase Auth.
+   *
+   * This function should only be called on a server. Never expose your `service_role` key in the browser.
+   */
+  private async _updateOAuthClient(
+    clientId: string,
+    params: UpdateOAuthClientParams
+  ): Promise<OAuthClientResponse> {
+    try {
+      return await _request(this.fetch, 'PUT', `${this.url}/admin/oauth/clients/${clientId}`, {
+        body: params,
+        headers: this.headers,
+        xform: (client: any) => {
+          return { data: client, error: null }
+        },
+      })
+    } catch (error) {
+      if (isAuthError(error)) {
+        return { data: null, error }
+      }
+
+      throw error
+    }
+  }
+
+  /**
    * Deletes an OAuth client.
    * Only relevant when the OAuth 2.1 server is enabled in Supabase Auth.
    *
@@ -467,15 +494,10 @@ export default class GoTrueAdminApi {
     clientId: string
   ): Promise<{ data: null; error: AuthError | null }> {
     try {
-      await _request(
-        this.fetch,
-        'DELETE',
-        `${this.url}/admin/oauth/clients/${clientId}`,
-        {
-          headers: this.headers,
-          noResolveJson: true,
-        }
-      )
+      await _request(this.fetch, 'DELETE', `${this.url}/admin/oauth/clients/${clientId}`, {
+        headers: this.headers,
+        noResolveJson: true,
+      })
       return { data: null, error: null }
     } catch (error) {
       if (isAuthError(error)) {

--- a/packages/core/auth-js/src/lib/types.ts
+++ b/packages/core/auth-js/src/lib/types.ts
@@ -1492,6 +1492,8 @@ export type OAuthClient = {
   registration_type: OAuthClientRegistrationType
   /** URI of the OAuth client */
   client_uri?: string
+  /** URI of the OAuth client's logo */
+  logo_uri?: string
   /** Array of allowed redirect URIs */
   redirect_uris: string[]
   /** Array of allowed grant types */
@@ -1523,6 +1525,24 @@ export type CreateOAuthClientParams = {
   response_types?: OAuthClientResponseType[]
   /** Scope of the OAuth client */
   scope?: string
+}
+
+/**
+ * Parameters for updating an existing OAuth client.
+ * All fields are optional. Only provided fields will be updated.
+ * Only relevant when the OAuth 2.1 server is enabled in Supabase Auth.
+ */
+export type UpdateOAuthClientParams = {
+  /** Human-readable name of the OAuth client */
+  client_name?: string
+  /** URI of the OAuth client */
+  client_uri?: string
+  /** URI of the OAuth client's logo */
+  logo_uri?: string
+  /** Array of allowed redirect URIs */
+  redirect_uris?: string[]
+  /** Array of allowed grant types */
+  grant_types?: OAuthClientGrantType[]
 }
 
 /**
@@ -1573,6 +1593,14 @@ export interface GoTrueAdminOAuthApi {
    * This function should only be called on a server. Never expose your `service_role` key in the browser.
    */
   getClient(clientId: string): Promise<OAuthClientResponse>
+
+  /**
+   * Updates an existing OAuth client.
+   * Only relevant when the OAuth 2.1 server is enabled in Supabase Auth.
+   *
+   * This function should only be called on a server. Never expose your `service_role` key in the browser.
+   */
+  updateClient(clientId: string, params: UpdateOAuthClientParams): Promise<OAuthClientResponse>
 
   /**
    * Deletes an OAuth client.


### PR DESCRIPTION
 ## Summary

Add support for updating existing OAuth clients through the admin API by implementing the `PUT /admin/oauth/clients/{client_id}` endpoint.

This change enables admins to modify OAuth client properties such as name, URIs, logo, redirect URIs, and grant types without having to delete and recreate the client.

Relevant: https://github.com/supabase/auth/pull/2231