### PR TITLE
fix(storage): expose status and statusCode on StorageError base class

### DIFF
--- a/packages/core/storage-js/src/lib/errors.ts
+++ b/packages/core/storage-js/src/lib/errors.ts
@@ -1,9 +1,13 @@
 export class StorageError extends Error {
   protected __isStorageError = true
+  status?: number
+  statusCode?: string
 
-  constructor(message: string) {
+  constructor(message: string, status?: number, statusCode?: string) {
     super(message)
     this.name = 'StorageError'
+    this.status = status
+    this.statusCode = statusCode
   }
 }
 
@@ -12,11 +16,11 @@ export function isStorageError(error: unknown): error is StorageError {
 }
 
 export class StorageApiError extends StorageError {
-  status: number
-  statusCode: string
+  override status: number
+  override statusCode: string
 
   constructor(message: string, status: number, statusCode: string) {
-    super(message)
+    super(message, status, statusCode)
     this.name = 'StorageApiError'
     this.status = status
     this.statusCode = statusCode


### PR DESCRIPTION
## Summary

Exposes `status` and `statusCode` properties on the base `StorageError` class for TypeScript compatibility.

## Problem

Storage operations return errors typed as `StorageError`, but `status` and `statusCode` properties only exist on the `StorageApiError` subclass. 
This causes TypeScript errors when users try to access these properties without casting.

## Solution

Add optional `status?: number` and `statusCode?: string` to the base `StorageError` class. Backwards compatible - no breaking changes.

## Related

- Closes #1408
