### PR TITLE
fix(realtime): wait for postgres_changes system ready before emitting SUBSCRIBED

### DIFF
--- a/packages/core/realtime-js/src/RealtimeChannel.ts
+++ b/packages/core/realtime-js/src/RealtimeChannel.ts
@@ -355,8 +355,12 @@ export default class RealtimeChannel {
 
             this.bindings.postgres_changes = newPostgresBindings
 
-            this._subscribeCallback = callback || null
-            this._pendingSystemReady.add('postgres_changes')
+            if (bindingsLen > 0) {
+              this._subscribeCallback = callback || null
+              this._pendingSystemReady.add('postgres_changes')
+            } else {
+              callback?.(REALTIME_SUBSCRIBE_STATES.SUBSCRIBED)
+            }
             return
           }
         })

--- a/packages/core/realtime-js/src/RealtimeChannel.ts
+++ b/packages/core/realtime-js/src/RealtimeChannel.ts
@@ -180,6 +180,9 @@ export default class RealtimeChannel {
   broadcastEndpointURL: string
   subTopic: string
   private: boolean
+  private _subscribeCallback: ((status: REALTIME_SUBSCRIBE_STATES, err?: Error) => void) | null =
+    null
+  private _pendingSystemReady: Set<string> = new Set()
 
   /**
    * Creates a channel that can broadcast messages, sync presence, and listen to Postgres changes.
@@ -352,7 +355,8 @@ export default class RealtimeChannel {
 
             this.bindings.postgres_changes = newPostgresBindings
 
-            callback && callback(REALTIME_SUBSCRIBE_STATES.SUBSCRIBED)
+            this._subscribeCallback = callback || null
+            this._pendingSystemReady.add('postgres_changes')
             return
           }
         })
@@ -820,6 +824,14 @@ export default class RealtimeChannel {
   }
 
   /** @internal */
+  _maybeEmitSubscribed(): void {
+    if (this._pendingSystemReady.size === 0 && this._subscribeCallback) {
+      this._subscribeCallback(REALTIME_SUBSCRIBE_STATES.SUBSCRIBED)
+      this._subscribeCallback = null
+    }
+  }
+
+  /** @internal */
   _trigger(type: string, payload?: any, ref?: string) {
     const typeLower = type.toLocaleLowerCase()
     const { close, error, leave, join } = CHANNEL_EVENTS
@@ -827,6 +839,12 @@ export default class RealtimeChannel {
     if (ref && events.indexOf(typeLower) >= 0 && ref !== this._joinRef()) {
       return
     }
+
+    if (typeLower === 'system' && payload?.extension && payload?.status === 'ok') {
+      this._pendingSystemReady.delete(payload.extension)
+      this._maybeEmitSubscribed()
+    }
+
     let handledPayload = this._onMessage(typeLower, payload, ref)
     if (payload && !handledPayload) {
       throw 'channel onMessage callbacks must return the payload, modified or unmodified'

--- a/packages/core/realtime-js/test/RealtimeChannel.lifecycle.test.ts
+++ b/packages/core/realtime-js/test/RealtimeChannel.lifecycle.test.ts
@@ -349,6 +349,8 @@ describe('Channel Lifecycle Management', () => {
           },
         })
 
+        channel._trigger('system', { extension: 'postgres_changes', status: 'ok' })
+
         expect(spy).toHaveBeenCalledTimes(1)
         expect(spy).toHaveBeenCalledWith({
           topic: 'realtime:topic',


### PR DESCRIPTION
## Summary

Fixes a race condition where `SUBSCRIBED` status is emitted before PostgreSQL logical replication is ready,
 causing early database writes to miss `postgres_changes` events.

## Problem

The Realtime subscription has a two-stage backend process:
1. **Stage 1 (Fast)**: Phoenix WebSocket channel join completes
2. **Stage 2 (Slow)**: PostgreSQL replication slot creation and stream initialization

Previously, the client emitted `SUBSCRIBED` after Stage 1, but the replication stream wasn't ready until Stage 2 completed. Any database writes in this window (~1-3 seconds) would not trigger `postgres_changes` events.

## Solution

Wait for the server's system message `{ extension: 'postgres_changes', status: 'ok' }` before emitting `SUBSCRIBED` when postgres_changes bindings are present. This message is sent by the server after `Realtime.Tenants.ReplicationConnection` confirms the replication stream is active.

For channels without postgres_changes (broadcast/presence only), behavior is unchanged.

## Changes

- Store subscribe callback and track pending system confirmations
- Add `_maybeEmitSubscribed()` that only fires when all confirmations received
- Handle system message in `_trigger()` to clear pending state
- Updated existing lifecycle tests to include system message trigger.

---
## Related

- Closes: https://github.com/supabase/supabase-js/issues/1599