### PR TITLE
feat(realtime): set default serializer to 2.0.0

### DIFF
--- a/packages/core/realtime-js/src/RealtimeClient.ts
+++ b/packages/core/realtime-js/src/RealtimeClient.ts
@@ -165,6 +165,7 @@ export default class RealtimeClient {
    * @param options.reconnectAfterMs he optional function that returns the millsec reconnect interval. Defaults to stepped backoff off.
    * @param options.worker Use Web Worker to set a side flow. Defaults to false.
    * @param options.workerUrl The URL of the worker script. Defaults to https://realtime.supabase.com/worker.js that includes a heartbeat event call to keep the connection alive.
+   * @param options.vsn The protocol version to use when connecting. Supported versions are "1.0.0" and "2.0.0". Defaults to "2.0.0".
    * @example
    * ```ts
    * import RealtimeClient from '@supabase/realtime-js'

--- a/packages/core/realtime-js/src/lib/constants.ts
+++ b/packages/core/realtime-js/src/lib/constants.ts
@@ -4,7 +4,7 @@ export const DEFAULT_VERSION = `realtime-js/${version}`
 
 export const VSN_1_0_0: string = '1.0.0'
 export const VSN_2_0_0: string = '2.0.0'
-export const DEFAULT_VSN: string = VSN_1_0_0
+export const DEFAULT_VSN: string = VSN_2_0_0
 
 export const VERSION = version
 

--- a/packages/core/realtime-js/test/RealtimeClient.auth.test.ts
+++ b/packages/core/realtime-js/test/RealtimeClient.auth.test.ts
@@ -172,7 +172,7 @@ describe('auth during connection states', () => {
       .spyOn(connectedSetup.socket, 'accessTokenValue', 'get')
       .mockReturnValue(token)
 
-    const heartbeatData = '{"topic":"phoenix","event":"heartbeat","payload":{},"ref":"1"}'
+    const heartbeatData = JSON.stringify([null, '1', 'phoenix', 'heartbeat', {}])
 
     await connectedSetup.socket.sendHeartbeat()
 

--- a/packages/core/realtime-js/test/RealtimeClient.config.test.ts
+++ b/packages/core/realtime-js/test/RealtimeClient.config.test.ts
@@ -17,7 +17,7 @@ describe('endpointURL', () => {
   test('returns endpoint for given full url', () => {
     assert.equal(
       testSetup.socket.endpointURL(),
-      `${testSetup.url}/websocket?apikey=123456789&vsn=1.0.0`
+      `${testSetup.url}/websocket?apikey=123456789&vsn=2.0.0`
     )
   })
 
@@ -27,7 +27,7 @@ describe('endpointURL', () => {
     })
     assert.equal(
       socket.endpointURL(),
-      `${testSetup.url}/websocket?foo=bar&apikey=123456789&vsn=1.0.0`
+      `${testSetup.url}/websocket?foo=bar&apikey=123456789&vsn=2.0.0`
     )
   })
 
@@ -35,15 +35,15 @@ describe('endpointURL', () => {
     const socket = new RealtimeClient(testSetup.url, {
       params: { apikey: '123456789' },
     })
-    assert.equal(socket.endpointURL(), `${testSetup.url}/websocket?apikey=123456789&vsn=1.0.0`)
+    assert.equal(socket.endpointURL(), `${testSetup.url}/websocket?apikey=123456789&vsn=2.0.0`)
   })
 
   test('returns endpoint with valid vsn', () => {
     const socket = new RealtimeClient(testSetup.url, {
       params: { apikey: '123456789' },
-      vsn: '2.0.0',
+      vsn: '1.0.0',
     })
-    assert.equal(socket.endpointURL(), `${testSetup.url}/websocket?apikey=123456789&vsn=2.0.0`)
+    assert.equal(socket.endpointURL(), `${testSetup.url}/websocket?apikey=123456789&vsn=1.0.0`)
   })
 
   test('errors out with unsupported version', () => {
@@ -58,6 +58,6 @@ describe('endpointURL', () => {
     })
     // Clear params after construction to test empty params scenario
     socket.params = {}
-    assert.equal(socket.endpointURL(), `${testSetup.url}/websocket?vsn=1.0.0`)
+    assert.equal(socket.endpointURL(), `${testSetup.url}/websocket?vsn=2.0.0`)
   })
 })

--- a/packages/core/realtime-js/test/RealtimeClient.errors.test.ts
+++ b/packages/core/realtime-js/test/RealtimeClient.errors.test.ts
@@ -88,7 +88,7 @@ describe('log operations', () => {
     assert.equal(testSetup.socket.logLevel, 'warn')
     assert.equal(
       testSetup.socket.endpointURL(),
-      `${testSetup.url}/websocket?apikey=123456789&log_level=warn&vsn=1.0.0`
+      `${testSetup.url}/websocket?apikey=123456789&log_level=warn&vsn=2.0.0`
     )
   })
 
@@ -101,7 +101,7 @@ describe('log operations', () => {
     assert.equal(testSetup.socket.logLevel, 'warn')
     assert.equal(
       testSetup.socket.endpointURL(),
-      `${testSetup.url}/websocket?apikey=123456789&log_level=warn&vsn=1.0.0`
+      `${testSetup.url}/websocket?apikey=123456789&log_level=warn&vsn=2.0.0`
     )
   })
 })

--- a/packages/core/realtime-js/test/RealtimeClient.heartbeatCallback.test.ts
+++ b/packages/core/realtime-js/test/RealtimeClient.heartbeatCallback.test.ts
@@ -109,12 +109,7 @@ describe('heartbeatCallback option', () => {
     socket['_heartbeatSentAt'] = Date.now() - 60000
 
     // Simulate heartbeat response message
-    const heartbeatResponse = {
-      topic: 'phoenix',
-      event: 'phx_reply',
-      payload: { status: 'ok' },
-      ref: '1',
-    }
+    const heartbeatResponse = [null, '1', 'phoenix', 'phx_reply', { status: 'ok' }]
 
     // Trigger message handling
     socket['_onConnMessage']({ data: JSON.stringify(heartbeatResponse) })
@@ -143,12 +138,7 @@ describe('heartbeatCallback option', () => {
     socket.pendingHeartbeatRef = '1'
 
     // Simulate heartbeat error response message
-    const heartbeatResponse = {
-      topic: 'phoenix',
-      event: 'phx_reply',
-      payload: { status: 'error' },
-      ref: '1',
-    }
+    const heartbeatResponse = [null, '1', 'phoenix', 'phx_reply', { status: 'error' }]
 
     // Trigger message handling
     socket['_onConnMessage']({ data: JSON.stringify(heartbeatResponse) })
@@ -182,12 +172,7 @@ describe('heartbeatCallback option', () => {
     socket.conn = mockConn as any
 
     // Simulate successful heartbeat response (should call with 'ok')
-    const heartbeatResponse = {
-      topic: 'phoenix',
-      event: 'phx_reply',
-      payload: { status: 'ok' },
-      ref: '1',
-    }
+    const heartbeatResponse = [null, '1', 'phoenix', 'phx_reply', { status: 'ok' }]
 
     socket['_onConnMessage']({ data: JSON.stringify(heartbeatResponse) })
 
@@ -252,12 +237,7 @@ describe('heartbeatCallback option', () => {
     const logSpy = vi.spyOn(socket, 'log')
 
     // Simulate heartbeat response message - should not throw despite callback error
-    const heartbeatResponse = {
-      topic: 'phoenix',
-      event: 'phx_reply',
-      payload: { status: 'ok' },
-      ref: '1',
-    }
+    const heartbeatResponse = [null, '1', 'phoenix', 'phx_reply', { status: 'ok' }]
 
     expect(() => {
       socket['_onConnMessage']({ data: JSON.stringify(heartbeatResponse) })

--- a/packages/core/realtime-js/test/RealtimeClient.test.ts
+++ b/packages/core/realtime-js/test/RealtimeClient.test.ts
@@ -270,12 +270,7 @@ describe('Additional Coverage Tests', () => {
       testSetup.socket.pendingHeartbeatRef = 'test-ref-123'
 
       const message = {
-        data: JSON.stringify({
-          topic: 'phoenix',
-          event: 'phx_reply',
-          payload: { status: 'ok' },
-          ref: 'test-ref-123',
-        }),
+        data: JSON.stringify([null, 'test-ref-123', 'phoenix', 'phx_reply', { status: 'ok' }]),
       }
 
       ;(testSetup.socket as any)._onConnMessage(message)
@@ -287,12 +282,7 @@ describe('Additional Coverage Tests', () => {
       testSetup.socket.pendingHeartbeatRef = 'test-ref-123'
 
       const message = {
-        data: JSON.stringify({
-          topic: 'phoenix',
-          event: 'phx_reply',
-          payload: { status: 'ok' },
-          ref: 'different-ref',
-        }),
+        data: JSON.stringify([null, 'different-ref', 'phoenix', 'phx_reply', { status: 'ok' }]),
       }
 
       ;(testSetup.socket as any)._onConnMessage(message)
@@ -304,12 +294,7 @@ describe('Additional Coverage Tests', () => {
       const logSpy = vi.spyOn(testSetup.socket, 'log')
 
       const message = {
-        data: JSON.stringify({
-          topic: 'test-topic',
-          event: 'test-event',
-          payload: { data: 'test' },
-          // No ref field
-        }),
+        data: JSON.stringify([null, null, 'test-topic', 'test-event', { data: 'test' }]),
       }
 
       ;(testSetup.socket as any)._onConnMessage(message)
@@ -468,12 +453,7 @@ describe('Additional Coverage Tests', () => {
       const logSpy = vi.spyOn(testSetup.socket, 'log')
 
       const message = {
-        data: JSON.stringify({
-          topic: 'test-topic',
-          event: 'test-event',
-          payload: { data: 'test' },
-          ref: '123',
-        }),
+        data: JSON.stringify([null, '123', 'test-topic', 'test-event', { data: 'test' }]),
       }
 
       ;(testSetup.socket as any)._onConnMessage(message)


### PR DESCRIPTION
<!-- Your PR title should follow the conventional commit format:
<type>(<scope>): <description> -->

## 🔍 Description

<!-- Provide a clear and concise description of what this PR does -->

Set default serializer to 2.0.0

The serializer version can be set to 1.0.0 in case of any issues

### What changed?

<!-- Describe the changes made in this PR -->

It just sets the default serializer to 2.0.0 instead of 1.0.0

### Why was this change needed?

<!-- Explain the motivation behind this change. Link any related issues. -->

2.0.0 protocol version has performance improvements and the ability to send binary payloads without extra encoding

## 📸 Screenshots/Examples

<!-- If applicable, add screenshots or code examples to help explain your changes -->

## 🔄 Breaking changes

<!-- If this PR contains breaking changes, describe them here -->

- [x] This PR contains no breaking changes

## 📋 Checklist

<!-- Ensure all items are checked before submitting -->

- [x] I have read the [Contributing Guidelines](https://github.com/supabase/supabase-js/blob/master/CONTRIBUTING.md)
- [x] My PR title follows the [conventional commit format](https://www.conventionalcommits.org/): `<type>(<scope>): <description>`
- [x] I have run `npx nx format` to ensure consistent code formatting
- [x] I have added tests for new functionality (if applicable)
- [x] I have updated documentation (if applicable)

## 📝 Additional notes

<!-- Add any additional notes, context, or concerns for reviewers -->

<!-- Thank you for contributing to Supabase! 💚 -->


Related to https://github.com/supabase/supabase-js/pull/1829, https://github.com/supabase/supabase-js/pull/1862, https://github.com/supabase/supabase-js/pull/1871, https://github.com/supabase/supabase-js/pull/1894 and https://github.com/supabase/supabase-js/pull/1925