### PR TITLE
feat(supabase): add missing HTTP headers for client platform and runtime detection

### DIFF
--- a/packages/core/supabase-js/src/lib/constants.ts
+++ b/packages/core/supabase-js/src/lib/constants.ts
@@ -45,12 +45,30 @@ export function getClientPlatform(): string | null {
 }
 
 export function getClientPlatformVersion(): string | null {
+  // Node.js / Bun environment
   // @ts-ignore
-  if (typeof process !== 'undefined' && process.version) {
-    // @ts-ignore
-    return process.version.slice(1)
+  if (typeof process !== 'undefined' && process.versions && process.versions.node) {
+    try {
+      // @ts-ignore
+      const os = require('os')
+      return os.release()
+    } catch (error) {
+      return null
+    }
   }
 
+  // Deno environment
+  // @ts-ignore
+  if (typeof Deno !== 'undefined' && Deno.osRelease) {
+    try {
+      // @ts-ignore
+      return Deno.osRelease()
+    } catch (error) {
+      return null
+    }
+  }
+
+  // Browser environment
   // @ts-ignore
   if (typeof navigator !== 'undefined') {
     // Modern User-Agent Client Hints API

--- a/packages/core/supabase-js/test/unit/constants.test.ts
+++ b/packages/core/supabase-js/test/unit/constants.test.ts
@@ -113,6 +113,59 @@ describe('constants', () => {
           expect(version.length).toBeGreaterThan(0)
         }
       })
+
+      test('getClientPlatformVersion returns OS version, not runtime version in Node.js', () => {
+        // Only run this test in Node.js environment
+        if (typeof process !== 'undefined' && process.versions && process.versions.node) {
+          const platformVersion = getClientPlatformVersion()
+          const runtimeVersion = getClientRuntimeVersion()
+
+          // Both should exist in Node.js environment
+          expect(platformVersion).not.toBeNull()
+          expect(runtimeVersion).not.toBeNull()
+
+          // They should be DIFFERENT values
+          if (platformVersion && runtimeVersion) {
+            expect(platformVersion).not.toBe(runtimeVersion)
+
+            // Platform version should NOT match Node.js version format
+            expect(platformVersion).not.toBe(process.version.slice(1))
+            expect(platformVersion).not.toBe(process.versions.node)
+          }
+        }
+      })
+
+      test('getClientPlatformVersion uses os.release() in Node.js', () => {
+        // Only run this test in Node.js environment
+        if (typeof process !== 'undefined' && process.versions && process.versions.node) {
+          const platformVersion = getClientPlatformVersion()
+          const os = require('os')
+          const expectedVersion = os.release()
+
+          expect(platformVersion).toBe(expectedVersion)
+        }
+      })
+
+      test('X-Supabase-Client-Platform-Version header contains OS version, not runtime version', () => {
+        const headers = DEFAULT_HEADERS
+
+        if (
+          headers['X-Supabase-Client-Platform-Version'] &&
+          headers['X-Supabase-Client-Runtime-Version']
+        ) {
+          const platformVersion = headers['X-Supabase-Client-Platform-Version']
+          const runtimeVersion = headers['X-Supabase-Client-Runtime-Version']
+
+          // Platform version should be different from runtime version
+          expect(platformVersion).not.toBe(runtimeVersion)
+
+          // In Node.js, ensure platform version is not the Node.js version
+          if (typeof process !== 'undefined' && process.versions && process.versions.node) {
+            expect(platformVersion).not.toBe(process.version.slice(1))
+            expect(platformVersion).not.toBe(process.versions.node)
+          }
+        }
+      })
     })
 
     describe('Client Runtime Detection', () => {


### PR DESCRIPTION
Moved from https://github.com/supabase/supabase-js/pull/1505
Author: @grdsdev 

## Summary

Add missing HTTP headers for client platform and runtime detection with simplified logic that only includes headers when detection is reliable.

## New Headers Added

- `X-Supabase-Client-Platform`: OS detection (macOS, Windows, Linux, iOS, Android)
- `X-Supabase-Client-Platform-Version`: Platform version 
- `X-Supabase-Client-Runtime`: Runtime environment (node, deno, bun)
- `X-Supabase-Client-Runtime-Version`: Runtime version

## Key Features

- Simple detection without regex pattern matching
- Headers omitted when detection fails (no "unknown" values)
- Backward compatible with existing `X-Client-Info` header
- Comprehensive unit tests added

## Test plan

- [x] All existing tests pass
- [x] New unit tests cover all detection functions
- [x] Tests verify conditional header inclusion