### PR TITLE
feat(storage): rename StorageAnalyticsApi to StorageAnalyticsClient

### DIFF
--- a/packages/core/storage-js/src/StorageClient.ts
+++ b/packages/core/storage-js/src/StorageClient.ts
@@ -1,6 +1,6 @@
 import StorageFileApi from './packages/StorageFileApi'
 import StorageBucketApi from './packages/StorageBucketApi'
-import StorageAnalyticsApi from './packages/StorageAnalyticsApi'
+import StorageAnalyticsClient from './packages/StorageAnalyticsClient'
 import { Fetch } from './lib/fetch'
 import { StorageVectorsClient } from './lib/vectors'
 
@@ -66,12 +66,15 @@ export class StorageClient extends StorageBucketApi {
   }
 
   /**
+   *
+   * @alpha
+   *
    * Access analytics storage operations using Iceberg tables.
    *
    * **Public alpha:** This API is part of a public alpha release and may not be available to your account type.
    *
    * @category Analytics Buckets
-   * @returns A StorageAnalyticsApi instance configured with the current storage settings.
+   * @returns A StorageAnalyticsClient instance configured with the current storage settings.
    * @example
    * ```typescript
    * const client = createClient(url, key)
@@ -87,7 +90,7 @@ export class StorageClient extends StorageBucketApi {
    * await analytics.deleteBucket('old-analytics-bucket')
    * ```
    */
-  get analytics(): StorageAnalyticsApi {
-    return new StorageAnalyticsApi(this.url + '/iceberg', this.headers, this.fetch)
+  get analytics(): StorageAnalyticsClient {
+    return new StorageAnalyticsClient(this.url + '/iceberg', this.headers, this.fetch)
   }
 }

--- a/packages/core/storage-js/src/index.ts
+++ b/packages/core/storage-js/src/index.ts
@@ -1,6 +1,6 @@
 export { StorageClient } from './StorageClient'
 export type { StorageClientOptions } from './StorageClient'
-export { default as StorageAnalyticsApi } from './packages/StorageAnalyticsApi'
+export { default as StorageAnalyticsClient } from './packages/StorageAnalyticsClient'
 export * from './lib/types'
 export * from './lib/errors'
 export * from './lib/vectors'

--- a/packages/core/storage-js/src/packages/StorageAnalyticsClient.ts
+++ b/packages/core/storage-js/src/packages/StorageAnalyticsClient.ts
@@ -5,17 +5,19 @@ import { resolveFetch } from '../lib/helpers'
 import { AnalyticBucket } from '../lib/types'
 
 /**
- * API class for managing Analytics Buckets using Iceberg tables
+ * Client class for managing Analytics Buckets using Iceberg tables
  * Provides methods for creating, listing, and deleting analytics buckets
  */
-export default class StorageAnalyticsApi {
+export default class StorageAnalyticsClient {
   protected url: string
   protected headers: { [key: string]: string }
   protected fetch: Fetch
   protected shouldThrowOnError = false
 
   /**
-   * Creates a new StorageAnalyticsApi instance
+   * @alpha
+   *
+   * Creates a new StorageAnalyticsClient instance
    *
    * **Public alpha:** This API is part of a public alpha release and may not be available to your account type.
    *
@@ -26,7 +28,7 @@ export default class StorageAnalyticsApi {
    *
    * @example
    * ```typescript
-   * const client = new StorageAnalyticsApi(url, headers)
+   * const client = new StorageAnalyticsClient(url, headers)
    * ```
    */
   constructor(url: string, headers: { [key: string]: string } = {}, fetch?: Fetch) {
@@ -36,6 +38,8 @@ export default class StorageAnalyticsApi {
   }
 
   /**
+   * @alpha
+   *
    * Enable throwing errors instead of returning them in the response
    * When enabled, failed operations will throw instead of returning { data: null, error }
    *
@@ -50,6 +54,8 @@ export default class StorageAnalyticsApi {
   }
 
   /**
+   * @alpha
+   *
    * Creates a new analytics bucket using Iceberg tables
    * Analytics buckets are optimized for analytical queries and data processing
    *
@@ -103,6 +109,8 @@ export default class StorageAnalyticsApi {
   }
 
   /**
+   * @alpha
+   *
    * Retrieves the details of all Analytics Storage buckets within an existing project
    * Only returns buckets of type 'ANALYTICS'
    *
@@ -190,6 +198,8 @@ export default class StorageAnalyticsApi {
   }
 
   /**
+   * @alpha
+   *
    * Deletes an existing analytics bucket
    * A bucket can't be deleted with existing objects inside it
    * You must first empty the bucket before deletion


### PR DESCRIPTION
## Summary

Renames `StorageAnalyticsApi` to `StorageAnalyticsClient` to align with the established naming convention where user-facing entry points use the "`Client`" suffix.

## Motivation

We have an architectural pattern where:
  - "`Client`" = User-facing entry points (`StorageClient`, `StorageVectorsClient`)
  - "`Api`" = Internal building blocks/lower-level APIs (`VectorBucketApi`, `VectorIndexApi`, `VectorDataApi`)

`StorageAnalyticsApi` was incorrectly using the "`Api`" suffix even though it's a top-level user-facing entry point accessed via `storage.analytics`. This inconsistency was confusing and didn't match the pattern used for vectors.

## Changes

- Renamed file: `StorageAnalyticsApi.ts` → `StorageAnalyticsClient.ts`
- Renamed class: `StorageAnalyticsApi` → `StorageAnalyticsClient`
- Updated class JSDoc comments
- Updated import/export statements in `StorageClient.ts` and `index.ts`

##  Impact

  - Breaking Change: Yes, but API is marked as `@alpha` (public alpha)
  - Public API: Export name changes from `StorageAnalyticsApi` to `StorageAnalyticsClient`
  - Internal: All references updated to use new name

##  Pattern Clarity

 After this change, our naming is now consistent:

 | Class                  | Type   | Usage |
  |------------------------|--------|---------------------------------------|
  | StorageClient          | Client | Main entry point  |
  | StorageVectorsClient   | Client | Vector operations entry point             |
  | StorageAnalyticsClient | Client | Analytics operations entry point (fixed)              |
  | VectorBucketApi        | Api    | Internal building block             |
  | VectorIndexApi         | Api    | Internal building block             |
  | VectorDataApi          | Api    | Internal building block (also exportable for  advanced usage) |