### PR TITLE
fix(auth): add dispose method to cleanup BroadcastChannel

### DIFF
--- a/packages/core/auth-js/test/GoTrueClient.browser.test.ts
+++ b/packages/core/auth-js/test/GoTrueClient.browser.test.ts
@@ -1371,3 +1371,30 @@ describe('MFA Complex Branches', () => {
     expect(mockFetch).toHaveBeenCalled()
   })
 })
+
+describe('GoTrueClient dispose', () => {
+  it('should clean up BroadcastChannel when dispose is called', async () => {
+    const mockClose = jest.fn()
+    const mockRemoveEventListener = jest.fn()
+    Object.defineProperty(window, 'BroadcastChannel', {
+      value: jest.fn().mockImplementation(() => ({
+        postMessage: jest.fn(),
+        addEventListener: jest.fn(),
+        removeEventListener: mockRemoveEventListener,
+        close: mockClose,
+      })),
+      writable: true,
+    })
+
+    const client = getClientWithSpecificStorage({
+      getItem: jest.fn(),
+      setItem: jest.fn(),
+      removeItem: jest.fn(),
+    })
+
+    await client.dispose()
+
+    expect(mockRemoveEventListener).toHaveBeenCalledWith('message', expect.any(Function))
+    expect(mockClose).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary

Adds a `dispose()` method to `GoTrueClient` to properly clean up the `BroadcastChannel` event listener and close the channel.

## Problem

In `GoTrueClient`, a `BroadcastChannel` is created with an event listener in the constructor, but there's no way to remove the listener or close the channel. The cleanup pattern exists for `visibilityChangedCallback` (via `_removeVisibilityChangedCallback()`) but was missed for `BroadcastChannel`.

**Location:** `packages/core/auth-js/src/GoTrueClient.ts` (~line 398)

## Solution

- Store callback reference in `broadcastChannelCallback` property
- Add private `_removeBroadcastChannel()` method (matches existing pattern)
- Add public `dispose()` method for full resource cleanup

## Changes

- `GoTrueClient.ts`: Added `broadcastChannelCallback` property, `_removeBroadcastChannel()`, and `dispose()` methods
- `GoTrueClient.browser.test.ts`: Added test for dispose cleanup

## Related

Closes #2020
