### PR TITLE
chore(auth): typo in error message

### DIFF
--- a/packages/core/auth-js/src/lib/locks.ts
+++ b/packages/core/auth-js/src/lib/locks.ts
@@ -229,7 +229,7 @@ export async function processLock<R>(
             setTimeout(() => {
               reject(
                 new ProcessLockAcquireTimeoutError(
-                  `Acquring process lock with name "${name}" timed out`
+                  `Acquiring process lock with name "${name}" timed out`
                 )
               )
             }, acquireTimeout)


### PR DESCRIPTION
## Description

Fixed a typo in the error message for `ProcessLockAcquireTimeoutError` in the auth-js package.

## Changes

- **File**: `packages/core/auth-js/src/lib/locks.ts:232`
- **Change**: `"Acquring"` → `"Acquiring"`

## Type of Change

- [x] Bug fix (fix)
- [ ] New feature (feat)
- [ ] Breaking change (feat! or fix!)
- [ ] Documentation update (docs)
- [ ] Other (chore, refactor, etc.)

## Testing

- [x] Code formatted (`nx format`)
- [x] Builds passing (`nx build auth-js`)
- [x] Used conventional commits

## Additional Context

This is a simple typo fix in an error message that improves code quality and professionalism.