### PR TITLE
feat(storage): align analytics from method with { data, error } pattern

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18119,9 +18119,9 @@
       }
     },
     "node_modules/iceberg-js": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.0.tgz",
-      "integrity": "sha512-kmgmea2nguZEvRqW79gDqNXyxA3OS5WIgMVffrHpqXV4F/J4UmNIw2vstixioLTNSkd5rFB8G0s3Lwzogm6OFw==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
@@ -33650,7 +33650,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "iceberg-js": "^0.8.0",
+        "iceberg-js": "^0.8.1",
         "tslib": "2.8.1"
       },
       "devDependencies": {

--- a/packages/core/storage-js/package.json
+++ b/packages/core/storage-js/package.json
@@ -37,7 +37,7 @@
     "docs:json": "typedoc --json docs/v2/spec.json --entryPoints src/index.ts --entryPoints src/packages/* --excludePrivate --excludeExternals --excludeProtected"
   },
   "dependencies": {
-    "iceberg-js": "^0.8.0",
+    "iceberg-js": "^0.8.1",
     "tslib": "2.8.1"
   },
   "devDependencies": {

--- a/packages/core/storage-js/test/analytics-getcatalog.test.ts
+++ b/packages/core/storage-js/test/analytics-getcatalog.test.ts
@@ -1,40 +1,40 @@
 /**
  * Unit tests for StorageAnalyticsClient.from() method
- * Tests that the method returns a properly configured IcebergRestCatalog instance
+ * Tests that the method returns a wrapped catalog directly and throws on invalid bucket names
  */
 
-import { IcebergRestCatalog } from 'iceberg-js'
 import StorageAnalyticsClient from '../src/packages/StorageAnalyticsClient'
 import { StorageError } from '../src/lib/errors'
 
 describe('StorageAnalyticsClient.from()', () => {
-  it('should return an IcebergRestCatalog instance', () => {
+  it('should return catalog directly for valid bucket name', () => {
     const client = new StorageAnalyticsClient('https://example.supabase.co/storage/v1/iceberg', {
       Authorization: 'Bearer test-token',
     })
 
     const catalog = client.from('my-analytics-bucket')
 
-    expect(catalog).toBeInstanceOf(IcebergRestCatalog)
+    expect(catalog).not.toBeNull()
+    expect(typeof catalog.listNamespaces).toBe('function')
   })
 
-  it('should return different instances for different bucket names', () => {
+  it('should return different catalog instances for different bucket names', () => {
     const client = new StorageAnalyticsClient('https://example.supabase.co/storage/v1/iceberg', {})
 
     const catalog1 = client.from('bucket-1')
     const catalog2 = client.from('bucket-2')
 
-    expect(catalog1).toBeInstanceOf(IcebergRestCatalog)
-    expect(catalog2).toBeInstanceOf(IcebergRestCatalog)
+    expect(catalog1).not.toBeNull()
+    expect(catalog2).not.toBeNull()
     expect(catalog1).not.toBe(catalog2) // Different instances
   })
 
-  it('should work with minimal configuration', () => {
+  it('should return catalog with all expected methods', () => {
     const client = new StorageAnalyticsClient('http://localhost:8181', {})
 
     const catalog = client.from('test-warehouse')
 
-    expect(catalog).toBeInstanceOf(IcebergRestCatalog)
+    expect(catalog).not.toBeNull()
     expect(typeof catalog.listNamespaces).toBe('function')
     expect(typeof catalog.createNamespace).toBe('function')
     expect(typeof catalog.createTable).toBe('function')
@@ -45,12 +45,20 @@ describe('StorageAnalyticsClient.from()', () => {
     expect(typeof catalog.dropNamespace).toBe('function')
   })
 
-  it('should work when called from throwOnError chain', () => {
+  it('should always throw on invalid bucket name (regardless of throwOnError)', () => {
+    const client = new StorageAnalyticsClient('https://example.supabase.co/storage/v1/iceberg', {})
+
+    // Invalid bucket name always throws - it's a programmer error
+    expect(() => client.from('bucket/invalid')).toThrow(StorageError)
+    expect(() => client.throwOnError().from('bucket/invalid')).toThrow(StorageError)
+  })
+
+  it('should return catalog when called from throwOnError chain with valid bucket', () => {
     const client = new StorageAnalyticsClient('https://example.supabase.co/storage/v1/iceberg', {})
 
     const catalog = client.throwOnError().from('my-bucket')
 
-    expect(catalog).toBeInstanceOf(IcebergRestCatalog)
+    expect(catalog).not.toBeNull()
   })
 
   describe('bucket name validation', () => {
@@ -82,19 +90,18 @@ describe('StorageAnalyticsClient.from()', () => {
     })
 
     describe('invalid bucket names', () => {
-      it('should reject empty or null bucket names', () => {
+      it('should throw for empty or null bucket names', () => {
         expect(() => client.from('')).toThrow(StorageError)
         expect(() => client.from(null as any)).toThrow(StorageError)
         expect(() => client.from(undefined as any)).toThrow(StorageError)
       })
 
-      it('should reject path traversal with slashes', () => {
+      it('should throw for path traversal with slashes', () => {
         expect(() => client.from('../etc/passwd')).toThrow(StorageError)
         expect(() => client.from('bucket/../other')).toThrow(StorageError)
-        // Note: '..' alone is valid (just two periods), only with slashes is it path traversal
       })
 
-      it('should reject names with path separators', () => {
+      it('should throw for names with path separators', () => {
         expect(() => client.from('bucket/nested')).toThrow(StorageError)
         expect(() => client.from('/bucket')).toThrow(StorageError)
         expect(() => client.from('bucket/')).toThrow(StorageError)
@@ -102,18 +109,18 @@ describe('StorageAnalyticsClient.from()', () => {
         expect(() => client.from('path\\to\\bucket')).toThrow(StorageError)
       })
 
-      it('should reject names with leading or trailing whitespace', () => {
+      it('should throw for names with leading or trailing whitespace', () => {
         expect(() => client.from(' bucket')).toThrow(StorageError)
         expect(() => client.from('bucket ')).toThrow(StorageError)
         expect(() => client.from(' bucket ')).toThrow(StorageError)
       })
 
-      it('should reject names exceeding 100 characters', () => {
+      it('should throw for names exceeding 100 characters', () => {
         const tooLongName = 'a'.repeat(101)
         expect(() => client.from(tooLongName)).toThrow(StorageError)
       })
 
-      it('should reject names with unsafe special characters', () => {
+      it('should throw for names with unsafe special characters', () => {
         expect(() => client.from('bucket{name}')).toThrow(StorageError)
         expect(() => client.from('bucket[name]')).toThrow(StorageError)
         expect(() => client.from('bucket<name>')).toThrow(StorageError)
@@ -124,7 +131,7 @@ describe('StorageAnalyticsClient.from()', () => {
       it('should provide clear error messages', () => {
         try {
           client.from('bucket/nested')
-          fail('Should have thrown an error')
+          fail('Expected to throw')
         } catch (error) {
           expect(error).toBeInstanceOf(StorageError)
           expect((error as StorageError).message).toContain('Invalid bucket name')
@@ -134,7 +141,7 @@ describe('StorageAnalyticsClient.from()', () => {
     })
 
     describe('URL encoding behavior', () => {
-      it('should reject strings with percent signs (URL encoding)', () => {
+      it('should throw for strings with percent signs (URL encoding)', () => {
         // The % character is not in the allowed character set, so URL-encoded
         // strings will be rejected. This is correct behavior - users should
         // pass unencoded bucket names.


### PR DESCRIPTION
## Summary

- Align `StorageAnalyticsClient.from()` catalog operations with SDK's `{ data, error }` pattern
- Bump `iceberg-js` dependency from 0.8.0 to 0.8.1
- Update JSDoc examples and tests to reflect the new API

## Context

An issue showed 500 errors when analytics catalog operations returned 404s. The platform API catch block couldn't distinguish client errors from server errors because the SDK was throwing instead of returning errors in the response.

Most storage operations return `{ data, error }` and don't throw (unless using `throwOnError()`). The analytics catalog was inconsistent with this pattern.

Since analytics buckets are in **public alpha**, we're treating this as a "got it wrong from the beginning" fix rather than a breaking change requiring a major version bump.

## Changes

**Before:**
```js
const catalog = supabase.storage.analytics.from('my-bucket')
const tables = await catalog.listTables({ namespace: ['default'] }) // throws on error
```

**After:**
```
const catalog = supabase.storage.analytics.from('my-bucket')
const { data: tables, error } = await catalog.listTables({ namespace: ['default'] })
if (error?.isNotFound()) {
    console.log('Namespace not found')
}
```