### PR TITLE
feat(auth): add support for Supabase Auth sb identifier

### DIFF
--- a/packages/core/auth-js/src/GoTrueClient.ts
+++ b/packages/core/auth-js/src/GoTrueClient.ts
@@ -2111,6 +2111,11 @@ export default class GoTrueClient {
     if (typeof this.detectSessionInUrl === 'function') {
       return this.detectSessionInUrl(new URL(window.location.href), params)
     }
+    // Check for Supabase Auth identifier
+    // Fall back to legacy detection for backwards compatibility with older Auth servers
+    if ('sb' in params) {
+      return true
+    }
     return Boolean(params.access_token || params.error_description)
   }
 

--- a/packages/core/auth-js/src/GoTrueClient.ts
+++ b/packages/core/auth-js/src/GoTrueClient.ts
@@ -2112,10 +2112,13 @@ export default class GoTrueClient {
       return this.detectSessionInUrl(new URL(window.location.href), params)
     }
     // Check for Supabase Auth identifier
-    // Fall back to legacy detection for backwards compatibility with older Auth servers
     if ('sb' in params) {
-      return true
+      // sb is just an identifier
+      // Still require OAuth params to prevent forced logout via crafted URLs with only 'sb'
+      return Boolean(params.access_token || params.error || params.error_description)
     }
+    // TODO @mandarini: Remove this legacy fallback in next major version and return false instead
+    // Legacy detection for backwards compatibility with older Auth servers that don't include 'sb'
     return Boolean(params.access_token || params.error_description)
   }
 

--- a/packages/core/auth-js/src/lib/types.ts
+++ b/packages/core/auth-js/src/lib/types.ts
@@ -84,15 +84,20 @@ export type GoTrueClientOptions = {
    * The function receives the current URL and parsed parameters, and should return true if the URL
    * should be processed as a Supabase auth callback, or false to ignore it.
    *
+   * By default, the client checks for the `sb` parameter (added by Supabase Auth server) to identify
+   * Supabase callbacks, with a fallback to legacy detection for older Auth server versions.
+   *
    * This is useful when your app uses other OAuth providers (e.g., Facebook Login) that also return
    * access_token in the URL fragment, which would otherwise be incorrectly intercepted by Supabase Auth.
    *
    * @example
    * ```ts
    * detectSessionInUrl: (url, params) => {
-   *   // Ignore Facebook OAuth redirects
+   *   // Prefer sb identifier (available on newer Auth servers)
+   *   if ('sb' in params) return true
+   *   // Ignore known third-party OAuth paths
    *   if (url.pathname === '/facebook/redirect') return false
-   *   // Use default detection for other URLs
+   *   // Fall back to legacy detection for older Auth servers
    *   return Boolean(params.access_token || params.error_description)
    * }
    * ```

--- a/packages/core/auth-js/src/lib/types.ts
+++ b/packages/core/auth-js/src/lib/types.ts
@@ -93,10 +93,13 @@ export type GoTrueClientOptions = {
    * @example
    * ```ts
    * detectSessionInUrl: (url, params) => {
-   *   // Prefer sb identifier (available on newer Auth servers)
-   *   if ('sb' in params) return true
    *   // Ignore known third-party OAuth paths
    *   if (url.pathname === '/facebook/redirect') return false
+   *   // Check for sb identifier (available on newer Auth servers)
+   *   // Still require OAuth params to prevent issues with crafted URLs
+   *   if ('sb' in params) {
+   *     return Boolean(params.access_token || params.error || params.error_description)
+   *   }
    *   // Fall back to legacy detection for older Auth servers
    *   return Boolean(params.access_token || params.error_description)
    * }

--- a/packages/core/auth-js/test/GoTrueClient.browser.test.ts
+++ b/packages/core/auth-js/test/GoTrueClient.browser.test.ts
@@ -669,7 +669,7 @@ describe('Callback URL handling', () => {
 
     // Should detect and process the error callback
     expect(error).toBeDefined()
-    expect(error?.message).toContain('access_denied')
+    expect(error?.message).toContain('User denied access')
   })
 })
 

--- a/packages/core/supabase-js/src/lib/types.ts
+++ b/packages/core/supabase-js/src/lib/types.ts
@@ -63,10 +63,13 @@ export type SupabaseClientOptions<SchemaName> = {
      * @example
      * ```ts
      * detectSessionInUrl: (url, params) => {
-     *   // Prefer sb identifier (available on newer Auth servers)
-     *   if ('sb' in params) return true
      *   // Ignore known third-party OAuth paths
      *   if (url.pathname === '/facebook/redirect') return false
+     *   // Check for sb identifier (available on newer Auth servers)
+     *   // Still require OAuth params to prevent issues with crafted URLs
+     *   if ('sb' in params) {
+     *     return Boolean(params.access_token || params.error || params.error_description)
+     *   }
      *   // Fall back to legacy detection for older Auth servers
      *   return Boolean(params.access_token || params.error_description)
      * }

--- a/packages/core/supabase-js/src/lib/types.ts
+++ b/packages/core/supabase-js/src/lib/types.ts
@@ -53,6 +53,9 @@ export type SupabaseClientOptions<SchemaName> = {
      * a Supabase auth callback. The function receives the current URL and parsed parameters,
      * and should return true if the URL should be processed as a Supabase auth callback.
      *
+     * By default, the client checks for the `sb` parameter (added by Supabase Auth server) to identify
+     * Supabase callbacks, with a fallback to legacy detection for older Auth server versions.
+     *
      * This is useful when your app uses other OAuth providers (e.g., Facebook Login) that
      * also return access_token in the URL fragment, which would otherwise be incorrectly
      * intercepted by Supabase Auth.
@@ -60,9 +63,11 @@ export type SupabaseClientOptions<SchemaName> = {
      * @example
      * ```ts
      * detectSessionInUrl: (url, params) => {
-     *   // Ignore Facebook OAuth redirects
+     *   // Prefer sb identifier (available on newer Auth servers)
+     *   if ('sb' in params) return true
+     *   // Ignore known third-party OAuth paths
      *   if (url.pathname === '/facebook/redirect') return false
-     *   // Use default detection for other URLs
+     *   // Fall back to legacy detection for older Auth servers
      *   return Boolean(params.access_token || params.error_description)
      * }
      * ```


### PR DESCRIPTION
 ## Summary

Add client-side support for the `sb` identifier that Supabase Auth server adds to OAuth redirect URLs (supabase/auth#2299).

## Problem

`auth-js` intercepts all URL fragments containing `access_token`, including those from non-Supabase OAuth providers (e.g., Facebook Login). This causes unintended authentication issues when apps use multiple OAuth providers.

## Solution

  - Updated `_isImplicitGrantCallback()` to check for the `sb` parameter first
  - Falls back to legacy detection (`access_token` / `error_description`) for backwards compatibility with older Auth server versions
  - Updated JSDoc documentation with a comprehensive example

## Example

```ts
  // New default behavior (automatic):
  // 1. Check for 'sb' parameter (new Auth servers)
  // 2. Fall back to access_token/error_description (legacy)

  // Custom predicate for advanced use cases:
  detectSessionInUrl: (url, params) => {
    if ('sb' in params) return true
    if (url.pathname === '/facebook/redirect') return false
    return Boolean(params.access_token || params.error_description)
  }
```

## Related

  - Issue: https://github.com/supabase/supabase-js/issues/1697

## Blocked by:

* https://github.com/supabase/supabase-js/pull/1958
* https://github.com/supabase/auth/pull/2299

## TODO as breaking change

On v3, as breaking change, remove the legacy fallback