### PR TITLE
chore(repo): remove Deno 1.x testing suite

### DIFF
--- a/.github/workflows/ci-supabase-js.yml
+++ b/.github/workflows/ci-supabase-js.yml
@@ -111,13 +111,9 @@ jobs:
           fail-on-error: false
         continue-on-error: true
   deno-tests:
-    name: Deno Tests / ${{ matrix.deno }}
+    name: Deno Tests
     runs-on: ubuntu-latest
     needs: build-package
-    strategy:
-      matrix:
-        deno: ['1.x', '2.x']
-      fail-fast: false
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -128,7 +124,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@v2
         with:
-          deno-version: ${{ matrix.deno }}
+          deno-version: '2.x'
 
       - name: Setup Supabase CLI
         uses: supabase/setup-cli@v1
@@ -183,21 +179,7 @@ jobs:
           npm view @supabase/supabase-js version --registry http://localhost:4873
           npm view @supabase/supabase-js --registry http://localhost:4873 | head -20
 
-      - name: Run Deno Tests (1.x)
-        if: ${{ matrix.deno == '1.x' }}
-        env:
-          STORAGE_JS_ENTRY: main
-          DENO_NPM_REGISTRY: http://localhost:4873
-        run: |
-          cd packages/core/supabase-js/test/deno
-          echo "registry=http://localhost:4873/" > .npmrc
-          npm install
-          npm test || npm test
-          rm -f .npmrc
-          cd ../../..
-
-      - name: Run Deno Tests (2.x)
-        if: ${{ matrix.deno == '2.x' }}
+      - name: Run Deno Tests
         env:
           DENO_NPM_REGISTRY: http://localhost:4873
         run: |
@@ -208,12 +190,10 @@ jobs:
           rm -f .npmrc
           cd ../../..
 
-      - name: Run integration and browser tests on Deno 2.x only
-        if: ${{ matrix.deno == '2.x' }}
+      - name: Run integration and browser tests
         run: npx nx test:integration:browser supabase-js
 
       - name: Run Edge Functions Tests
-        if: ${{ matrix.deno == '2.x' }}
         run: |
           cd packages/core/supabase-js/test/deno
           npm run test:edge-functions

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -57,7 +57,7 @@ npm install @supabase/auth-js@latest
 
 - **Node.js 20+** - Native fetch support
 - **Modern browsers** - All modern browsers
-- **Deno 1.0+** - Native fetch built-in
+- **Deno 2.x** - Native fetch built-in
 - **Bun 0.1+** - Native fetch built-in
 - **React Native** - With fetch polyfill provided by the framework
 - **Expo** - With fetch polyfill provided by the framework

--- a/packages/core/functions-js/test/functions/hijack/index.ts
+++ b/packages/core/functions-js/test/functions/hijack/index.ts
@@ -1,4 +1,4 @@
-import { serve } from 'https://deno.land/std@0.130.0/http/server.ts'
+import { serve } from 'https://deno.land/std/http/server.ts'
 
 serve((req) => {
   // Decode JWT to check if this is a health check

--- a/packages/core/supabase-js/test/deno/run-deno-test.js
+++ b/packages/core/supabase-js/test/deno/run-deno-test.js
@@ -2,33 +2,11 @@
 
 const { execSync } = require('child_process');
 
-// Get Deno version
-let denoVersion = '1.0.0'; // default fallback
-try {
-  const versionOutput = execSync('deno --version', { encoding: 'utf-8' });
-  const match = versionOutput.match(/deno (\d+)\.(\d+)\.(\d+)/);
-  if (match) {
-    denoVersion = `${match[1]}.${match[2]}.${match[3]}`;
-  }
-} catch (error) {
-  console.warn('Could not determine Deno version, assuming 1.x');
-}
-
-const majorVersion = parseInt(denoVersion.split('.')[0]);
-
 // Get test file from arguments
 const testFile = process.argv[2] || 'integration.test.ts';
 
-// Base flags that work for both versions
-let flags = '--allow-all --no-check --unstable-sloppy-imports';
-
-// Add version-specific flags
-if (majorVersion >= 2) {
-  flags += ' --unstable-detect-cjs';
-  console.log(`Running with Deno ${denoVersion} (v2+ detected, using --unstable-detect-cjs)`);
-} else {
-  console.log(`Running with Deno ${denoVersion} (v1.x detected, skipping --unstable-detect-cjs)`);
-}
+// Flags for Deno 2.x
+const flags = '--allow-all --no-check --unstable-sloppy-imports --unstable-detect-cjs';
 
 // Run the test
 const command = `deno test ${flags} ${testFile}`;

--- a/packages/core/supabase-js/test/deno/setup-deps.js
+++ b/packages/core/supabase-js/test/deno/setup-deps.js
@@ -49,10 +49,7 @@ denoJson.imports = {
   '@supabase/functions-js': `npm:@supabase/functions-js@${versions.functions}`,
   '@supabase/postgrest-js': `npm:@supabase/postgrest-js@${versions.postgrest}`,
   '@supabase/auth-js': `npm:@supabase/auth-js@${versions.auth}`,
-  '@supabase/storage-js':
-    process.env.STORAGE_JS_ENTRY === 'main'
-      ? `npm:@supabase/storage-js@${versions.storage}/dist/main/index.js`
-      : `npm:@supabase/storage-js@${versions.storage}/dist/module/index.js`,
+  '@supabase/storage-js': `npm:@supabase/storage-js@${versions.storage}/dist/module/index.js`,
 }
 
 // Ensure Node types are available for Deno type-checking of .d.ts files


### PR DESCRIPTION
We no longer support Deno 1.x, it's been EOL for quite some time. No need to run the Deno 1.x tests on CI.