### PR TITLE
fix(supabase): resolve jsDelivr CDN ESM import failure with .js extensions

### DIFF
--- a/packages/core/supabase-js/package.json
+++ b/packages/core/supabase-js/package.json
@@ -36,7 +36,7 @@
   "scripts": {
     "build": "npm run build:main && npm run build:module && npm run build:esm && npm run build:umd",
     "build:main": "tsc -p tsconfig.json",
-    "build:module": "tsc -p tsconfig.module.json",
+    "build:module": "tsc -p tsconfig.module.json && node scripts/fix-esm-extensions.cjs",
     "build:esm": "node scripts/copy-wrapper.cjs",
     "build:umd": "webpack --env mode=production",
     "test": "npm run test:types && npm run test:run",

--- a/packages/core/supabase-js/scripts/fix-esm-extensions.cjs
+++ b/packages/core/supabase-js/scripts/fix-esm-extensions.cjs
@@ -1,0 +1,37 @@
+/**
+ * Post-build script to add .js extensions to relative imports in ESM output.
+ *
+ * Node.js ESM requires explicit file extensions for relative imports.
+ * TypeScript doesn't add these by default, so we add them after compilation.
+ *
+ * This fixes:
+ * - Node.js direct ESM imports (import { createClient } from '@supabase/supabase-js')
+ * - jsDelivr CDN ESM imports (when bundled with the module build)
+ */
+const fs = require('fs')
+const path = require('path')
+
+function addJsExtensions(dir) {
+  const files = fs.readdirSync(dir, { withFileTypes: true })
+  for (const file of files) {
+    const fullPath = path.join(dir, file.name)
+    if (file.isDirectory()) {
+      addJsExtensions(fullPath)
+    } else if (file.name.endsWith('.js')) {
+      let content = fs.readFileSync(fullPath, 'utf8')
+      // Add .js to relative imports that don't already have an extension
+      // Matches: from './foo' or from '../foo/bar' but not from './foo.js'
+      content = content.replace(/(from\s+['"])(\.\.?\/[^'"]+)(?<!\.js)(['"])/g, '$1$2.js$3')
+      fs.writeFileSync(fullPath, content)
+    }
+  }
+}
+
+const targetDir = path.resolve(__dirname, '../dist/module')
+if (fs.existsSync(targetDir)) {
+  addJsExtensions(targetDir)
+  console.log('✓ Added .js extensions to ESM imports in dist/module/')
+} else {
+  console.error('Error: dist/module directory not found')
+  process.exit(1)
+}

--- a/packages/core/supabase-js/wrapper.mjs
+++ b/packages/core/supabase-js/wrapper.mjs
@@ -1,22 +1,94 @@
-// Direct package re-exports - these work correctly in:
-// - Node.js (resolves via node_modules)
-// - jsDelivr (bundles with named exports)
-// - esm.sh (bundles correctly)
-// - Bundlers (webpack, vite, etc.)
-export * from '@supabase/auth-js'
-export { PostgrestError } from '@supabase/postgrest-js'
-export {
+import * as index from '../module/index.js'
+const {
+  PostgrestError,
   FunctionsHttpError,
   FunctionsFetchError,
   FunctionsRelayError,
   FunctionsError,
   FunctionRegion,
-} from '@supabase/functions-js'
-export * from '@supabase/realtime-js'
+  SupabaseClient,
+  createClient,
+  GoTrueAdminApi,
+  GoTrueClient,
+  AuthAdminApi,
+  AuthClient,
+  navigatorLock,
+  NavigatorLockAcquireTimeoutError,
+  lockInternals,
+  processLock,
+  SIGN_OUT_SCOPES,
+  AuthError,
+  AuthApiError,
+  AuthUnknownError,
+  CustomAuthError,
+  AuthSessionMissingError,
+  AuthInvalidTokenResponseError,
+  AuthInvalidCredentialsError,
+  AuthImplicitGrantRedirectError,
+  AuthPKCEGrantCodeExchangeError,
+  AuthRetryableFetchError,
+  AuthWeakPasswordError,
+  AuthInvalidJwtError,
+  isAuthError,
+  isAuthApiError,
+  isAuthSessionMissingError,
+  isAuthImplicitGrantRedirectError,
+  isAuthRetryableFetchError,
+  isAuthWeakPasswordError,
+  RealtimePresence,
+  RealtimeChannel,
+  RealtimeClient,
+  REALTIME_LISTEN_TYPES,
+  REALTIME_POSTGRES_CHANGES_LISTEN_EVENT,
+  REALTIME_PRESENCE_LISTEN_EVENTS,
+  REALTIME_SUBSCRIBE_STATES,
+  REALTIME_CHANNEL_STATES,
+} = index.default || index
 
-// Local exports from CJS build (Node.js can import CJS from ESM)
-import main from '../main/index.js'
-export const { SupabaseClient, createClient } = main
+export {
+  PostgrestError,
+  FunctionsHttpError,
+  FunctionsFetchError,
+  FunctionsRelayError,
+  FunctionsError,
+  FunctionRegion,
+  SupabaseClient,
+  createClient,
+  GoTrueAdminApi,
+  GoTrueClient,
+  AuthAdminApi,
+  AuthClient,
+  navigatorLock,
+  NavigatorLockAcquireTimeoutError,
+  lockInternals,
+  processLock,
+  SIGN_OUT_SCOPES,
+  AuthError,
+  AuthApiError,
+  AuthUnknownError,
+  CustomAuthError,
+  AuthSessionMissingError,
+  AuthInvalidTokenResponseError,
+  AuthInvalidCredentialsError,
+  AuthImplicitGrantRedirectError,
+  AuthPKCEGrantCodeExchangeError,
+  AuthRetryableFetchError,
+  AuthWeakPasswordError,
+  AuthInvalidJwtError,
+  isAuthError,
+  isAuthApiError,
+  isAuthSessionMissingError,
+  isAuthImplicitGrantRedirectError,
+  isAuthRetryableFetchError,
+  isAuthWeakPasswordError,
+  RealtimePresence,
+  RealtimeChannel,
+  RealtimeClient,
+  REALTIME_LISTEN_TYPES,
+  REALTIME_POSTGRES_CHANGES_LISTEN_EVENT,
+  REALTIME_PRESENCE_LISTEN_EVENTS,
+  REALTIME_SUBSCRIBE_STATES,
+  REALTIME_CHANNEL_STATES,
+}
 
-// Default export
-export default main
+export default index.default || index


### PR DESCRIPTION
## Summary

Fixes jsDelivr CDN imports failing with `Cannot read properties of null (reading 'AuthClient')` since v2.86.1.

## Problem

When jsDelivr bundles the CJS main build, it transforms `require('@supabase/auth-js')` to default imports. Since auth-js has `export default null` (added by Rollup for packages without default exports), destructuring fails.

## Solution

1. **Changed wrapper to import from ESM module build** instead of CJS main build
2. **Added post-build script** to add `.js` extensions to relative imports in the module build

This fixes both:
  - jsDelivr CDN imports
  - Node.js direct ESM imports (`.js` extensions satisfy Node.js requirements)

## Changes

  - `wrapper.mjs` - Import from `../module/index.js` instead of `../main/index.js` (thanks @7ttp)
  - `scripts/fix-esm-extensions.cjs` - Adds `.js` extensions to compiled ESM imports
 
## Related

  - Fixes #1942
  - Alternative to #1943 (which only fixed jsDelivr but broke Node.js ESM)