### PR TITLE
fix(auth): prevent deadlock in updateUser

### DIFF
--- a/packages/core/auth-js/src/GoTrueClient.ts
+++ b/packages/core/auth-js/src/GoTrueClient.ts
@@ -1830,7 +1830,7 @@ export default class GoTrueClient {
         }
         session.user = data.user as User
         await this._saveSession(session)
-        await this._notifyAllSubscribers('USER_UPDATED', session)
+        void this._notifyAllSubscribers('USER_UPDATED', session).catch(console.error)
         return this._returnResult({ data: { user: session.user }, error: null })
       })
     } catch (error) {


### PR DESCRIPTION
<!-- Your PR title should follow the conventional commit format:
<type>(<scope>): <description> -->

## 🔍 Description

<!-- Provide a clear and concise description of what this PR does -->

### What changed?

Modified the `_updateUser` method in `src/GoTrueClient.ts` to execute the `_notifyAllSubscribers` call asynchronously.

### Why was this change needed?

This fixes a deadlock issue where `updateUser` would hang indefinitely despite a successful server response.

I've got the same issue as issue #1441 . After digging into it, I found that the issue is because `updateUser` acquires a lock, and after success, it calls and `awaits _notifyAllSubscribers`. However, the lock is unavailable for the subscribers. So the subscriber waits for the lock, and updateUser waits for the subscriber => Deadlock

Closes #1441 

## 📸 Screenshots/Examples

<!-- If applicable, add screenshots or code examples to help explain your changes -->

## 🔄 Breaking changes

<!-- If this PR contains breaking changes, describe them here -->

- [x] This PR contains no breaking changes

## 📋 Checklist

<!-- Ensure all items are checked before submitting -->

- [x] I have read the [Contributing Guidelines](https://github.com/supabase/supabase-js/blob/master/CONTRIBUTING.md)
- [x] My PR title follows the [conventional commit format](https://www.conventionalcommits.org/): `<type>(<scope>): <description>`
- [x] I have run `npx nx format` to ensure consistent code formatting
- [ ] I have added tests for new functionality (if applicable)
- [ ] I have updated documentation (if applicable)

## 📝 Additional notes

<!-- Add any additional notes, context, or concerns for reviewers -->

<!-- Thank you for contributing to Supabase! 💚 -->
