### PR TITLE
refactor(auth): make error handling consistent in setSession

### DIFF
--- a/packages/core/auth-js/src/GoTrueClient.ts
+++ b/packages/core/auth-js/src/GoTrueClient.ts
@@ -1899,7 +1899,7 @@ export default class GoTrueClient {
       } else {
         const { data, error } = await this._getUser(currentSession.access_token)
         if (error) {
-          throw error
+          return this._returnResult({ data: { user: null, session: null }, error })
         }
         session = {
           access_token: currentSession.access_token,


### PR DESCRIPTION
### Summary
Makes error handling consistent in `_setSession` by returning errors directly instead of throwing them.

### Problem
Line 1902 throws an error from `_getUser`, while line 1893 returns an error from `_callRefreshToken`. 
This inconsistency within the same function makes the code harder to understand and maintain

### Solution
Changed to return the error via `_returnResult()`, matching the existing pattern used.

### Related
- closes #1699

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved error handling consistency for anonymous sign-in operations.
* Enhanced session validation error handling to return standardized result formats instead of throwing exceptions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->