### PR TITLE
fix(auth): restore SSR OAuth functionality broken in v2.91.0

### DIFF
--- a/packages/core/auth-js/src/GoTrueClient.ts
+++ b/packages/core/auth-js/src/GoTrueClient.ts
@@ -1146,9 +1146,7 @@ export default class GoTrueClient {
       }
       if (data.session) {
         await this._saveSession(data.session)
-        setTimeout(async () => {
-          await this._notifyAllSubscribers('SIGNED_IN', data.session)
-        }, 0)
+        await this._notifyAllSubscribers('SIGNED_IN', data.session)
       }
       return this._returnResult({ data: { ...data, redirectType: redirectType ?? null }, error })
     } catch (error) {


### PR DESCRIPTION
# Summary

Reverts #2014 which broke OAuth authentication in SSR/serverless environments.

# Problem

PR #2014 added `setTimeout(..., 0)` to defer `SIGNED_IN` event notifications in `exchangeCodeForSession`. While this prevented a deadlock in some scenarios, it introduced a critical regression:

**In serverless/SSR environments (Next.js, Vercel, etc.):**
- OAuth callbacks rely on `exchangeCodeForSession` to trigger auth state change listeners
- These listeners (via `@supabase/ssr`) write auth cookies during the request
- `setTimeout(..., 0)` defers execution to the next event loop tick
- The serverless function completes and returns the response **before** the deferred callback runs
- Result: **No auth cookies are set, OAuth login fails**

**User Impact:**
- OAuth login (Google, etc.) stopped working after upgrading from v2.90.1 to v2.91.0
- Users are redirected but remain logged out
- OTP auth continues to work (unaffected)

# Solution

The deadlock issue that #2014 attempted to fix is properly addressed by #2016, which makes `_notifyAllSubscribers` non-blocking by removing `await` on subscriber callbacks. This approach:

✅ Prevents deadlocks when callbacks perform async operations like `getUser()` or `getSession()`  
✅ Keeps notifications synchronous so SSR cookie adapters work correctly  
✅ Fixes the root cause instead of working around it with `setTimeout`

# Related

- Closes https://github.com/supabase/supabase-js/issues/2037
- Supersedes https://github.com/supabase/supabase-js/pull/2038
- Superseded by #2016 (proper deadlock fix)
- Original deadlock issue: #2013

