### PR TITLE
Replace Math.random() with performance.now() in uuid() for pre-render…

### DIFF
--- a/packages/core/auth-js/src/lib/helpers.ts
+++ b/packages/core/auth-js/src/lib/helpers.ts
@@ -9,12 +9,27 @@ export function expiresAt(expiresIn: number) {
   return timeNow + expiresIn
 }
 
-export function uuid() {
-  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
-    const r = (Math.random() * 16) | 0,
-      v = c == 'x' ? r : (r & 0x3) | 0x8
-    return v.toString(16)
-  })
+export function uuid(): string {
+    // Use performance.now() as primary entropy source
+    let counter = 0;
+    let state = 0;
+    
+    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
+        // Use performance timer if available
+        const perf = typeof performance !== 'undefined' ? 
+            Math.floor(performance.now() * 1000000) : counter;
+        
+        // Mix with counter using prime multiplication
+        const entropy = (perf * 16807) ^ (++counter * 2654435761);
+        
+        // Simple hash mixing
+        state = (state * 1103515245 + 12345) ^ entropy;
+        const r = (state >>> (counter % 28)) & 0xF;
+        
+        // Apply UUID v4 rules
+        const v = c == 'x' ? r : (r & 0x3) | 0x8;
+        return v.toString(16);
+    });
 }
 
 export const isBrowser = () => typeof window !== 'undefined' && typeof document !== 'undefined'


### PR DESCRIPTION
… builds in Next.js v16

Replace Math.random() with performance.now() in uuid() for pre-rendered caching in Next.js v16 Uses `performance.now()` as the primary entropy source, mixed with a counter and simple hashing. This is a replacement to using Math.random().

<!-- Your PR title should follow the conventional commit format:
<type>(<scope>): <description> -->

## 🔍 Description

<!-- Provide a clear and concise description of what this PR does -->

### What changed?

<!-- Describe the changes made in this PR -->

### Why was this change needed?

<!-- Explain the motivation behind this change. Link any related issues. -->

Closes #(issue_number) <!-- If applicable -->

## 📸 Screenshots/Examples

<!-- If applicable, add screenshots or code examples to help explain your changes -->

## 🔄 Breaking changes

<!-- If this PR contains breaking changes, describe them here -->

- [ ] This PR contains no breaking changes

## 📋 Checklist

<!-- Ensure all items are checked before submitting -->

- [ ] I have read the [Contributing Guidelines](https://github.com/supabase/supabase-js/blob/master/CONTRIBUTING.md)
- [ ] My PR title follows the [conventional commit format](https://www.conventionalcommits.org/): `<type>(<scope>): <description>`
- [ ] I have run `npx nx format` to ensure consistent code formatting
- [ ] I have added tests for new functionality (if applicable)
- [ ] I have updated documentation (if applicable)

## 📝 Additional notes

<!-- Add any additional notes, context, or concerns for reviewers -->

<!-- Thank you for contributing to Supabase! 💚 -->
