### PR TITLE
chore(repo): re-enable integration test

### DIFF
--- a/.github/workflows/ci-supabase-js.yml
+++ b/.github/workflows/ci-supabase-js.yml
@@ -226,9 +226,8 @@ jobs:
           rm -f .npmrc
           cd ../../..
 
-      # Temporarily disable this test until root cause is found
-      # - name: Run integration and browser tests
-      #   run: npx nx test:integration:browser supabase-js
+      - name: Run integration and browser tests
+        run: npx nx test:integration:browser supabase-js
 
       - name: Run Edge Functions Tests
         run: |


### PR DESCRIPTION
Recent updates do not cause integration test to fail any more, so time to re-enable it.