### PR TITLE
revert(realtime): validate table filter in postgres_changes event dispatch

### DIFF
--- a/packages/core/realtime-js/src/RealtimeChannel.ts
+++ b/packages/core/realtime-js/src/RealtimeChannel.ts
@@ -854,8 +854,7 @@ export default class RealtimeChannel {
                 bindId &&
                 payload.ids?.includes(bindId) &&
                 (bindEvent === '*' ||
-                  bindEvent?.toLocaleLowerCase() === payload.data?.type.toLocaleLowerCase()) &&
-                (!bind.filter?.table || bind.filter.table === payload.data?.table)
+                  bindEvent?.toLocaleLowerCase() === payload.data?.type.toLocaleLowerCase())
               )
             } else {
               const bindEvent = bind?.filter?.event?.toLocaleLowerCase()

--- a/packages/core/realtime-js/test/RealtimeChannel.postgres.test.ts
+++ b/packages/core/realtime-js/test/RealtimeChannel.postgres.test.ts
@@ -570,48 +570,6 @@ describe('Postgres Changes Trigger Tests', () => {
   })
 })
 
-describe('PostgreSQL table filter validation', () => {
-  test('should only trigger callback for matching table when ids match', () => {
-    const conversationsSpy = vi.fn()
-    const messagesSpy = vi.fn()
-
-    channel.bindings.postgres_changes = [
-      {
-        id: 'conv-id',
-        type: 'postgres_changes',
-        filter: { event: 'INSERT', schema: 'public', table: 'conversations' },
-        callback: conversationsSpy,
-      },
-      {
-        id: 'msg-id',
-        type: 'postgres_changes',
-        filter: { event: 'INSERT', schema: 'public', table: 'messages' },
-        callback: messagesSpy,
-      },
-    ]
-
-    channel._trigger(
-      'postgres_changes',
-      {
-        ids: ['conv-id', 'msg-id'],
-        data: {
-          type: 'INSERT',
-          table: 'messages',
-          schema: 'public',
-          record: { id: 1 },
-          columns: [{ name: 'id', type: 'int4' }],
-          commit_timestamp: '2000-01-01T00:01:01Z',
-          errors: [],
-        },
-      },
-      '1'
-    )
-
-    expect(messagesSpy).toHaveBeenCalledTimes(1)
-    expect(conversationsSpy).toHaveBeenCalledTimes(0)
-  })
-})
-
 describe('Generic event type overload', () => {
   test('should accept generic event type parameter without type errors', () => {
     const event: '*' | 'INSERT' | 'UPDATE' | 'DELETE' = 'INSERT'


### PR DESCRIPTION
This reverts commit d2cdf7fa89b4a8cd5a9f7dad68b3cde07b95fed8 from PR https://github.com/supabase/supabase-js/pull/1999

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated event filtering logic in realtime channels to ensure proper event dispatch.

* **Tests**
  * Removed PostgreSQL table filter validation test suites.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->