### PR TITLE
chore(auth): bump version in tests to v2.185.0

### DIFF
--- a/packages/core/auth-js/infra/docker-compose.yml
+++ b/packages/core/auth-js/infra/docker-compose.yml
@@ -2,7 +2,7 @@
 version: '3'
 services:
   gotrue: # Signup enabled, autoconfirm off
-    image: supabase/auth:v2.176.0
+    image: supabase/auth:v2.185.0
     ports:
       - '9999:9999'
     environment:
@@ -42,7 +42,7 @@ services:
       - db
     restart: on-failure
   autoconfirm: # Signup enabled, autoconfirm on
-    image: supabase/auth:v2.176.0
+    image: supabase/auth:v2.185.0
     ports:
       - '9998:9998'
     environment:
@@ -73,7 +73,7 @@ services:
       - db
     restart: on-failure
   autoconfirm_with_asymmetric_keys: # Signup enabled, autoconfirm on
-    image: supabase/auth:v2.176.0
+    image: supabase/auth:v2.185.0
     ports:
       - '9996:9996'
     environment:
@@ -103,7 +103,7 @@ services:
       - db
     restart: on-failure
   disabled: # Signup disabled
-    image: supabase/auth:v2.176.0
+    image: supabase/auth:v2.185.0
     ports:
       - '9997:9997'
     environment:


### PR DESCRIPTION
Bumps auth versions in tests to `v2.185.0`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal authentication service infrastructure to the latest version for continued stability and security maintenance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->