### PR TITLE
chore(realtime): remove console.log spam from toJson transformer

### DIFF
--- a/packages/core/realtime-js/src/lib/transformers.ts
+++ b/packages/core/realtime-js/src/lib/transformers.ts
@@ -189,8 +189,7 @@ export const toJson = (value: RecordValue): RecordValue => {
   if (typeof value === 'string') {
     try {
       return JSON.parse(value)
-    } catch (error) {
-      console.log(`JSON parse error: ${error}`)
+    } catch {
       return value
     }
   }


### PR DESCRIPTION
## summary

removes unnecessary `console.log` that spams user logs when `jsonb` columns contain primitive string values.

## problem

the toJson transformer logs `JSON parse error` to console whenever `JSON.parse` fails. this happens when `jsonb` columns store primitive strings. the function already handles this gracefully by returning the original value, but the `console.log` spams production logs.

## fix

remove the `console.log`. the error is already handled by returning the `original value.`

closes #1731

cc @mandarini 