### PR TITLE
feat(postgrest): add isdistinct and regex pattern matching operators

### DIFF
--- a/packages/core/postgrest-js/test/filters.test.ts
+++ b/packages/core/postgrest-js/test/filters.test.ts
@@ -778,3 +778,54 @@ test('filter on rpc', async () => {
     }
   `)
 })
+
+test('isDistinct', async () => {
+  const res = await postgrest.from('users').select('username').isDistinct('status', 'ONLINE')
+  expect(res).toMatchInlineSnapshot(`
+    {
+      "count": null,
+      "data": [
+        {
+          "username": "kiwicopple",
+        },
+      ],
+      "error": null,
+      "status": 200,
+      "statusText": "OK",
+    }
+  `)
+})
+
+test('regexMatch', async () => {
+  const res = await postgrest.from('users').select('username').regexMatch('username', '^sup')
+  expect(res).toMatchInlineSnapshot(`
+    {
+      "count": null,
+      "data": [
+        {
+          "username": "supabot",
+        },
+      ],
+      "error": null,
+      "status": 200,
+      "statusText": "OK",
+    }
+  `)
+})
+
+test('regexIMatch', async () => {
+  const res = await postgrest.from('users').select('username').regexIMatch('username', '^SUP')
+  expect(res).toMatchInlineSnapshot(`
+    {
+      "count": null,
+      "data": [
+        {
+          "username": "supabot",
+        },
+      ],
+      "error": null,
+      "status": 200,
+      "statusText": "OK",
+    }
+  `)
+})


### PR DESCRIPTION
## Description

Adds first-class support for missing [PostgREST operators](https://docs.postgrest.org/en/v12/references/api/tables_views.html#operators) in `postgrest-js`:
  - `isDistinct()` - IS DISTINCT FROM operator (treats NULL as a comparable value)
  - `regexMatch()` - PostgreSQL `~` regex pattern matching (case-sensitive)
  - `regexIMatch()` - PostgreSQL `~*` regex pattern matching (case-insensitive)

Previously these operators were only accessible via the `.filter()` escape hatch.