### PR TITLE
Fix/postgrest not null narrowing

### DIFF
--- a/packages/core/postgrest-js/src/PostgrestTransformBuilder.ts
+++ b/packages/core/postgrest-js/src/PostgrestTransformBuilder.ts
@@ -72,20 +72,9 @@ export default class PostgrestTransformBuilder<
     >
   }
 
-  order<ColumnName extends string & keyof Row>(
-    column: ColumnName,
-    options?: { ascending?: boolean; nullsFirst?: boolean; referencedTable?: undefined }
-  ): this
   order(
     column: string,
     options?: { ascending?: boolean; nullsFirst?: boolean; referencedTable?: string }
-  ): this
-  /**
-   * @deprecated Use `options.referencedTable` instead of `options.foreignTable`
-   */
-  order<ColumnName extends string & keyof Row>(
-    column: ColumnName,
-    options?: { ascending?: boolean; nullsFirst?: boolean; foreignTable?: undefined }
   ): this
   /**
    * @deprecated Use `options.referencedTable` instead of `options.foreignTable`


### PR DESCRIPTION
Improves TypeScript type inference for PostgREST filters by correctly narrowing column types after explicit non-null checks.

### What changed?

- Added a specialized overload for `not(column, 'is', null)` in `PostgrestFilterBuilder`
- Ensured that when a column is filtered to exclude `NULL`, the resulting row type marks that column as **non-nullable**
- Preserved existing behavior for all other `not()` filter usages

### Why was this change needed?

Previously, filtering out `NULL` values using `not(column, 'is', null)` did not update the inferred row type, leaving the column typed as nullable.  
This caused a mismatch between PostgREST semantics and TypeScript inference.

This change aligns the type system with runtime behavior and improves developer ergonomics.

Closes #1360

## 📸 Screenshots/Examples

```ts
// Before
const { data } = await supabase
  .from('users')
  .select()
  .not('email', 'is', null)

// email: string | null ❌

// After
// email: string ✅