### PR TITLE
fix(auth): add last_challenged_at property to factor type

### DIFF
--- a/packages/core/auth-js/src/lib/types.ts
+++ b/packages/core/auth-js/src/lib/types.ts
@@ -375,6 +375,7 @@ export type Factor<
 
   created_at: string
   updated_at: string
+  last_challenged_at?: string
 }
 
 export interface UserAppMetadata {


### PR DESCRIPTION
adds `last_challenged_at` to the Factor type to match the gotrue server response.

closes https://github.com/supabase/supabase-js/issues/1678
