### PR TITLE
fix(supabase): inline string literal in databasewithoutinternals type

### DIFF
--- a/packages/core/supabase-js/src/lib/types.ts
+++ b/packages/core/supabase-js/src/lib/types.ts
@@ -136,9 +136,6 @@ export type QueryResult<T> = T extends PromiseLike<infer U> ? U : never
 export type QueryData<T> = T extends PromiseLike<{ data: infer U }> ? Exclude<U, null> : never
 export type QueryError = PostgrestError
 
-/** @internal Key used for Supabase internal metadata in Database types. */
-type InternalSupabaseKey = '__InternalSupabase'
-
 /**
  * Strips internal Supabase metadata from Database types.
  * Useful for libraries defining generic constraints on Database types.
@@ -148,4 +145,4 @@ type InternalSupabaseKey = '__InternalSupabase'
  * type CleanDB = DatabaseWithoutInternals<Database>
  * ```
  */
-export type DatabaseWithoutInternals<DB> = Omit<DB, InternalSupabaseKey>
+export type DatabaseWithoutInternals<DB> = Omit<DB, '__InternalSupabase'>


### PR DESCRIPTION
Fixes TS2304 error ppl get "Cannot find name 'InternalSupabaseKey'" when using DatabaseWithoutInternals type.

The private type alias was referenced in the exported type but not included in declaration files. Inlining the string literal directly resolves this.

closes https://github.com/supabase/supabase-js/issues/1987