### PR TITLE
chore(postgrest): clarify count behaviour with pagination methods

### DIFF
--- a/packages/core/postgrest-js/src/PostgrestQueryBuilder.ts
+++ b/packages/core/postgrest-js/src/PostgrestQueryBuilder.ts
@@ -82,6 +82,10 @@ export default class PostgrestQueryBuilder<
    *
    * `"estimated"`: Uses exact count for low numbers and planned count for high
    * numbers.
+   *
+   * @remarks
+   * When using `count` with `.range()` or `.limit()`, the returned `count` is the total number of rows
+   * that match your filters, not the number of rows in the current page. Use this to build pagination UI.
    */
   select<
     Query extends string = '*',


### PR DESCRIPTION
## Summary

Adds TSDoc clarification to the `select()` method explaining that `count` with pagination methods returns the total number of matching rows, not the paginated count.

## Problem

Users reported that `count` appears to "ignore" `.range()` filters, expecting `count` to match `data.length` when using pagination. However, this is the **intended behavior**, not a bug.

The confusion arises because:
- `data.length` returns the number of rows in the current page (e.g., 10)
- `count` returns the total number of matching rows across all pages (e.g., 100)

## Solution

Added `@remarks` to the `select()` method TSDoc clarifying that when using `count` with `.range()` or `.limit()`, the returned `count` represents the total number of rows matching your filters (before pagination). 
This is the intended behavior to enable building pagination UI like "Showing 1-10 of 100 results".


## Related
- Closes https://github.com/supabase/supabase-js/issues/1275

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified documentation for count operations when used with pagination or limit parameters, specifying that the count reflects the total number of rows matching filters rather than just the returned subset.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->