### PR TITLE
test(functions): resolve flaky test failures from Docker exec cleanup race condition

### DIFF
--- a/packages/core/functions-js/test/spec/hello.spec.ts
+++ b/packages/core/functions-js/test/spec/hello.spec.ts
@@ -18,7 +18,9 @@ describe('basic tests (hello function)', () => {
   })
 
   afterAll(async () => {
-    relay && relay.container && (await relay.container.stop())
+    if (relay) {
+      await relay.stop()
+    }
   })
 
   test('invoke hello with auth header', async () => {

--- a/packages/core/functions-js/test/spec/hijack.spec.ts
+++ b/packages/core/functions-js/test/spec/hijack.spec.ts
@@ -18,7 +18,9 @@ describe('hijack connection', () => {
   })
 
   afterAll(async () => {
-    relay && relay.container && (await relay.container.stop())
+    if (relay) {
+      await relay.stop()
+    }
   })
 
   test('invoke func', async () => {

--- a/packages/core/functions-js/test/spec/params.spec.ts
+++ b/packages/core/functions-js/test/spec/params.spec.ts
@@ -22,7 +22,9 @@ describe('params reached to function', () => {
   })
 
   afterAll(async () => {
-    relay && relay.container && (await relay.container.stop())
+    if (relay) {
+      await relay.stop()
+    }
   })
 
   test('invoke mirror', async () => {


### PR DESCRIPTION
## Description

Fixes flaky test failures in `functions-js` caused by a race condition during Docker container cleanup in CI.

## Problem

Tests were intermittently failing in CI with "no such exec instance" errors during teardown. The issue occurred when testcontainers tried to clean up exec processes after the container had already stopped, causing the test suite to fail even though all actual tests passed.

## Solution

- Added a safe `stop()` method to the `Relay` class that catches and ignores "no such exec" errors during cleanup
- Updated all test files to use the new `relay.stop()` method instead of direct `container.stop()`
- Changed `runRelay` to return a proper `Relay` instance instead of a plain object