### PR TITLE
fix(supabase): resolve jsDelivr CDN ESM import failure

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -125,6 +125,7 @@
         "npm:jiti@2.4.2",
         "npm:jsonc-eslint-parser@^2.1.0",
         "npm:jsonwebtoken@9",
+        "npm:jsr@~0.13.5",
         "npm:nx@21.6.2",
         "npm:prettier@^3.6.2",
         "npm:ts-jest@^29.4.2",
@@ -132,7 +133,7 @@
         "npm:tslib@^2.3.0",
         "npm:typedoc@~0.27.9",
         "npm:typescript@~5.8.3",
-        "npm:verdaccio@^6.0.5",
+        "npm:verdaccio@^6.2.4",
         "npm:vite@7.1.11",
         "npm:vitest@^3.2.4",
         "npm:webpack-cli@^5.1.4"
@@ -194,6 +195,7 @@
         "packageJson": {
           "dependencies": [
             "npm:form-data@4",
+            "npm:iceberg-js@~0.8.1",
             "npm:ts-loader@^9.4.2",
             "npm:tslib@2.8.1",
             "npm:webpack-cli@^5.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3364,9 +3364,9 @@
       }
     },
     "node_modules/@inquirer/external-editor/node_modules/iconv-lite": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
-      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.1.tgz",
+      "integrity": "sha512-2Tth85cXwGFHfvRgZWszZSvdo+0Xsqmw8k8ZwxScfcBneNUraK+dxRxRm24nszx80Y0TVio8kKLt5sLE7ZCLlw==",
       "dev": true,
       "license": "MIT",
       "peer": true,

--- a/packages/core/supabase-js/wrapper.mjs
+++ b/packages/core/supabase-js/wrapper.mjs
@@ -1,94 +1,22 @@
-import * as index from '../main/index.js'
-const {
-  PostgrestError,
-  FunctionsHttpError,
-  FunctionsFetchError,
-  FunctionsRelayError,
-  FunctionsError,
-  FunctionRegion,
-  SupabaseClient,
-  createClient,
-  GoTrueAdminApi,
-  GoTrueClient,
-  AuthAdminApi,
-  AuthClient,
-  navigatorLock,
-  NavigatorLockAcquireTimeoutError,
-  lockInternals,
-  processLock,
-  SIGN_OUT_SCOPES,
-  AuthError,
-  AuthApiError,
-  AuthUnknownError,
-  CustomAuthError,
-  AuthSessionMissingError,
-  AuthInvalidTokenResponseError,
-  AuthInvalidCredentialsError,
-  AuthImplicitGrantRedirectError,
-  AuthPKCEGrantCodeExchangeError,
-  AuthRetryableFetchError,
-  AuthWeakPasswordError,
-  AuthInvalidJwtError,
-  isAuthError,
-  isAuthApiError,
-  isAuthSessionMissingError,
-  isAuthImplicitGrantRedirectError,
-  isAuthRetryableFetchError,
-  isAuthWeakPasswordError,
-  RealtimePresence,
-  RealtimeChannel,
-  RealtimeClient,
-  REALTIME_LISTEN_TYPES,
-  REALTIME_POSTGRES_CHANGES_LISTEN_EVENT,
-  REALTIME_PRESENCE_LISTEN_EVENTS,
-  REALTIME_SUBSCRIBE_STATES,
-  REALTIME_CHANNEL_STATES,
-} = index.default || index
-
+// Direct package re-exports - these work correctly in:
+// - Node.js (resolves via node_modules)
+// - jsDelivr (bundles with named exports)
+// - esm.sh (bundles correctly)
+// - Bundlers (webpack, vite, etc.)
+export * from '@supabase/auth-js'
+export { PostgrestError } from '@supabase/postgrest-js'
 export {
-  PostgrestError,
   FunctionsHttpError,
   FunctionsFetchError,
   FunctionsRelayError,
   FunctionsError,
   FunctionRegion,
-  SupabaseClient,
-  createClient,
-  GoTrueAdminApi,
-  GoTrueClient,
-  AuthAdminApi,
-  AuthClient,
-  navigatorLock,
-  NavigatorLockAcquireTimeoutError,
-  lockInternals,
-  processLock,
-  SIGN_OUT_SCOPES,
-  AuthError,
-  AuthApiError,
-  AuthUnknownError,
-  CustomAuthError,
-  AuthSessionMissingError,
-  AuthInvalidTokenResponseError,
-  AuthInvalidCredentialsError,
-  AuthImplicitGrantRedirectError,
-  AuthPKCEGrantCodeExchangeError,
-  AuthRetryableFetchError,
-  AuthWeakPasswordError,
-  AuthInvalidJwtError,
-  isAuthError,
-  isAuthApiError,
-  isAuthSessionMissingError,
-  isAuthImplicitGrantRedirectError,
-  isAuthRetryableFetchError,
-  isAuthWeakPasswordError,
-  RealtimePresence,
-  RealtimeChannel,
-  RealtimeClient,
-  REALTIME_LISTEN_TYPES,
-  REALTIME_POSTGRES_CHANGES_LISTEN_EVENT,
-  REALTIME_PRESENCE_LISTEN_EVENTS,
-  REALTIME_SUBSCRIBE_STATES,
-  REALTIME_CHANNEL_STATES,
-}
+} from '@supabase/functions-js'
+export * from '@supabase/realtime-js'
 
-export default index.default || index
+// Local exports from CJS build (Node.js can import CJS from ESM)
+import main from '../main/index.js'
+export const { SupabaseClient, createClient } = main
+
+// Default export
+export default main


### PR DESCRIPTION
## Summary

Fixes jsDelivr CDN imports failing with `Cannot read properties of null (reading 'AuthClient')` since v2.86.1.

## Problem

PR #1914 changed `wrapper.mjs` to import from the CJS build (`../main/index.js`) and manually destructure 46 exports. When jsDelivr bundles this:
  1. Rollup transforms CJS `require('@supabase/auth-js')` → `import default from '@supabase/auth-js'`
  2. `auth-js` has no default export, so Rollup adds `export default null`
  3. Destructuring `AuthClient` from `null` throws

## Solution

Rewrite `wrapper.mjs` to use direct package re-exports

This approach:
  - Uses export * for automatic sync (no manual maintenance)
  - Works with jsDelivr (bundles see named exports, not CJS default imports)
  - Works with Node.js, esm.sh, and all bundlers
  - Reduces wrapper from 95 lines to 22 lines

## Related

  - Fixes #1942
  - Alternative to #1943