### PR TITLE
fix(postgrest): add explicit response type for maybeSingle()

### DIFF
--- a/packages/core/postgrest-js/src/PostgrestBuilder.ts
+++ b/packages/core/postgrest-js/src/PostgrestBuilder.ts
@@ -2,7 +2,7 @@ import type {
   PostgrestSingleResponse,
   PostgrestResponseSuccess,
   CheckMatchingArrayTypes,
-  PostgrestMaybeSingleResponse, 
+  PostgrestMaybeSingleResponse,
   MergePartialResult,
   IsValidResultOverride,
 } from './types/types'

--- a/packages/core/postgrest-js/src/types/types.ts
+++ b/packages/core/postgrest-js/src/types/types.ts
@@ -32,8 +32,6 @@ export type PostgrestMaybeSingleResponse<T> =
   | PostgrestResponseSuccess<T | null>
   | PostgrestResponseFailure
 
-
-
 export type DatabaseWithOptions<Database, Options extends ClientServerOptions> = {
   db: Database
   options: Options


### PR DESCRIPTION
Adds a dedicated PostgrestMaybeSingleResponse type to better represent the
existing runtime behavior of maybeSingle().

This is a type-only change and does not modify any runtime logic.