### PR TITLE
docs(postgrest): hide methods that should not show in the docs

### DIFF
--- a/packages/core/postgrest-js/src/PostgrestBuilder.ts
+++ b/packages/core/postgrest-js/src/PostgrestBuilder.ts
@@ -28,7 +28,8 @@ export default abstract class PostgrestBuilder<
   protected fetch: Fetch
   protected isMaybeSingle: boolean
 
-  /**
+  /** @hidden
+   *
    * Creates a builder configured for a specific PostgREST request.
    *
    * @example

--- a/packages/core/postgrest-js/src/PostgrestClient.ts
+++ b/packages/core/postgrest-js/src/PostgrestClient.ts
@@ -3,7 +3,8 @@ import PostgrestFilterBuilder from './PostgrestFilterBuilder'
 import { Fetch, GenericSchema, ClientServerOptions } from './types/common/common'
 import { GetRpcFunctionFilterBuilderByArgs } from './types/common/rpc'
 
-/**
+/** @hidden
+ *
  * PostgREST client.
  *
  * @typeParam Database - Types for the schema from the [type

--- a/packages/core/postgrest-js/src/PostgrestError.ts
+++ b/packages/core/postgrest-js/src/PostgrestError.ts
@@ -8,7 +8,8 @@ export default class PostgrestError extends Error {
   hint: string
   code: string
 
-  /**
+  /** @hidden
+   *
    * @example
    * ```ts
    * import PostgrestError from '@supabase/postgrest-js'

--- a/packages/core/postgrest-js/src/PostgrestQueryBuilder.ts
+++ b/packages/core/postgrest-js/src/PostgrestQueryBuilder.ts
@@ -21,7 +21,8 @@ export default class PostgrestQueryBuilder<
   signal?: AbortSignal
   fetch?: Fetch
 
-  /**
+  /** @hidden
+   *
    * Creates a query builder scoped to a Postgres table or view.
    *
    * @example
@@ -265,7 +266,7 @@ export default class PostgrestQueryBuilder<
     Relationships,
     'POST'
   >
-    /**
+  /**
    * Perform an UPSERT on the table or view. Depending on the column(s) passed
    * to `onConflict`, `.upsert()` allows you to perform the equivalent of
    * `.insert()` if a row with the corresponding `onConflict` columns doesn't
@@ -350,7 +351,6 @@ export default class PostgrestQueryBuilder<
    * // }
    * ```
    */
-
 
   upsert<Row extends Relation extends { Insert: unknown } ? Relation['Insert'] : never>(
     values: Row | Row[],

--- a/packages/core/postgrest-js/src/index.ts
+++ b/packages/core/postgrest-js/src/index.ts
@@ -14,6 +14,7 @@ export {
   PostgrestBuilder,
   PostgrestError,
 }
+/** @hidden */
 export default {
   PostgrestClient,
   PostgrestQueryBuilder,


### PR DESCRIPTION
## 🔍 Description

Hide methods that should not show when auto generating the JS docs.

### What changed?

Add `@hidden` where needed.

### Why was this change needed?

Needed when auto generating the JS docs with the relevant methods, interfaces, etc.

## 📋 Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/supabase/supabase-js/blob/master/CONTRIBUTING.md)
- [x] My PR title follows the [conventional commit format](https://www.conventionalcommits.org/): `<type>(<scope>): <description>`
- [x] I have run `npx nx format` to ensure consistent code formatting