### PR TITLE
fix(realtime): handle websocket race condition in node.js

### DIFF
--- a/packages/core/realtime-js/src/RealtimeClient.ts
+++ b/packages/core/realtime-js/src/RealtimeClient.ts
@@ -641,6 +641,10 @@ export default class RealtimeClient {
     this.conn.onerror = (error: Event) => this._onConnError(error)
     this.conn.onmessage = (event: any) => this._onConnMessage(event)
     this.conn.onclose = (event: any) => this._onConnClose(event)
+
+    if (this.conn.readyState === SOCKET_STATES.open) {
+      this._onConnOpen()
+    }
   }
 
   /**


### PR DESCRIPTION
when using the `ws` module in node.js, the websocket can connect before the `onopen` handler is attached. this causes subscriptions to timeout because `_onConnOpen` never fires.

this fix checks `readyState` after setting up handlers and manually triggers `_onConnOpen` if the connection is already open.


closes https://github.com/supabase/supabase-js/issues/1559

cc @mandarini 