### PR TITLE
fix(supabase): avoid edge runtime warnings in next.js

### DIFF
--- a/packages/core/realtime-js/src/lib/websocket-factory.ts
+++ b/packages/core/realtime-js/src/lib/websocket-factory.ts
@@ -92,9 +92,10 @@ export class WebSocketFactory {
       }
     }
 
-    if (typeof process !== 'undefined') {
-      // Use dynamic property access to avoid Next.js Edge Runtime static analysis warnings
-      const processVersions = (process as any)['versions']
+    // Use dynamic property access to avoid Next.js Edge Runtime static analysis warnings
+    const _process = (globalThis as any)['process']
+    if (_process) {
+      const processVersions = _process['versions']
       if (processVersions && processVersions['node']) {
         // Remove 'v' prefix if present and parse the major version
         const versionString = processVersions['node']

--- a/packages/core/supabase-js/src/index.ts
+++ b/packages/core/supabase-js/src/index.ts
@@ -72,12 +72,13 @@ function shouldShowDeprecationWarning(): boolean {
   }
 
   // Skip if process is not available (e.g., Edge Runtime)
-  if (typeof process === 'undefined') {
+  // Use dynamic property access to avoid Next.js Edge Runtime static analysis warnings
+  const _process = (globalThis as any)['process']
+  if (!_process) {
     return false
   }
 
-  // Use dynamic property access to avoid Next.js Edge Runtime static analysis warnings
-  const processVersion = (process as any)['version']
+  const processVersion = _process['version']
   if (processVersion === undefined || processVersion === null) {
     return false
   }


### PR DESCRIPTION
## Summary

Fixes Edge Runtime warnings when using `supabase-js` in Next.js middleware.

## Problem

Next.js static analyzer detects usage of `process.versions` and `process.version` in the built output and shows warnings during `next build`:

- A Node.js API is used (`process.versions` at line: 43) which is not supported in the Edge Runtime  
- A Node.js API is used (`process.version` at line: 389) which is not supported in the Edge Runtime

## Solution

Use dynamic property access via `globalThis` instead of `typeof process` checks.

The static analyzer cannot trace string-based property access, so it no longer flags these as Node.js API usage.

**Before**
~~~
typeof process !== 'undefined'
~~~

**After**
~~~
globalThis['process']
~~~

## Changes

- `packages/core/realtime-js/src/lib/websocket-factory.ts`
- `packages/core/supabase-js/src/index.ts`

## Related

Closes #1552
