### PR TITLE
chore(supabase): add unified SupabaseError type

### DIFF
--- a/packages/core/supabase-js/src/index.ts
+++ b/packages/core/supabase-js/src/index.ts
@@ -25,6 +25,7 @@ export type {
   QueryData,
   QueryError,
   DatabaseWithoutInternals,
+  SupabaseError,
 } from './lib/types'
 
 /**

--- a/packages/core/supabase-js/src/lib/types.ts
+++ b/packages/core/supabase-js/src/lib/types.ts
@@ -1,7 +1,8 @@
-import { GoTrueClientOptions } from '@supabase/auth-js'
+import { GoTrueClientOptions, AuthError } from '@supabase/auth-js'
 import { RealtimeClientOptions } from '@supabase/realtime-js'
 import { PostgrestError } from '@supabase/postgrest-js'
-import type { StorageClientOptions } from '@supabase/storage-js'
+import { FunctionsError } from '@supabase/functions-js'
+import type { StorageClientOptions, StorageError } from '@supabase/storage-js'
 import type {
   GenericSchema,
   GenericRelationship,
@@ -20,6 +21,19 @@ export type {
   GenericView,
   GenericFunction,
 }
+
+/**
+ * Union type of all Supabase error types.
+ * Useful for generic error handling across all Supabase operations.
+ *
+ * @example
+ * ```ts
+ * function handleError(error: SupabaseError) {
+ *   console.error(error.message)
+ * }
+ * ```
+ */
+export type SupabaseError = AuthError | PostgrestError | FunctionsError | StorageError
 
 export interface SupabaseAuthClientOptions extends GoTrueClientOptions {}
 


### PR DESCRIPTION
adds a unified SupabaseError type that combines AuthError, PostgrestError, FunctionsError, and StorageError into a single union type for easier generic error handling across all supabase operations.

closes #1414