### PR TITLE
fix(supabase): resolve Firefox extension cross-context Promise error

### DIFF
--- a/packages/core/supabase-js/src/SupabaseClient.ts
+++ b/packages/core/supabase-js/src/SupabaseClient.ts
@@ -165,7 +165,8 @@ export default class SupabaseClient<
     })
     if (this.accessToken) {
       // Start auth immediately to avoid race condition with channel subscriptions
-      this.accessToken()
+      // Wrap Promise to avoid Firefox extension cross-context Promise access errors
+      Promise.resolve(this.accessToken())
         .then((token) => this.realtime.setAuth(token))
         .catch((e) => console.warn('Failed to set initial Realtime auth token:', e))
     }


### PR DESCRIPTION
## Summary
Firefox extensions throw `"Permission denied to access property 'then'"` when initializing Supabase client with custom `accessToken` option.

## Problem
Firefox's XRay Vision security prevents direct `.then()` access on Promises from different security contexts
 (background script vs content script).

## Solution
Wrap `accessToken()` Promise with `Promise.resolve()` to create a new Promise in the current context before chaining.

## Related
- Closes #1710