### PR TITLE
fix(postgrest): prevent shared state between query builder operations

### DIFF
--- a/packages/core/postgrest-js/src/PostgrestQueryBuilder.ts
+++ b/packages/core/postgrest-js/src/PostgrestQueryBuilder.ts
@@ -278,7 +278,7 @@ export default class PostgrestQueryBuilder<
     Relationships,
     'POST'
   >
-    /**
+  /**
    * Perform an UPSERT on the table or view. Depending on the column(s) passed
    * to `onConflict`, `.upsert()` allows you to perform the equivalent of
    * `.insert()` if a row with the corresponding `onConflict` columns doesn't
@@ -363,7 +363,6 @@ export default class PostgrestQueryBuilder<
    * // }
    * ```
    */
-
 
   upsert<Row extends Relation extends { Insert: unknown } ? Relation['Insert'] : never>(
     values: Row | Row[],

--- a/packages/core/postgrest-js/test/basic.test.ts
+++ b/packages/core/postgrest-js/test/basic.test.ts
@@ -2191,3 +2191,15 @@ test('maybeSingle handles zero rows error', async () => {
     }
   `)
 })
+
+test('should not share state between operations on same query builder', async () => {
+  const table = postgrest.from('users')
+  const q1 = table.select('*').eq('status', 'ONLINE')
+  const q2 = table.select('*').eq('status', 'OFFLINE')
+
+  // Verify URLs don't contain each other's filters
+  expect((q1 as any).url.toString()).not.toContain('status=eq.OFFLINE')
+  expect((q2 as any).url.toString()).not.toContain('status=eq.ONLINE')
+  expect((q1 as any).url.toString()).toContain('status=eq.ONLINE')
+  expect((q2 as any).url.toString()).toContain('status=eq.OFFLINE')
+})


### PR DESCRIPTION
when reusing a `PostgrestQueryBuilder` instance returned by `.from()`, 
url search params and headers were being shared across multiple operations, 
causing filters to accumulate unexpectedly.
this fix ensures each operation receives its own cloned state.

fixes https://github.com/supabase/supabase-js/issues/1640
