### PR TITLE
fix(auth): add banned_until property to user type

### DIFF
--- a/packages/core/auth-js/src/lib/types.ts
+++ b/packages/core/auth-js/src/lib/types.ts
@@ -419,6 +419,7 @@ export interface User {
   is_sso_user?: boolean
   factors?: (Factor<FactorType, 'verified'> | Factor<FactorType, 'unverified'>)[]
   deleted_at?: string
+  banned_until?: string
 }
 
 export interface UserAttributes {


### PR DESCRIPTION
adds the missing `banned_until` property to the user type. 
the gotrue server returns this field when a user is `banned` but the `typescript` type was missing it.

closes #1376