### PR TITLE
fix(ci): add persist-credentials: false to release job checkouts

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,7 +38,7 @@ jobs:
           private-key: ${{ secrets.PRIVATE_KEY }}
       - name: Check if actor is member of admin or sdk team
         id: team-check
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
@@ -68,11 +68,13 @@ jobs:
           echo "You must be a member of @supabase/admin or @supabase/sdk."
           exit 1
 
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+      - name: Checkout code
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
-      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238  # v6.2.0
+      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
@@ -157,7 +159,7 @@ jobs:
           owner: supabase
           repositories: supabase, supabase-js
       - name: Trigger supabase/supabase update-js-libs workflow
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
@@ -188,7 +190,7 @@ jobs:
           repositories: supabase, supabase-js
 
       - name: Trigger supabase/supabase docs workflow
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
@@ -265,12 +267,13 @@ jobs:
           private-key: ${{ secrets.PRIVATE_KEY }}
 
       - name: Checkout code
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238  # v6.2.0
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'


### PR DESCRIPTION
Fix release jobs failing after actions/checkout v6 upgrade

Both `release-stable` and `release-canary` jobs started failing after upgrading to `actions/checkout@v6` due to credential handling conflicts. Version 6 changed how credentials are persisted, causing "Duplicate header: Authorization" errors when release scripts try to authenticate.

**Solution**: Disable credential persistence in checkout actions so release scripts handle authentication via `RELEASE_GITHUB_TOKEN`/`GH_TOKEN` environment variables without conflicts.

**Changes**:
- Added `persist-credentials: false` to checkout steps in both `release-stable` and `release-canary` jobs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD workflow configuration structure with enhanced consistency, better step organization, and minor configuration updates for reliable publishing processes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->