### PR TITLE
fix(supabase): use esm module build in wrapper to fix browser compatibility

### DIFF
--- a/packages/core/supabase-js/wrapper.mjs
+++ b/packages/core/supabase-js/wrapper.mjs
@@ -1,4 +1,4 @@
-import * as index from '../main/index.js'
+import * as index from '../module/index.js'
 const {
   PostgrestError,
   FunctionsHttpError,


### PR DESCRIPTION
the esm wrapper was importing from the cjs build which causes `exports is not defined` error when loaded directly in browsers. changed to import from the esm module build instead.

closes #1942 
supersedes https://github.com/supabase/supabase-js/pull/1914 

cc @mandarini 