### PR TITLE
fix(auth): skip navigator lock when persistSession is false

### DIFF
--- a/packages/core/auth-js/src/GoTrueClient.ts
+++ b/packages/core/auth-js/src/GoTrueClient.ts
@@ -328,7 +328,7 @@ export default class GoTrueClient {
 
     if (settings.lock) {
       this.lock = settings.lock
-    } else if (isBrowser() && globalThis?.navigator?.locks) {
+    } else if (this.persistSession && isBrowser() && globalThis?.navigator?.locks) {
       this.lock = navigatorLock
     } else {
       this.lock = lockNoOp


### PR DESCRIPTION
## what

when `persistSession: false` is set, the auth client was still using navigator locks for cross-tab coordination. this caused `NavigatorLockAcquireTimeoutError` to appear in the console even though there's no shared state between tabs when sessions are stored in memory only.

## why

navigator locks are used for cross-tab session coordination. when `persistSession: false:`
- sessions are stored in memory only (not localStorage)
- each tab has its own isolated session
- no cross-tab coordination is needed
- the lock acquisition can fail and throw errors unnecessarily

this is consistent with how `BroadcastChannel` is already handled in the same file, which also checks `persistSession` before enabling cross-tab communication.

## how

added  `his.persistSession` check to the condition for using `
avigatorLock`. when `persistSession: false` the client now uses `lockNoOp` instead.

closes https://github.com/supabase/supabase-js/issues/1517