### PR TITLE
feat(storage): add setHeader method to BaseApiClient

### DIFF
--- a/packages/core/storage-js/src/lib/common/BaseApiClient.ts
+++ b/packages/core/storage-js/src/lib/common/BaseApiClient.ts
@@ -47,6 +47,19 @@ export default abstract class BaseApiClient<TError extends StorageError = Storag
   }
 
   /**
+   * Set an HTTP header for the request.
+   * Creates a shallow copy of headers to avoid mutating shared state.
+   *
+   * @param name - Header name
+   * @param value - Header value
+   * @returns this - For method chaining
+   */
+  public setHeader(name: string, value: string): this {
+    this.headers = { ...this.headers, [name]: value }
+    return this
+  }
+
+  /**
    * Handles API operation with standardized error handling
    * Eliminates repetitive try-catch blocks across all API methods
    *


### PR DESCRIPTION
## 🔍 Description

### What changed?

Added a `setHeader(name, value)` method to `BaseApiClient` in storage-js. This allows setting per-request HTTP headers on any storage operation, matching the existing pattern in postgrest-js which was added in https://github.com/supabase/postgrest-js/pull/550.

The method creates a shallow copy of the headers object to avoid mutating shared state between instances (e.g. between `StorageClient` and `StorageFileApi` returned by `from()`).

### Why was this change needed?

postgrest-js supports per-request header overrides via `setHeader`, but storage-js has no equivalent. Setting headers for storage requests currently requires creating a new Supabase client, setting the header using `options.global.headers` – not preferable when headers need to be set dynamically per request.

This PR enables use cases like:

```ts
supabase.storage.from('bucket').setHeader('x-custom', 'value').upload(...)
```

## 📸 Screenshots/Examples

```ts
// Set a single header
const { data, error } = await supabase.storage
  .from('avatars')
  .setHeader('custom-header', 'value')
  .upload('path/to/file.txt', fileBody)

// Chain multiple headers
const { data, error } = await supabase.storage
  .from('avatars')
  .setHeader('x-header-a', '1')
  .setHeader('x-header-b', '2')
  .download('path/to/file.txt')
```

## 🔄 Breaking changes

- [x] This PR contains no breaking changes

## 📋 Checklist

<!-- Ensure all items are checked before submitting -->

- [x] I have read the [Contributing Guidelines](https://github.com/supabase/supabase-js/blob/master/CONTRIBUTING.md)
- [x] My PR title follows the [conventional commit format](https://www.conventionalcommits.org/): `<type>(<scope>): <description>`
- [x] I have run `npx nx format` to ensure consistent code formatting
- [x] I have added tests for new functionality (if applicable)
- [x] I have updated documentation (if applicable)

## 📝 Additional notes

storage-js currently uses an object to store headers, whereas postgrest-js transitioned from an object to the standard `Headers` API ~8mo ago in https://github.com/supabase/postgrest-js/pull/619. I chose to keep the change minimal, but I'd be happy to migrate to `Headers` in this PR if you'd prefer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added method to set custom headers on API clients with support for method chaining
  * Headers are applied immutably without affecting original configuration

* **Tests**
  * Added comprehensive test coverage for header-setting functionality

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->