### PR TITLE
feat(supabase): add failOnNetworkError option to prevent silent fallback to anon key

### DIFF
--- a/packages/core/supabase-js/src/lib/types.ts
+++ b/packages/core/supabase-js/src/lib/types.ts
@@ -81,6 +81,16 @@ export type SupabaseClientOptions<SchemaName> = {
      * throwing the error instead of returning it as part of a successful response.
      */
     throwOnError?: SupabaseAuthClientOptions['throwOnError']
+    /**
+     * When true, throws an error if session retrieval fails due to network issues
+     * instead of silently falling back to the anonymous API key.
+     *
+     * This prevents RLS policies from silently failing when `auth.uid()` returns null
+     * due to network errors during token refresh.
+     *
+     * @default false
+     */
+    failOnNetworkError?: boolean
   }
   /**
    * Options passed to the realtime-js instance


### PR DESCRIPTION
 ## Summary

- Adds `failOnNetworkError` option to prevent silent fallback to anon key during network failures
- When enabled, throws instead of silently degrading auth, giving apps clear error handling
- Backward compatible: defaults to `false` (current behavior)

## Problem

During network issues (Cloudflare outages, DNS failures, timeouts), `getSession()` returns `{ session: null, error }`. The client ignores the error and uses the anon key, causing:

- RLS policies with `auth.uid() = user_id` to fail (auth.uid() is NULL)
- Users receive cryptic 406 errors instead of network errors

## Solution

  ```typescript
  const supabase = createClient(url, key, {
    auth: { failOnNetworkError: true }
  })
```