### PR TITLE
fix(postgrest): set columns parameter for single-object insert/upsert

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3341,14 +3341,14 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@inquirer/external-editor": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.2.tgz",
-      "integrity": "sha512-yy9cOoBnx58TlsPrIxauKIFQTiyH+0MK4e97y4sV9ERbI+zDxw7i2hxHLCIEGIE/8PPvDxGhgzIOTSOWcs6/MQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz",
+      "integrity": "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "chardet": "^2.1.0",
+        "chardet": "^2.1.1",
         "iconv-lite": "^0.7.0"
       },
       "engines": {
@@ -3382,9 +3382,9 @@
       }
     },
     "node_modules/@inquirer/figures": {
-      "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.14.tgz",
-      "integrity": "sha512-DbFgdt+9/OZYFM+19dbpXOSeAstPy884FPy1KjDu4anWwymZeOYhMY1mdFri172htv6mvc/uvIAAi7b7tvjJBQ==",
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.15.tgz",
+      "integrity": "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==",
       "dev": true,
       "license": "MIT",
       "peer": true,

--- a/packages/core/postgrest-js/src/PostgrestQueryBuilder.ts
+++ b/packages/core/postgrest-js/src/PostgrestQueryBuilder.ts
@@ -130,11 +130,11 @@ export default class PostgrestQueryBuilder<
     })
   }
 
-  // TODO(v3): Make `defaultToNull` consistent for both single & bulk inserts.
   insert<Row extends Relation extends { Insert: unknown } ? Relation['Insert'] : never>(
     values: Row,
     options?: {
       count?: 'exact' | 'planned' | 'estimated'
+      defaultToNull?: boolean
     }
   ): PostgrestFilterBuilder<
     ClientOptions,
@@ -183,8 +183,7 @@ export default class PostgrestQueryBuilder<
    * numbers.
    *
    * @param options.defaultToNull - Make missing fields default to `null`.
-   * Otherwise, use the default value for the column. Only applies for bulk
-   * inserts.
+   * Otherwise, use the default value for the column.
    */
   insert<Row extends Relation extends { Insert: unknown } ? Relation['Insert'] : never>(
     values: Row | Row[],
@@ -213,12 +212,12 @@ export default class PostgrestQueryBuilder<
       this.headers.append('Prefer', `missing=default`)
     }
 
-    if (Array.isArray(values)) {
-      const columns = values.reduce((acc, x) => acc.concat(Object.keys(x)), [] as string[])
-      if (columns.length > 0) {
-        const uniqueColumns = [...new Set(columns)].map((column) => `"${column}"`)
-        this.url.searchParams.set('columns', uniqueColumns.join(','))
-      }
+    const columns = Array.isArray(values)
+      ? values.reduce((acc, x) => acc.concat(Object.keys(x)), [] as string[])
+      : Object.keys(values)
+    if (columns.length > 0) {
+      const uniqueColumns = [...new Set(columns)].map((column) => `"${column}"`)
+      this.url.searchParams.set('columns', uniqueColumns.join(','))
     }
 
     return new PostgrestFilterBuilder({
@@ -231,13 +230,13 @@ export default class PostgrestQueryBuilder<
     })
   }
 
-  // TODO(v3): Make `defaultToNull` consistent for both single & bulk upserts.
   upsert<Row extends Relation extends { Insert: unknown } ? Relation['Insert'] : never>(
     values: Row,
     options?: {
       onConflict?: string
       ignoreDuplicates?: boolean
       count?: 'exact' | 'planned' | 'estimated'
+      defaultToNull?: boolean
     }
   ): PostgrestFilterBuilder<
     ClientOptions,
@@ -265,7 +264,7 @@ export default class PostgrestQueryBuilder<
     Relationships,
     'POST'
   >
-    /**
+  /**
    * Perform an UPSERT on the table or view. Depending on the column(s) passed
    * to `onConflict`, `.upsert()` allows you to perform the equivalent of
    * `.insert()` if a row with the corresponding `onConflict` columns doesn't
@@ -301,7 +300,7 @@ export default class PostgrestQueryBuilder<
    * @param options.defaultToNull - Make missing fields default to `null`.
    * Otherwise, use the default value for the column. This only applies when
    * inserting new rows, not when merging with existing rows under
-   * `ignoreDuplicates: false`. This also only applies when doing bulk upserts.
+   * `ignoreDuplicates: false`.
    *
    * @example Upsert a single row using a unique key
    * ```ts
@@ -351,7 +350,6 @@ export default class PostgrestQueryBuilder<
    * ```
    */
 
-
   upsert<Row extends Relation extends { Insert: unknown } ? Relation['Insert'] : never>(
     values: Row | Row[],
     {
@@ -386,12 +384,12 @@ export default class PostgrestQueryBuilder<
       this.headers.append('Prefer', 'missing=default')
     }
 
-    if (Array.isArray(values)) {
-      const columns = values.reduce((acc, x) => acc.concat(Object.keys(x)), [] as string[])
-      if (columns.length > 0) {
-        const uniqueColumns = [...new Set(columns)].map((column) => `"${column}"`)
-        this.url.searchParams.set('columns', uniqueColumns.join(','))
-      }
+    const columns = Array.isArray(values)
+      ? values.reduce((acc, x) => acc.concat(Object.keys(x)), [] as string[])
+      : Object.keys(values)
+    if (columns.length > 0) {
+      const uniqueColumns = [...new Set(columns)].map((column) => `"${column}"`)
+      this.url.searchParams.set('columns', uniqueColumns.join(','))
     }
 
     return new PostgrestFilterBuilder({

--- a/packages/core/postgrest-js/test/basic.test.ts
+++ b/packages/core/postgrest-js/test/basic.test.ts
@@ -1569,6 +1569,52 @@ describe("insert, update, delete with count: 'exact'", () => {
     `)
   })
 
+  test('single upsert with column defaults', async () => {
+    let res = await postgrest
+      .from('channels')
+      .upsert({ slug: 'test-single-upsert' }, { defaultToNull: false })
+      .select()
+      .rollback()
+    expect(res).toMatchInlineSnapshot(`
+      {
+        "count": null,
+        "data": [
+          {
+            "data": null,
+            "id": 8,
+            "slug": "test-single-upsert",
+          },
+        ],
+        "error": null,
+        "status": 201,
+        "statusText": "Created",
+      }
+    `)
+  })
+
+  test('single insert with column defaults', async () => {
+    let res = await postgrest
+      .from('channels')
+      .insert({ slug: 'test-single-insert' }, { defaultToNull: false })
+      .select()
+      .rollback()
+    expect(res).toMatchInlineSnapshot(`
+      {
+        "count": null,
+        "data": [
+          {
+            "data": null,
+            "id": 9,
+            "slug": "test-single-insert",
+          },
+        ],
+        "error": null,
+        "status": 201,
+        "statusText": "Created",
+      }
+    `)
+  })
+
   test("update with count: 'exact'", async () => {
     let res = await postgrest
       .from('messages')


### PR DESCRIPTION
## Summary

  - Fix single-object `upsert()` and `insert()` to set the `columns` URL parameter
  - Add `defaultToNull` option to single-object overloads for consistency
  - Previously only array (bulk) operations set `columns`, causing single-object upserts to  attempt updating ALL table columns, setting missing ones to `null`

  Closes #1653