### PR TITLE
fix(postgrest): validate empty or invalid relation names in Postgrest…

### DIFF
--- a/packages/core/postgrest-js/src/PostgrestClient.ts
+++ b/packages/core/postgrest-js/src/PostgrestClient.ts
@@ -88,6 +88,10 @@ export default class PostgrestClient<
    * @param relation - The table or view name to query
    */
   from(relation: string): PostgrestQueryBuilder<ClientOptions, Schema, any, any> {
+    if (!relation || typeof relation !== 'string' || relation.trim() === '') {
+      throw new Error('Invalid relation name: relation must be a non-empty string.')
+    }
+
     const url = new URL(`${this.url}/${relation}`)
     return new PostgrestQueryBuilder(url, {
       headers: new Headers(this.headers),


### PR DESCRIPTION
## 🔍 Description

This PR validates the `relation` argument passed to `PostgrestClient.from()`.  
Previously, calling:

```ts
supabase.from('')
```

would generate an invalid URL (ending with `//`) and result in unclear or confusing PostgREST or network errors.  
This validation provides clearer developer feedback and avoids silent failures.

### What changed?

- Added a validation check in `PostgrestClient.from()` to ensure the relation name:
  - is a string  
  - is not empty  
  - is not only whitespace  

If validation fails, the client now throws:

```
Invalid relation name: relation must be a non-empty string.
```

### Why was this change needed?

Developers frequently make small mistakes such as using an empty string for the relation.  
Without validation, this results in unclear and difficult-to-debug errors from downstream fetch calls.

This PR improves DX (developer experience) by catching the issue early and providing a helpful error message.

Closes # (not applicable)

---

## 📸 Screenshots/Examples

**Before**

```ts
supabase.from('')
// ❌ Leads to confusing network errors or malformed URLs
```

**After**

```ts
supabase.from('')
// ❌ Throws: "Invalid relation name: relation must be a non-empty string."
```

---

## 🔄 Breaking changes

- [x] This PR contains no breaking changes

---

## 📋 Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/supabase/supabase-js/blob/master/CONTRIBUTING.md)
- [x] My PR title follows the [conventional commit format](https://www.conventionalcommits.org/): `<type>(<scope>): <description>`
- [x] I have run `npx nx format` to ensure consistent code formatting
- [ ] I have added tests for new functionality (if applicable)
- [x] I have updated documentation (not applicable)

---

## 📝 Additional notes

This enhancement helps prevent silent URL errors, improves developer feedback, and aligns with the existing validation behavior in other Supabase JavaScript client modules.

<!-- Thank you for contributing to Supabase! 💚 -->
