### PR TITLE
fix(auth): suppress getsession warning when getuser is called first

### DIFF
--- a/packages/core/auth-js/src/GoTrueClient.ts
+++ b/packages/core/auth-js/src/GoTrueClient.ts
@@ -2787,6 +2787,8 @@ export default class GoTrueClient {
   private async _removeSession() {
     this._debug('#_removeSession()')
 
+    this.suppressGetSessionWarning = false
+
     await removeItemAsync(this.storage, this.storageKey)
     await removeItemAsync(this.storage, this.storageKey + '-code-verifier')
     await removeItemAsync(this.storage, this.storageKey + '-user')


### PR DESCRIPTION
## summary

when getuser() returns a valid user, suppress the insecure user warning for subsequent getsession() calls since the developer is already following best practices by verifying the user with the supabase auth server.

## problem

the warning using the user object as returned from supabase.auth.getsession()... fires every time getsession() is called, even when the developer also calls getuser() to verify the user. this creates noisy, misleading logs.

## solution

set suppressgetsessionwarning = true when getuser() successfully returns a user, preventing the warning from firing on subsequent getsession() calls.

## changes

- packages/core/auth-js/src/gotrueclient.ts: added suppression logic in getuser() method

closes #1895