### PR TITLE
fix(realtime): add generic overload for postgres_changes event type

### DIFF
--- a/packages/core/realtime-js/src/RealtimeChannel.ts
+++ b/packages/core/realtime-js/src/RealtimeChannel.ts
@@ -451,6 +451,11 @@ export default class RealtimeChannel {
     filter: RealtimePostgresChangesFilter<`${REALTIME_POSTGRES_CHANGES_LISTEN_EVENT.DELETE}`>,
     callback: (payload: RealtimePostgresDeletePayload<T>) => void
   ): RealtimeChannel
+  on<T extends { [key: string]: any }>(
+    type: `${REALTIME_LISTEN_TYPES.POSTGRES_CHANGES}`,
+    filter: RealtimePostgresChangesFilter<`${REALTIME_POSTGRES_CHANGES_LISTEN_EVENT}`>,
+    callback: (payload: RealtimePostgresChangesPayload<T>) => void
+  ): RealtimeChannel
   /**
    * The following is placed here to display on supabase.com/docs/reference/javascript/subscribe.
    * @param type One of "broadcast", "presence", or "postgres_changes".

--- a/packages/core/realtime-js/test/RealtimeChannel.postgres.test.ts
+++ b/packages/core/realtime-js/test/RealtimeChannel.postgres.test.ts
@@ -612,6 +612,25 @@ describe('PostgreSQL table filter validation', () => {
   })
 })
 
+describe('Generic event type overload', () => {
+  test('should accept generic event type parameter without type errors', () => {
+    const event: '*' | 'INSERT' | 'UPDATE' | 'DELETE' = 'INSERT'
+
+    channel.on(
+      'postgres_changes',
+      {
+        event,
+        schema: 'public',
+        table: 'users',
+      },
+      () => {}
+    )
+
+    expect(channel.bindings.postgres_changes.length).toBe(1)
+    expect(channel.bindings.postgres_changes[0].filter.event).toBe('INSERT')
+  })
+})
+
 describe('PostgreSQL payload transformation', () => {
   test('should transform postgres_changes payload when triggered', () => {
     const callbackSpy = vi.fn()


### PR DESCRIPTION
Adds a generic overload for `on()` with `postgres_changes` that accepts any event type, enabling reusable subscription helpers with union types like `'*' | 'INSERT' | 'UPDATE' | 'DELETE'`.

Fixes "No overload matches this call" error when passing generic event parameters to `channel.on('postgres_changes', ...)`.


closes https://github.com/supabase/supabase-js/issues/1451