### PR TITLE
fix(realtime): omit authorization header when no access token exists

### DIFF
--- a/packages/core/realtime-js/src/RealtimeChannel.ts
+++ b/packages/core/realtime-js/src/RealtimeChannel.ts
@@ -554,21 +554,22 @@ export default class RealtimeChannel {
     payload: any,
     opts: { timeout?: number } = {}
   ): Promise<{ success: true } | { success: false; status: number; error: string }> {
-    const authorization = this.socket.accessTokenValue
-      ? `Bearer ${this.socket.accessTokenValue}`
-      : ''
-
     if (payload === undefined || payload === null) {
       return Promise.reject('Payload is required for httpSend()')
     }
 
+    const headers: Record<string, string> = {
+      apikey: this.socket.apiKey ? this.socket.apiKey : '',
+      'Content-Type': 'application/json',
+    }
+
+    if (this.socket.accessTokenValue) {
+      headers['Authorization'] = `Bearer ${this.socket.accessTokenValue}`
+    }
+
     const options = {
       method: 'POST',
-      headers: {
-        Authorization: authorization,
-        apikey: this.socket.apiKey ? this.socket.apiKey : '',
-        'Content-Type': 'application/json',
-      },
+      headers,
       body: JSON.stringify({
         messages: [
           {
@@ -626,16 +627,18 @@ export default class RealtimeChannel {
       )
 
       const { event, payload: endpoint_payload } = args
-      const authorization = this.socket.accessTokenValue
-        ? `Bearer ${this.socket.accessTokenValue}`
-        : ''
+      const headers: Record<string, string> = {
+        apikey: this.socket.apiKey ? this.socket.apiKey : '',
+        'Content-Type': 'application/json',
+      }
+
+      if (this.socket.accessTokenValue) {
+        headers['Authorization'] = `Bearer ${this.socket.accessTokenValue}`
+      }
+
       const options = {
         method: 'POST',
-        headers: {
-          Authorization: authorization,
-          apikey: this.socket.apiKey ? this.socket.apiKey : '',
-          'Content-Type': 'application/json',
-        },
+        headers,
         body: JSON.stringify({
           messages: [
             {

--- a/packages/core/realtime-js/test/RealtimeChannel.messaging.test.ts
+++ b/packages/core/realtime-js/test/RealtimeChannel.messaging.test.ts
@@ -330,7 +330,7 @@ describe('send', () => {
       {
         description: 'without access token',
         accessToken: undefined,
-        expectedAuth: '',
+        expectedAuth: undefined,
       },
       {
         description: 'with access token',
@@ -363,13 +363,17 @@ describe('send', () => {
           config: { private: true },
         })
 
+        const expectedHeaders: Record<string, string> = {
+          apikey: 'abc123',
+          'Content-Type': 'application/json',
+        }
+        if (expectedAuth) {
+          expectedHeaders['Authorization'] = expectedAuth
+        }
+
         const expectedBody = {
           method: 'POST',
-          headers: {
-            Authorization: expectedAuth,
-            apikey: 'abc123',
-            'Content-Type': 'application/json',
-          },
+          headers: expectedHeaders,
           body: '{"messages":[{"topic":"topic","event":"test","private":true}]}',
           signal: new AbortController().signal,
         }
@@ -498,12 +502,12 @@ describe('httpSend', () => {
     {
       name: 'without access token',
       hasToken: false,
-      expectedAuth: '',
+      expectedAuth: undefined as string | undefined,
     },
     {
       name: 'with access token',
       hasToken: true,
-      expectedAuth: 'Bearer token123',
+      expectedAuth: 'Bearer token123' as string | undefined,
     },
   ]
 


### PR DESCRIPTION
## summary

when using the `realtime rest` fallback without a session, the client sends an empty authorization header which causes a 500 error from the server.

## problem

the rest fallback in `httpSend()` and `send()`always includes an `authorization header`, even when no token exists. this results in `Authorization: ` (empty value) being sent, which the server rejects with 500.

## fix

only add the authorization header when `AccessTokenValue` is truthy. the server accepts requests with just the `apikey` header.

closes #1936 & #1590
supersedes #1561