### PR TITLE
fix(auth): correct getAuthorizationDetails return type for already consented OAuth responses

### DIFF
--- a/packages/core/auth-js/src/lib/types.ts
+++ b/packages/core/auth-js/src/lib/types.ts
@@ -1782,10 +1782,21 @@ export type OAuthAuthorizationDetails = {
 }
 
 /**
+ * OAuth authorization details when user has already consented.
+ * Only relevant when the OAuth 2.1 server is enabled in Supabase Auth.
+ */
+export type OAuthAlreadyConsentedDetails = {
+  /** URL to redirect the user back to the OAuth client */
+  redirect_url: string
+}
+
+/**
  * Response type for getting OAuth authorization details.
  * Only relevant when the OAuth 2.1 server is enabled in Supabase Auth.
  */
-export type AuthOAuthAuthorizationDetailsResponse = RequestResult<OAuthAuthorizationDetails>
+export type AuthOAuthAuthorizationDetailsResponse = RequestResult<
+  OAuthAuthorizationDetails | OAuthAlreadyConsentedDetails
+>
 
 /**
  * Response type for OAuth consent decision (approve/deny).
@@ -1834,7 +1845,7 @@ export interface AuthOAuthServerApi {
    * Only relevant when the OAuth 2.1 server is enabled in Supabase Auth.
    *
    * This method returns authorization details including client info, scopes, and user information.
-   * If the response includes a redirect_uri, it means consent was already given - the caller
+   * If the response includes a redirect_url, it means consent was already given - the caller
    * should handle the redirect manually if needed.
    *
    * @param authorizationId - The authorization ID from the authorization request


### PR DESCRIPTION
## Summary

Make `OAuthAuthorizationDetails` fields optional to support already-consented OAuth responses.

## Problem

`getAuthorizationDetails` is typed to return `AuthOAuthAuthorizationDetailsResponse` with required fields (`authorization_id`, `client`, `user`, `scope`).
 However, when a user has already approved access to an OAuth client, the API returns only `{ redirect_url: string }` without the other fields, causing TypeScript type mismatches.

## Solution

Made `authorization_id`, `client`, `user`, and `scope` optional in `OAuthAuthorizationDetails` type. 
Also fixed a typo in the JSDoc (`redirect_uri` → `redirect_url`).

## Related

- Closes https://github.com/supabase/supabase-js/issues/2023
