### PR TITLE
feat(supabase): add opt-in header inclusion in realtime WebSocket params

### DIFF
--- a/packages/core/supabase-js/src/lib/types.ts
+++ b/packages/core/supabase-js/src/lib/types.ts
@@ -82,7 +82,23 @@ export type SupabaseClientOptions<SchemaName> = {
   /**
    * Options passed to the realtime-js instance
    */
-  realtime?: RealtimeClientOptions
+  realtime?: RealtimeClientOptions & {
+    /**
+     * Array of header names from `global.headers` to include as WebSocket query parameters.
+     * This enables RLS policies that check `request.headers` to work with realtime subscriptions.
+     *
+     * @example
+     * ```typescript
+     * createClient(url, key, {
+     *   global: { headers: { 'x-tenant-id': 'tenant-123' } },
+     *   realtime: { includeHeadersInParams: ['x-tenant-id'] }
+     * })
+     * ```
+     *
+     * Security: Only explicitly listed headers are included. Avoid including sensitive data.
+     */
+    includeHeadersInParams?: string[]
+  }
   storage?: StorageClientOptions
   global?: {
     /**

--- a/packages/core/supabase-js/test/unit/SupabaseClient.test.ts
+++ b/packages/core/supabase-js/test/unit/SupabaseClient.test.ts
@@ -188,6 +188,113 @@ describe('SupabaseClient', () => {
     })
   })
 
+  describe('Realtime Headers in Params', () => {
+    test('should copy specified headers to realtime params', () => {
+      const client = createClient(URL, KEY, {
+        global: {
+          headers: {
+            'x-tenant-id': 'tenant-123',
+            'x-other-header': 'other-value',
+          },
+        },
+        realtime: {
+          includeHeadersInParams: ['x-tenant-id'],
+        },
+      })
+
+      // @ts-ignore - accessing private property
+      expect(client.realtime.params['x-tenant-id']).toBe('tenant-123')
+      // @ts-ignore - accessing private property
+      expect(client.realtime.params['x-other-header']).toBeUndefined()
+    })
+
+    test('should not copy headers if includeHeadersInParams is not specified', () => {
+      const client = createClient(URL, KEY, {
+        global: {
+          headers: {
+            'x-tenant-id': 'tenant-123',
+          },
+        },
+      })
+
+      // @ts-ignore - accessing private property
+      expect(client.realtime.params['x-tenant-id']).toBeUndefined()
+    })
+
+    test('should allow explicit realtime params to override headers', () => {
+      const client = createClient(URL, KEY, {
+        global: {
+          headers: {
+            'x-tenant-id': 'tenant-from-header',
+          },
+        },
+        realtime: {
+          includeHeadersInParams: ['x-tenant-id'],
+          params: {
+            'x-tenant-id': 'tenant-override',
+          },
+        },
+      })
+
+      // @ts-ignore - accessing private property
+      expect(client.realtime.params['x-tenant-id']).toBe('tenant-override')
+    })
+
+    test('should handle missing headers gracefully', () => {
+      const client = createClient(URL, KEY, {
+        global: {
+          headers: {
+            'x-existing': 'value',
+          },
+        },
+        realtime: {
+          includeHeadersInParams: ['x-non-existent', 'x-existing'],
+        },
+      })
+
+      // @ts-ignore - accessing private property
+      expect(client.realtime.params['x-non-existent']).toBeUndefined()
+      // @ts-ignore - accessing private property
+      expect(client.realtime.params['x-existing']).toBe('value')
+    })
+
+    test('should handle empty includeHeadersInParams array', () => {
+      const client = createClient(URL, KEY, {
+        global: {
+          headers: {
+            'x-tenant-id': 'tenant-123',
+          },
+        },
+        realtime: {
+          includeHeadersInParams: [],
+        },
+      })
+
+      // @ts-ignore - accessing private property
+      expect(client.realtime.params['x-tenant-id']).toBeUndefined()
+    })
+
+    test('should maintain backward compatibility when no includeHeadersInParams', () => {
+      const client = createClient(URL, KEY, {
+        global: {
+          headers: {
+            'x-tenant-id': 'tenant-123',
+          },
+        },
+        realtime: {
+          params: {
+            'custom-param': 'custom-value',
+          },
+        },
+      })
+
+      // @ts-ignore - accessing private property
+      expect(client.realtime.params['custom-param']).toBe('custom-value')
+      // @ts-ignore - accessing private property
+      expect(client.realtime.params['x-tenant-id']).toBeUndefined()
+    })
+  })
+
   describe('Schema Management', () => {
     test('should switch schema', () => {
       const client = createClient<Database>(URL, KEY)


### PR DESCRIPTION
## Summary
Adds opt-in support for including `global.headers` in Realtime WebSocket query params, enabling RLS policies that check `request.headers` to work with realtime subscriptions.

Usage:

```typescript
  createClient(url, key, {
    global: { headers: { 'x-tenant-id': 'tenant-123' } },
    realtime: { includeHeadersInParams: ['x-tenant-id'] }
  })
```

## Changes
- New `realtime.includeHeadersInParams` option in `createClient()`
- Specified headers are copied to WebSocket URL as query params
- Fully backward compatible (opt-in only)

## Use Case
Enables multi-tenant patterns where tenant context is passed via headers (e.g., `x-tenant-id`) to work with realtime subscriptions, addressing issue #1797.