### PR TITLE
fix(auth): handle uncaught promise rejections during initialization

### DIFF
--- a/packages/core/auth-js/src/GoTrueClient.ts
+++ b/packages/core/auth-js/src/GoTrueClient.ts
@@ -398,11 +398,17 @@ export default class GoTrueClient {
       this.broadcastChannel?.addEventListener('message', async (event) => {
         this._debug('received broadcast notification from other tab or client', event)
 
-        await this._notifyAllSubscribers(event.data.event, event.data.session, false) // broadcast = false so we don't get an endless loop of messages
+        try {
+          await this._notifyAllSubscribers(event.data.event, event.data.session, false) // broadcast = false so we don't get an endless loop of messages
+        } catch (error) {
+          this._debug('#broadcastChannel', 'error', error)
+        }
       })
     }
 
-    this.initialize()
+    this.initialize().catch((error) => {
+      this._debug('#initialize()', 'error', error)
+    })
   }
 
   /**
@@ -3028,7 +3034,13 @@ export default class GoTrueClient {
     }
 
     try {
-      this.visibilityChangedCallback = async () => await this._onVisibilityChanged(false)
+      this.visibilityChangedCallback = async () => {
+        try {
+          await this._onVisibilityChanged(false)
+        } catch (error) {
+          this._debug('#visibilityChangedCallback', 'error', error)
+        }
+      }
 
       window?.addEventListener('visibilitychange', this.visibilityChangedCallback)
 


### PR DESCRIPTION
## Problem

`initialize()` is called in the constructor without a `.catch()` handler. 
When using async storage adapters (e.g., Chrome extensions), lock acquisition timeouts or storage errors cause unhandled promise rejections that crash the application.

## Solution

Add `.catch()` handlers to `initialize()`, broadcast channel message handler, and visibility change callback. 
Errors are logged via `_debug()` and remain retrievable via `await client.initialize()`.

## Related

- Closes #2030