### PR TITLE
fix(auth): clarify updateUserById applies changes directly

### DIFF
--- a/packages/core/auth-js/src/GoTrueAdminApi.ts
+++ b/packages/core/auth-js/src/GoTrueAdminApi.ts
@@ -276,7 +276,7 @@ export default class GoTrueAdminApi {
   }
 
   /**
-   * Updates the user data.
+   * Updates the user data. Changes are applied directly without confirmation flows.
    *
    * @param attributes The data you want to update.
    *

--- a/packages/core/auth-js/src/lib/types.ts
+++ b/packages/core/auth-js/src/lib/types.ts
@@ -515,14 +515,14 @@ export interface AdminUserAttributes extends Omit<UserAttributes, 'data'> {
   app_metadata?: object
 
   /**
-   * Confirms the user's email address if set to true.
+   * Sets the user's email as confirmed when true, or unconfirmed when false.
    *
    * Only a service role can modify.
    */
   email_confirm?: boolean
 
   /**
-   * Confirms the user's phone number if set to true.
+   * Sets the user's phone as confirmed when true, or unconfirmed when false.
    *
    * Only a service role can modify.
    */


### PR DESCRIPTION
## Summary

Users expected `updateUserById({ email, email_confirm: false })` to require user confirmation before applying the email change. The admin API intentionally applies changes directly.

## Problem

The documentation for `updateUserById` and `email_confirm`/`phone_confirm` was ambiguous, leading users to believe setting `email_confirm: false` would prevent immediate email updates.

## Solution

Clarified documentation:
- `updateUserById`: "Changes are applied directly without confirmation flows"
- `email_confirm`: "Sets the user's email as confirmed when true, or unconfirmed when false"
- `phone_confirm`: "Sets the user's phone as confirmed when true, or unconfirmed when false"

## Related

- Closes #1307