### PR TITLE
ci(deps): upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/ci-supabase-js.yml
+++ b/.github/workflows/ci-supabase-js.yml
@@ -454,7 +454,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@f4d14e03ff726c06358e5557344e1da148b56cf7 # v1.2.2
+        uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3  # v2.1.2
         with:
           bun-version: latest
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -142,7 +142,7 @@ jobs:
           find ./gh-pages -name "*.json" -o -name "*.html" | head -20
 
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@373f7f263a76c20808c831209c920827a82a2847 # v3.9.3
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e  # v4.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./gh-pages


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions for improved features, bug fixes, and security updates.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `oven-sh/setup-bun` | [`f4d14e0`](https://github.com/oven-sh/setup-bun/commit/f4d14e03ff726c06358e5557344e1da148b56cf7) | [`3d26778`](https://github.com/oven-sh/setup-bun/commit/3d267786b128fe76c2f16a390aa2448b815359f3) | [Release](https://github.com/oven-sh/setup-bun/releases/tag/v2) | ci-supabase-js.yml |
| `peaceiris/actions-gh-pages` | [`373f7f2`](https://github.com/peaceiris/actions-gh-pages/commit/373f7f263a76c20808c831209c920827a82a2847) | [`4f9cc66`](https://github.com/peaceiris/actions-gh-pages/commit/4f9cc6602d3f66b9c108549d475ec49e8ef4d45e) | [Release](https://github.com/peaceiris/actions-gh-pages/releases/tag/v4) | docs.yml |

## Why upgrade?

Keeping GitHub Actions up to date ensures:
- **Security**: Latest security patches and fixes
- **Features**: Access to new functionality and improvements
- **Compatibility**: Better support for current GitHub features
- **Performance**: Optimizations and efficiency improvements

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
