### PR TITLE
fix(realtime): handle null values in postgres changes filter comparison

### DIFF
--- a/packages/core/realtime-js/src/RealtimeChannel.ts
+++ b/packages/core/realtime-js/src/RealtimeChannel.ts
@@ -327,9 +327,9 @@ export default class RealtimeChannel {
               if (
                 serverPostgresFilter &&
                 serverPostgresFilter.event === event &&
-                serverPostgresFilter.schema === schema &&
-                serverPostgresFilter.table === table &&
-                serverPostgresFilter.filter === filter
+                RealtimeChannel.isFilterValueEqual(serverPostgresFilter.schema, schema) &&
+                RealtimeChannel.isFilterValueEqual(serverPostgresFilter.table, table) &&
+                RealtimeChannel.isFilterValueEqual(serverPostgresFilter.filter, filter)
               ) {
                 newPostgresBindings.push({
                   ...clientPostgresBinding,
@@ -947,6 +947,20 @@ export default class RealtimeChannel {
     }
 
     return true
+  }
+
+  /**
+   * Compares two optional filter values for equality.
+   * Treats undefined, null, and empty string as equivalent empty values.
+   * @internal
+   */
+  private static isFilterValueEqual(
+    serverValue: string | undefined | null,
+    clientValue: string | undefined
+  ): boolean {
+    const normalizedServer = serverValue ?? undefined
+    const normalizedClient = clientValue ?? undefined
+    return normalizedServer === normalizedClient
   }
 
   /** @internal */


### PR DESCRIPTION
## summary

fixes the `mismatch between server and client bindings for postgres changes` error that occurs when subscribing to postgres_changes.

## problem

when the client subscribes without a filter:
```js
.on('postgres_changes', {
  event: '*',
  schema: 'public',
  table: 'notifications',
}, callback)
```

the server returns `ilter: null` in the response, but the client has `ilter: undefined`. the strict equality check `
ull === undefined` returns false, causing a false mismatch error.

## solution

added a helper method `isFilterValueEqual` that normalizes null to undefined before comparison. this handles the json serialization discrepancy between server and client.

- closes #1917