### PR TITLE
fix(auth): defer subscriber notification in exchangeCodeForSession to prevent deadlock

### DIFF
--- a/packages/core/auth-js/src/GoTrueClient.ts
+++ b/packages/core/auth-js/src/GoTrueClient.ts
@@ -1146,7 +1146,9 @@ export default class GoTrueClient {
       }
       if (data.session) {
         await this._saveSession(data.session)
-        await this._notifyAllSubscribers('SIGNED_IN', data.session)
+        setTimeout(async () => {
+          await this._notifyAllSubscribers('SIGNED_IN', data.session)
+        }, 0)
       }
       return this._returnResult({ data: { ...data, redirectType: redirectType ?? null }, error })
     } catch (error) {


### PR DESCRIPTION
## Summary

Defers `_notifyAllSubscribers` call in `_exchangeCodeForSession` using `setTimeout` to prevent deadlock on iOS/Capacitor PKCE OAuth flow.

## Problem

On iOS/Capacitor with PKCE flow, `exchangeCodeForSession()` would hang indefinitely when a subscriber callback (in `onAuthStateChange`) tried to call `getSession()` or make authenticated requests.

The deadlock occurred because:
1. `exchangeCodeForSession()` acquires a lock via `_acquireLock()`
2. Inside the lock, it calls `await _notifyAllSubscribers()` which awaits all subscriber callbacks
3. If a subscriber callback calls `getSession()`, it tries to acquire the same lock
4. The lock queues the `getSession()` call to wait for the current operation
5. But the current operation is waiting for the subscriber callback to complete
6. Deadlock: subscriber waits for `getSession()` which waits for lock which waits for subscriber

## Solution

Defer `_notifyAllSubscribers` using `setTimeout(..., 0)` so it runs after the lock is released. 
This matches the existing pattern used here: https://github.com/supabase/supabase-js/blob/master/packages/core/auth-js/src/GoTrueClient.ts#L521

## Related

Closes #1566

Thanks @simplysparsh