### PR TITLE
fix(realtime): account for null refs when encoding messages

### DIFF
--- a/packages/core/realtime-js/src/lib/serializer.ts
+++ b/packages/core/realtime-js/src/lib/serializer.ts
@@ -3,8 +3,8 @@
 import { CHANNEL_EVENTS } from '../lib/constants'
 
 export type Msg<T> = {
-  join_ref: string
-  ref: string
+  join_ref?: string | null
+  ref?: string | null
   topic: string
   event: string
   payload: T
@@ -42,19 +42,22 @@ export default class Serializer {
   }
 
   private _binaryEncodePush(message: Msg<ArrayBuffer>) {
-    const { join_ref, ref, event, topic, payload } = message
-    const metaLength = this.META_LENGTH + join_ref.length + ref.length + topic.length + event.length
+    const { event, topic, payload } = message
+    const ref = message.ref ?? ''
+    const joinRef = message.join_ref ?? ''
+
+    const metaLength = this.META_LENGTH + joinRef.length + ref.length + topic.length + event.length
 
     const header = new ArrayBuffer(this.HEADER_LENGTH + metaLength)
     let view = new DataView(header)
     let offset = 0
 
     view.setUint8(offset++, this.KINDS.push) // kind
-    view.setUint8(offset++, join_ref.length)
+    view.setUint8(offset++, joinRef.length)
     view.setUint8(offset++, ref.length)
     view.setUint8(offset++, topic.length)
     view.setUint8(offset++, event.length)
-    Array.from(join_ref, (char) => view.setUint8(offset++, char.charCodeAt(0)))
+    Array.from(joinRef, (char) => view.setUint8(offset++, char.charCodeAt(0)))
     Array.from(ref, (char) => view.setUint8(offset++, char.charCodeAt(0)))
     Array.from(topic, (char) => view.setUint8(offset++, char.charCodeAt(0)))
     Array.from(event, (char) => view.setUint8(offset++, char.charCodeAt(0)))
@@ -75,13 +78,15 @@ export default class Serializer {
   }
 
   private _encodeBinaryUserBroadcastPush(message: Msg<{ event: string } & { [key: string]: any }>) {
-    const { join_ref, ref, topic } = message
+    const topic = message.topic
+    const ref = message.ref ?? ''
+    const joinRef = message.join_ref ?? ''
     const userEvent = message.payload.event
     const userPayload = message.payload?.payload ?? new ArrayBuffer(0)
 
     const metaLength =
       this.USER_BROADCAST_PUSH_META_LENGTH +
-      join_ref.length +
+      joinRef.length +
       ref.length +
       topic.length +
       userEvent.length
@@ -91,12 +96,12 @@ export default class Serializer {
     let offset = 0
 
     view.setUint8(offset++, this.KINDS.userBroadcastPush) // kind
-    view.setUint8(offset++, join_ref.length)
+    view.setUint8(offset++, joinRef.length)
     view.setUint8(offset++, ref.length)
     view.setUint8(offset++, topic.length)
     view.setUint8(offset++, userEvent.length)
     view.setUint8(offset++, this.BINARY_ENCODING)
-    Array.from(join_ref, (char) => view.setUint8(offset++, char.charCodeAt(0)))
+    Array.from(joinRef, (char) => view.setUint8(offset++, char.charCodeAt(0)))
     Array.from(ref, (char) => view.setUint8(offset++, char.charCodeAt(0)))
     Array.from(topic, (char) => view.setUint8(offset++, char.charCodeAt(0)))
     Array.from(userEvent, (char) => view.setUint8(offset++, char.charCodeAt(0)))
@@ -109,7 +114,9 @@ export default class Serializer {
   }
 
   private _encodeJsonUserBroadcastPush(message: Msg<{ event: string } & { [key: string]: any }>) {
-    const { join_ref, ref, topic } = message
+    const topic = message.topic
+    const ref = message.ref ?? ''
+    const joinRef = message.join_ref ?? ''
     const userEvent = message.payload.event
     const userPayload = message.payload?.payload ?? {}
 
@@ -118,7 +125,7 @@ export default class Serializer {
 
     const metaLength =
       this.USER_BROADCAST_PUSH_META_LENGTH +
-      join_ref.length +
+      joinRef.length +
       ref.length +
       topic.length +
       userEvent.length
@@ -128,12 +135,12 @@ export default class Serializer {
     let offset = 0
 
     view.setUint8(offset++, this.KINDS.userBroadcastPush) // kind
-    view.setUint8(offset++, join_ref.length)
+    view.setUint8(offset++, joinRef.length)
     view.setUint8(offset++, ref.length)
     view.setUint8(offset++, topic.length)
     view.setUint8(offset++, userEvent.length)
     view.setUint8(offset++, this.JSON_ENCODING)
-    Array.from(join_ref, (char) => view.setUint8(offset++, char.charCodeAt(0)))
+    Array.from(joinRef, (char) => view.setUint8(offset++, char.charCodeAt(0)))
     Array.from(ref, (char) => view.setUint8(offset++, char.charCodeAt(0)))
     Array.from(topic, (char) => view.setUint8(offset++, char.charCodeAt(0)))
     Array.from(userEvent, (char) => view.setUint8(offset++, char.charCodeAt(0)))


### PR DESCRIPTION
<!-- Your PR title should follow the conventional commit format:
<type>(<scope>): <description> -->

## 🔍 Description

<!-- Provide a clear and concise description of what this PR does -->

ref and join_ref can be null/undefined in certain scenarios like when publishing heartbeats.

Currently using JSON to send heartbeats so not an actual issue but in the future this can be changed and we want to be ready.

### What changed?

<!-- Describe the changes made in this PR -->

Serializer handles null/undefined for `join_ref` and `ref`

### Why was this change needed?

<!-- Explain the motivation behind this change. Link any related issues. -->

The `Msg` type is now fixed with optional `join_ref` and `ref`. Heartbeats for example don't send a `join_ref` as they don't have a specific channel to refer to. 

## 📸 Screenshots/Examples

<!-- If applicable, add screenshots or code examples to help explain your changes -->

## 🔄 Breaking changes

<!-- If this PR contains breaking changes, describe them here -->

- [ ] This PR contains no breaking changes

## 📋 Checklist

<!-- Ensure all items are checked before submitting -->

- [x] I have read the [Contributing Guidelines](https://github.com/supabase/supabase-js/blob/master/CONTRIBUTING.md)
- [x] My PR title follows the [conventional commit format](https://www.conventionalcommits.org/): `<type>(<scope>): <description>`
- [x] I have run `npx nx format` to ensure consistent code formatting
- [x] I have added tests for new functionality (if applicable)
- [x] I have updated documentation (if applicable)

## 📝 Additional notes

<!-- Add any additional notes, context, or concerns for reviewers -->

<!-- Thank you for contributing to Supabase! 💚 -->
