### PR TITLE
fix(auth): clear local storage on signOut when session is already missing

### DIFF
--- a/packages/core/auth-js/src/GoTrueClient.ts
+++ b/packages/core/auth-js/src/GoTrueClient.ts
@@ -2156,7 +2156,7 @@ export default class GoTrueClient {
   ): Promise<{ error: AuthError | null }> {
     return await this._useSession(async (result) => {
       const { data, error: sessionError } = result
-      if (sessionError) {
+      if (sessionError && !isAuthSessionMissingError(sessionError)) {
         return this._returnResult({ error: sessionError })
       }
       const accessToken = data.session?.access_token
@@ -2167,8 +2167,9 @@ export default class GoTrueClient {
           // ignore 401s since an invalid or expired JWT should sign out the current session
           if (
             !(
-              isAuthApiError(error) &&
-              (error.status === 404 || error.status === 401 || error.status === 403)
+              (isAuthApiError(error) &&
+                (error.status === 404 || error.status === 401 || error.status === 403)) ||
+              isAuthSessionMissingError(error)
             )
           ) {
             return this._returnResult({ error })


### PR DESCRIPTION
## Summary

Fixes signOut throwing AuthSessionMissingError and leaving stale session data in local storage when the session was already invalidated from another device.

## Problem

When a user signs out globally from one device, all sessions are invalidated on the server. If the user then tries to call signOut() from a second device, the method throws AuthSessionMissingError and returns early without clearing the local storage. This leaves the client in a broken state with stale session data.

## Solution

Handle AuthSessionMissingError in _signOut by:
1. Not returning early when sessionError is AuthSessionMissingError
2. Ignoring AuthSessionMissingError from admin.signOut alongside existing 404/401/403 handling

This ensures local storage is always cleared when signOut is called, regardless of server-side session state.

## Related

- Closes https://github.com/supabase/supabase-js/issues/1616
