### PR TITLE
chore(ci): format changelogs before commiting

### DIFF
--- a/scripts/release-stable.ts
+++ b/scripts/release-stable.ts
@@ -185,6 +185,10 @@ function safeExec(cmd: string, opts = {}) {
   const branchName = `release-${version}`
 
   try {
+    // Format generated changelogs before committing
+    console.log('\n✨ Formatting generated changelogs...')
+    safeExec('npx nx format:write')
+    console.log('✅ Changelogs formatted\n')
     safeExec(`git checkout -b ${branchName}`)
     safeExec('git add CHANGELOG.md || true')
     safeExec('git add packages/**/CHANGELOG.md || true')


### PR DESCRIPTION
Format changelogs before commiting, or else the `pre-push` hook will block the push, as happened [here](https://github.com/supabase/supabase-js/actions/runs/18902390075/job/53952478115).