### PR TITLE
feat(postgrest): based select() API to postgrest-js

### DIFF
--- a/packages/core/postgrest-js/docs/SELECT_BUILDER_PLAN.md
+++ b/packages/core/postgrest-js/docs/SELECT_BUILDER_PLAN.md
@@ -370,16 +370,13 @@ type SelectSpec = string | SelectItem[] // string for backward compat only
 ### New Files
 
 1. `packages/core/postgrest-js/src/select-query-parser/select-builder.ts`
-
    - Type definitions for SelectSpec, FieldSpec, RelationSpec, etc.
    - `serializeSelect()` function to convert array to string
 
 2. `packages/core/postgrest-js/src/select-query-parser/result-from-spec.ts`
-
    - Type inference for array-based specs (parallel to result.ts)
 
 3. `packages/core/postgrest-js/test/select-builder.test.ts`
-
    - Unit tests for serialization
 
 4. `packages/core/postgrest-js/test/select-builder.test-d.ts`
@@ -388,12 +385,10 @@ type SelectSpec = string | SelectItem[] // string for backward compat only
 ### Modified Files
 
 1. `packages/core/postgrest-js/src/PostgrestQueryBuilder.ts`
-
    - Update `select()` to accept `SelectSpec` in addition to string
    - Call `serializeSelect()` when array is passed
 
 2. `packages/core/postgrest-js/src/PostgrestTransformBuilder.ts`
-
    - Same changes for the chained `select()` after mutations
 
 3. `packages/core/postgrest-js/src/index.ts`

--- a/packages/core/postgrest-js/docs/SELECT_BUILDER_PLAN.md
+++ b/packages/core/postgrest-js/docs/SELECT_BUILDER_PLAN.md
@@ -32,78 +32,80 @@ Simple cases use strings, complex features use objects:
 
 ```typescript
 // Aggregate functions
-type AggregateFunction = "count" | "sum" | "avg" | "min" | "max";
+type AggregateFunction = 'count' | 'sum' | 'avg' | 'min' | 'max'
 
 // Field/column selection
 interface FieldSpec {
-  column: string;
-  as?: string;
-  cast?: string;
-  json?: string[];
-  jsonText?: string[];
-  aggregate?: AggregateFunction;
+  column: string
+  as?: string
+  cast?: string
+  json?: string[]
+  jsonText?: string[]
+  aggregate?: AggregateFunction
 }
 
 // Relation/join selection
 interface RelationSpec {
-  relation: string;
-  as?: string;
-  hint?: string;
-  inner?: boolean;
-  left?: boolean;
-  select: SelectSpec;
+  relation: string
+  as?: string
+  hint?: string
+  inner?: boolean
+  left?: boolean
+  select: SelectSpec
 }
 
 // Spread operation
 interface SpreadSpec {
-  spread: true;
-  relation: string;
-  hint?: string;
-  select: SelectSpec;
+  spread: true
+  relation: string
+  hint?: string
+  select: SelectSpec
 }
 
 // Count shorthand
 interface CountSpec {
-  count: true;
-  as?: string;
-  cast?: string;
+  count: true
+  as?: string
+  cast?: string
 }
 
 // Single item in select array
-type SelectItem = string | FieldSpec | RelationSpec | SpreadSpec | CountSpec;
+type SelectItem = string | FieldSpec | RelationSpec | SpreadSpec | CountSpec
 
 // Full select specification
-type SelectSpec = string | SelectItem[];
+type SelectSpec = string | SelectItem[]
 ```
 
 ## Feature Coverage
 
-| Feature            | String Syntax           | Array Syntax                         |
-| ------------------ | ----------------------- | ------------------------------------ |
-| Simple columns     | `'id, name'`            | `['id', 'name']`                     |
-| Column alias       | `'display:username'`    | `{ column, as }`                     |
-| Type cast          | `'col::text'`           | `{ column, cast }`                   |
-| JSON path (->)     | `'data->foo'`           | `{ column, json: [...] }`            |
-| JSON as text (->>) | `'data->>foo'`          | `{ column, jsonText: [...] }`        |
-| Column aggregate   | `'id.sum()'`            | `{ column, aggregate }`              |
-| Top-level count    | `'count()'`             | `{ count: true }`                    |
-| Relation (join)    | `'posts(id)'`           | `{ relation, select }`               |
-| Relation alias     | `'author:users(id)'`    | `{ relation, as, select }`           |
-| Inner join         | `'posts!inner(id)'`     | `{ relation, inner: true }`          |
-| Left join          | `'posts!left(id)'`      | `{ relation, left: true }`           |
-| FK hint            | `'users!fk_id(id)'`     | `{ relation, hint }`                 |
-| Spread             | `'...profile(status)'`  | `{ spread: true, relation }`         |
-| Nested relations   | `'posts(comments(id))'` | nested `select` arrays               |
+| Feature            | String Syntax           | Array Syntax                  |
+| ------------------ | ----------------------- | ----------------------------- |
+| Simple columns     | `'id, name'`            | `['id', 'name']`              |
+| Column alias       | `'display:username'`    | `{ column, as }`              |
+| Type cast          | `'col::text'`           | `{ column, cast }`            |
+| JSON path (->)     | `'data->foo'`           | `{ column, json: [...] }`     |
+| JSON as text (->>) | `'data->>foo'`          | `{ column, jsonText: [...] }` |
+| Column aggregate   | `'id.sum()'`            | `{ column, aggregate }`       |
+| Top-level count    | `'count()'`             | `{ count: true }`             |
+| Relation (join)    | `'posts(id)'`           | `{ relation, select }`        |
+| Relation alias     | `'author:users(id)'`    | `{ relation, as, select }`    |
+| Inner join         | `'posts!inner(id)'`     | `{ relation, inner: true }`   |
+| Left join          | `'posts!left(id)'`      | `{ relation, left: true }`    |
+| FK hint            | `'users!fk_id(id)'`     | `{ relation, hint }`          |
+| Spread             | `'...profile(status)'`  | `{ spread: true, relation }`  |
+| Nested relations   | `'posts(comments(id))'` | nested `select` arrays        |
 
 ## Files Created/Modified
 
 ### New Files
+
 - `src/select-query-parser/select-builder.ts` - Types and serialization
 - `test/select-builder.test.ts` - Unit tests (56 tests)
 - `test/select-builder-integration.test.ts` - Integration tests (24 tests)
 - `test/select-builder.test-d.ts` - Type tests
 
 ### Modified Files
+
 - `src/PostgrestQueryBuilder.ts` - Accept array in `select()`
 - `src/PostgrestTransformBuilder.ts` - Accept array in `select()`
 - `src/index.ts` - Export new types

--- a/packages/core/postgrest-js/docs/SELECT_BUILDER_PLAN.md
+++ b/packages/core/postgrest-js/docs/SELECT_BUILDER_PLAN.md
@@ -1,0 +1,109 @@
+# Plan: Add Array-Based Type-Safe select() API
+
+## Overview
+
+Add a new array-based API for `select()` that provides IDE autocomplete while maintaining full backward compatibility with the existing string-based API.
+
+## Design: Hybrid Array API
+
+Simple cases use strings, complex features use objects:
+
+```typescript
+// Simple - just column names
+.select(['id', 'name', 'email'])
+
+// With alias
+.select(['id', { column: 'username', as: 'display_name' }])
+
+// With relation
+.select(['id', { relation: 'posts', select: ['id', 'title'] }])
+
+// Complex - all features
+.select([
+  { column: 'created_at', cast: 'text' },
+  { column: 'data', json: ['settings', 'theme'] },
+  { relation: 'posts', hint: 'fk_author', inner: true, select: ['id'] },
+  { spread: true, relation: 'profile', select: ['status'] },
+  { count: true, as: 'total' }
+])
+```
+
+## Type Definitions
+
+```typescript
+// Aggregate functions
+type AggregateFunction = "count" | "sum" | "avg" | "min" | "max";
+
+// Field/column selection
+interface FieldSpec {
+  column: string;
+  as?: string;
+  cast?: string;
+  json?: string[];
+  jsonText?: string[];
+  aggregate?: AggregateFunction;
+}
+
+// Relation/join selection
+interface RelationSpec {
+  relation: string;
+  as?: string;
+  hint?: string;
+  inner?: boolean;
+  left?: boolean;
+  select: SelectSpec;
+}
+
+// Spread operation
+interface SpreadSpec {
+  spread: true;
+  relation: string;
+  hint?: string;
+  select: SelectSpec;
+}
+
+// Count shorthand
+interface CountSpec {
+  count: true;
+  as?: string;
+  cast?: string;
+}
+
+// Single item in select array
+type SelectItem = string | FieldSpec | RelationSpec | SpreadSpec | CountSpec;
+
+// Full select specification
+type SelectSpec = string | SelectItem[];
+```
+
+## Feature Coverage
+
+| Feature            | String Syntax           | Array Syntax                         |
+| ------------------ | ----------------------- | ------------------------------------ |
+| Simple columns     | `'id, name'`            | `['id', 'name']`                     |
+| Column alias       | `'display:username'`    | `{ column, as }`                     |
+| Type cast          | `'col::text'`           | `{ column, cast }`                   |
+| JSON path (->)     | `'data->foo'`           | `{ column, json: [...] }`            |
+| JSON as text (->>) | `'data->>foo'`          | `{ column, jsonText: [...] }`        |
+| Column aggregate   | `'id.sum()'`            | `{ column, aggregate }`              |
+| Top-level count    | `'count()'`             | `{ count: true }`                    |
+| Relation (join)    | `'posts(id)'`           | `{ relation, select }`               |
+| Relation alias     | `'author:users(id)'`    | `{ relation, as, select }`           |
+| Inner join         | `'posts!inner(id)'`     | `{ relation, inner: true }`          |
+| Left join          | `'posts!left(id)'`      | `{ relation, left: true }`           |
+| FK hint            | `'users!fk_id(id)'`     | `{ relation, hint }`                 |
+| Spread             | `'...profile(status)'`  | `{ spread: true, relation }`         |
+| Nested relations   | `'posts(comments(id))'` | nested `select` arrays               |
+
+## Files Created/Modified
+
+### New Files
+- `src/select-query-parser/select-builder.ts` - Types and serialization
+- `test/select-builder.test.ts` - Unit tests (56 tests)
+- `test/select-builder-integration.test.ts` - Integration tests (24 tests)
+- `test/select-builder.test-d.ts` - Type tests
+
+### Modified Files
+- `src/PostgrestQueryBuilder.ts` - Accept array in `select()`
+- `src/PostgrestTransformBuilder.ts` - Accept array in `select()`
+- `src/index.ts` - Export new types

--- a/packages/core/postgrest-js/docs/SELECT_BUILDER_PLAN.md
+++ b/packages/core/postgrest-js/docs/SELECT_BUILDER_PLAN.md
@@ -36,22 +36,22 @@ type AggregateFunction = 'count' | 'sum' | 'avg' | 'min' | 'max'
 
 // Field/column selection
 interface FieldSpec {
-  column: string
-  as?: string
-  cast?: string
-  json?: string[]
-  jsonText?: string[]
+  column: string // Column name (autocomplete from Row type)
+  as?: string // Alias
+  cast?: string // Type cast (::text, ::int4, etc.)
+  json?: string[] // JSON path using -> (returns JSON)
+  jsonText?: string[] // JSON path using ->> (returns text)
   aggregate?: AggregateFunction
 }
 
 // Relation/join selection
 interface RelationSpec {
-  relation: string
-  as?: string
-  hint?: string
-  inner?: boolean
-  left?: boolean
-  select: SelectSpec
+  relation: string // Relation name (autocomplete from Relationships)
+  as?: string // Alias
+  hint?: string // FK hint for disambiguation
+  inner?: boolean // !inner join (filter parent if no match)
+  left?: boolean // !left join (explicit, currently no-op in PostgREST)
+  select: SelectSpec // Nested selection
 }
 
 // Spread operation
@@ -69,43 +69,371 @@ interface CountSpec {
   cast?: string
 }
 
-// Single item in select array
+// Single item in select array (no '*' - encourage explicit column selection)
 type SelectItem = string | FieldSpec | RelationSpec | SpreadSpec | CountSpec
 
 // Full select specification
-type SelectSpec = string | SelectItem[]
+type SelectSpec = string | SelectItem[] // string for backward compat only
 ```
 
 ## Feature Coverage
 
-| Feature            | String Syntax           | Array Syntax                  |
-| ------------------ | ----------------------- | ----------------------------- |
-| Simple columns     | `'id, name'`            | `['id', 'name']`              |
-| Column alias       | `'display:username'`    | `{ column, as }`              |
-| Type cast          | `'col::text'`           | `{ column, cast }`            |
-| JSON path (->)     | `'data->foo'`           | `{ column, json: [...] }`     |
-| JSON as text (->>) | `'data->>foo'`          | `{ column, jsonText: [...] }` |
-| Column aggregate   | `'id.sum()'`            | `{ column, aggregate }`       |
-| Top-level count    | `'count()'`             | `{ count: true }`             |
-| Relation (join)    | `'posts(id)'`           | `{ relation, select }`        |
-| Relation alias     | `'author:users(id)'`    | `{ relation, as, select }`    |
-| Inner join         | `'posts!inner(id)'`     | `{ relation, inner: true }`   |
-| Left join          | `'posts!left(id)'`      | `{ relation, left: true }`    |
-| FK hint            | `'users!fk_id(id)'`     | `{ relation, hint }`          |
-| Spread             | `'...profile(status)'`  | `{ spread: true, relation }`  |
-| Nested relations   | `'posts(comments(id))'` | nested `select` arrays        |
+| #                                                 | Feature            | String Syntax           | Array Key(s)                  |
+| ------------------------------------------------- | ------------------ | ----------------------- | ----------------------------- |
+| [1](#1-simple-column-selection)                   | Simple columns     | `'id, name'`            | `['id', 'name']`              |
+| [2](#2-star-selection-not-supported-in-array-api) | Star selection     | `'*'`                   | _(not supported)_             |
+| [3](#3-column-alias)                              | Column alias       | `'display:username'`    | `{ column, as }`              |
+| [4](#4-type-cast)                                 | Type cast          | `'col::text'`           | `{ column, cast }`            |
+| [5](#5-json-path-access--)                        | JSON path (->)     | `'data->foo'`           | `{ column, json: [...] }`     |
+| [6](#6-json-path-as-text--)                       | JSON as text (->>) | `'data->>foo'`          | `{ column, jsonText: [...] }` |
+| [7](#7-column-aggregate)                          | Column aggregate   | `'id.sum()'`            | `{ column, aggregate }`       |
+| [8](#8-top-level-count)                           | Top-level count    | `'count()'`             | `{ count: true }`             |
+| [9](#9-embedded-relation-join)                    | Relation (join)    | `'posts(id)'`           | `{ relation, select }`        |
+| [10](#10-relation-alias)                          | Relation alias     | `'author:users(id)'`    | `{ relation, as, select }`    |
+| [11](#11-inner-join)                              | Inner join         | `'posts!inner(id)'`     | `{ relation, inner: true }`   |
+| [12](#12-left-join-explicit)                      | Left join          | `'posts!left(id)'`      | `{ relation, left: true }`    |
+| [13](#13-foreign-key-hint-disambiguation)         | FK hint            | `'users!fk_id(id)'`     | `{ relation, hint }`          |
+| [14](#14-hint--inner-join)                        | Hint + inner       | `'users!fk!inner(id)'`  | `{ relation, hint, inner }`   |
+| [15](#15-spread-relation)                         | Spread             | `'...profile(status)'`  | `{ spread: true, relation }`  |
+| [16](#16-spread-with-hint)                        | Spread + hint      | `'...users!fk(name)'`   | `{ spread, relation, hint }`  |
+| [17](#17-nested-relations)                        | Nested relations   | `'posts(comments(id))'` | nested `select` arrays        |
+| [18](#18-complex-combined-example)                | Combined           | _(see example)_         | _(see example)_               |
 
-## Files Created/Modified
+---
+
+## Feature Examples
+
+### 1. Simple Column Selection
+
+```typescript
+// String syntax
+.select('id, name, email')
+
+// Array syntax
+.select(['id', 'name', 'email'])
+```
+
+### 2. Star Selection (Not Supported in Array API)
+
+```typescript
+// String syntax (still works for backward compat)
+.select('*')
+
+// Array syntax - must use explicit columns instead
+.select(['id', 'name', 'email', 'created_at'])
+```
+
+### 3. Column Alias
+
+```typescript
+// String: display_name:username
+.select('display_name:username')
+
+// Array
+.select([{ column: 'username', as: 'display_name' }])
+
+// Combined with other columns
+.select(['id', { column: 'username', as: 'display_name' }, 'email'])
+```
+
+### 4. Type Cast
+
+```typescript
+// String: created_at::text
+.select('created_at::text')
+
+// Array
+.select([{ column: 'created_at', cast: 'text' }])
+
+// Cast with alias: creation_date:created_at::text
+.select([{ column: 'created_at', as: 'creation_date', cast: 'text' }])
+```
+
+### 5. JSON Path Access (->)
+
+```typescript
+// String: data->settings->theme (returns JSON)
+.select('data->settings->theme')
+
+// Array
+.select([{ column: 'data', json: ['settings', 'theme'] }])
+
+// With alias: theme:data->settings->theme
+.select([{ column: 'data', as: 'theme', json: ['settings', 'theme'] }])
+```
+
+### 6. JSON Path as Text (->>)
+
+```typescript
+// String: data->>name (returns text)
+.select('data->>name')
+
+// Array
+.select([{ column: 'data', jsonText: ['name'] }])
+
+// Deep path with text: data->settings->>theme
+.select([{ column: 'data', jsonText: ['settings', 'theme'] }])
+```
+
+### 7. Column Aggregate
+
+```typescript
+// String: id.sum()
+.select('id.sum()')
+
+// Array
+.select([{ column: 'id', aggregate: 'sum' }])
+
+// With alias: total_amount:amount.sum()
+.select([{ column: 'amount', as: 'total_amount', aggregate: 'sum' }])
+
+// All aggregate functions: count, sum, avg, min, max
+.select([
+  { column: 'id', aggregate: 'count' },
+  { column: 'amount', aggregate: 'sum' },
+  { column: 'price', aggregate: 'avg' },
+  { column: 'quantity', aggregate: 'min' },
+  { column: 'total', aggregate: 'max' }
+])
+```
+
+### 8. Top-Level Count
+
+```typescript
+// String: count()
+.select('count()')
+
+// Array
+.select([{ count: true }])
+
+// With alias: total:count()
+.select([{ count: true, as: 'total' }])
+
+// With cast: count()::text
+.select([{ count: true, cast: 'text' }])
+```
+
+### 9. Embedded Relation (Join)
+
+```typescript
+// String: posts(id, title)
+.select('posts(id, title)')
+
+// Array
+.select([{ relation: 'posts', select: ['id', 'title'] }])
+
+// With parent columns
+.select([
+  'id',
+  'name',
+  { relation: 'posts', select: ['id', 'title', 'created_at'] }
+])
+```
+
+### 10. Relation Alias
+
+```typescript
+// String: author:users(id, name)
+.select('author:users(id, name)')
+
+// Array
+.select([{ relation: 'users', as: 'author', select: ['id', 'name'] }])
+```
+
+### 11. Inner Join
+
+```typescript
+// String: posts!inner(id, title)
+// Only returns parent rows that have matching posts
+.select('posts!inner(id, title)')
+
+// Array
+.select([{ relation: 'posts', inner: true, select: ['id', 'title'] }])
+```
+
+### 12. Left Join (Explicit)
+
+```typescript
+// String: posts!left(id, title)
+// Currently a no-op in PostgREST (left join is default), but explicit
+.select('posts!left(id, title)')
+
+// Array
+.select([{ relation: 'posts', left: true, select: ['id', 'title'] }])
+```
+
+### 13. Foreign Key Hint (Disambiguation)
+
+```typescript
+// String: users!author_id(id, name)
+// When table has multiple FKs to same table, specify which one
+.select('users!author_id(id, name)')
+
+// Array
+.select([{ relation: 'users', hint: 'author_id', select: ['id', 'name'] }])
+
+// Full FK name hint
+.select([{ relation: 'users', hint: 'posts_author_id_fkey', select: ['id', 'name'] }])
+```
+
+### 14. Hint + Inner Join
+
+```typescript
+// String: users!author_id!inner(id, name)
+.select('users!author_id!inner(id, name)')
+
+// Array
+.select([{ relation: 'users', hint: 'author_id', inner: true, select: ['id', 'name'] }])
+```
+
+### 15. Spread Relation
+
+```typescript
+// String: ...profile(status, bio)
+// Unpacks profile fields at current level instead of nesting
+.select('...profile(status, bio)')
+
+// Array
+.select([{ spread: true, relation: 'profile', select: ['status', 'bio'] }])
+
+// Combined with regular columns
+.select([
+  'id',
+  'name',
+  { spread: true, relation: 'profile', select: ['status', 'bio'] }
+])
+// Result: { id, name, status, bio } instead of { id, name, profile: { status, bio } }
+```
+
+### 16. Spread with Hint
+
+```typescript
+// String: ...users!author_id(username)
+.select('...users!author_id(username)')
+
+// Array
+.select([{ spread: true, relation: 'users', hint: 'author_id', select: ['username'] }])
+```
+
+### 17. Nested Relations
+
+```typescript
+// String: posts(id, comments(id, text, author:users(name)))
+.select('posts(id, comments(id, text, author:users(name)))')
+
+// Array
+.select([{
+  relation: 'posts',
+  select: [
+    'id',
+    {
+      relation: 'comments',
+      select: [
+        'id',
+        'text',
+        { relation: 'users', as: 'author', select: ['name'] }
+      ]
+    }
+  ]
+}])
+```
+
+### 18. Complex Combined Example
+
+```typescript
+// String: id, display_name:name, config:data->settings, posts!inner(id, title, comment_count:comments(count()))
+.select('id, display_name:name, config:data->settings, posts!inner(id, title, comment_count:comments(count()))')
+
+// Array
+.select([
+  'id',
+  { column: 'name', as: 'display_name' },
+  { column: 'data', as: 'config', json: ['settings'] },
+  {
+    relation: 'posts',
+    inner: true,
+    select: [
+      'id',
+      'title',
+      {
+        relation: 'comments',
+        as: 'comment_count',
+        select: [{ count: true }]
+      }
+    ]
+  }
+])
+```
+
+## Files to Create/Modify
 
 ### New Files
 
-- `src/select-query-parser/select-builder.ts` - Types and serialization
-- `test/select-builder.test.ts` - Unit tests (56 tests)
-- `test/select-builder-integration.test.ts` - Integration tests (24 tests)
-- `test/select-builder.test-d.ts` - Type tests
+1. `packages/core/postgrest-js/src/select-query-parser/select-builder.ts`
+
+   - Type definitions for SelectSpec, FieldSpec, RelationSpec, etc.
+   - `serializeSelect()` function to convert array to string
+
+2. `packages/core/postgrest-js/src/select-query-parser/result-from-spec.ts`
+
+   - Type inference for array-based specs (parallel to result.ts)
+
+3. `packages/core/postgrest-js/test/select-builder.test.ts`
+
+   - Unit tests for serialization
+
+4. `packages/core/postgrest-js/test/select-builder.test-d.ts`
+   - Type tests for inference
 
 ### Modified Files
 
-- `src/PostgrestQueryBuilder.ts` - Accept array in `select()`
-- `src/PostgrestTransformBuilder.ts` - Accept array in `select()`
-- `src/index.ts` - Export new types
+1. `packages/core/postgrest-js/src/PostgrestQueryBuilder.ts`
+
+   - Update `select()` to accept `SelectSpec` in addition to string
+   - Call `serializeSelect()` when array is passed
+
+2. `packages/core/postgrest-js/src/PostgrestTransformBuilder.ts`
+
+   - Same changes for the chained `select()` after mutations
+
+3. `packages/core/postgrest-js/src/index.ts`
+   - Export new types
+
+## Implementation Steps
+
+### Phase 0: Setup
+
+1. Copy this plan to `docs/SELECT_BUILDER_PLAN.md` in the repo root for reference
+
+### Phase 1: Core Types and Serialization
+
+1. Create `select-builder.ts` with type definitions
+2. Implement `serializeSelect()` function
+3. Add unit tests for all serialization cases
+
+### Phase 2: Integration
+
+1. Update `PostgrestQueryBuilder.select()` signature
+2. Update `PostgrestTransformBuilder.select()` signature
+3. Ensure string queries still work unchanged
+
+### Phase 3: Type Inference (Full Inference)
+
+1. Create `result-from-spec.ts` with `GetResultFromSpec` type
+   - Process array items recursively like the string parser does
+   - Handle all features: columns, aliases, casts, JSON paths, aggregates, relations, spreads
+   - Return exact inferred types matching the string parser behavior
+2. Connect to existing type system (reuse `TablesAndViews`, `GenericRelationship`, etc.)
+3. Add type tests to verify inference matches string parser
+
+### Phase 4: Polish
+
+1. Export types from package index
+2. Run full test suite
+3. Update any affected type tests
+
+## Verification
+
+1. **Unit tests**: `nx test postgrest-js` - serialization correctness
+2. **Type tests**: `nx test:types postgrest-js` - type inference
+3. **Integration**: `nx test:ci:postgrest postgrest-js` - full test suite with Docker

--- a/packages/core/postgrest-js/src/index.ts
+++ b/packages/core/postgrest-js/src/index.ts
@@ -32,3 +32,14 @@ export type { ClientServerOptions as PostgrestClientOptions } from './types/comm
 // https://github.com/supabase/postgrest-js/issues/551
 // To be replaced with a helper type that only uses public types
 export type { GetResult as UnstableGetResult } from './select-query-parser/result'
+// Array-based select builder types
+export type {
+  SelectSpec,
+  SelectItem,
+  FieldSpec,
+  RelationSpec,
+  SpreadSpec,
+  CountSpec,
+  AggregateFunction,
+} from './select-query-parser/select-builder'
+export { serializeSelectSpec } from './select-query-parser/select-builder'

--- a/packages/core/postgrest-js/src/select-query-parser/select-builder.ts
+++ b/packages/core/postgrest-js/src/select-query-parser/select-builder.ts
@@ -1,0 +1,368 @@
+/**
+ * Array-based select query builder types and serialization.
+ *
+ * This module provides type-safe building blocks for constructing PostgREST
+ * select queries using arrays and objects instead of string templates.
+ * This enables IDE autocomplete and compile-time validation.
+ */
+
+// ============================================================================
+// Type Definitions
+// ============================================================================
+
+/**
+ * Aggregate functions supported by PostgREST.
+ */
+export type AggregateFunction = 'count' | 'sum' | 'avg' | 'min' | 'max'
+
+/**
+ * Field/column selection specification.
+ *
+ * @example
+ * // Simple column
+ * { column: 'id' }
+ *
+ * // With alias: display_name:username
+ * { column: 'username', as: 'display_name' }
+ *
+ * // With cast: created_at::text
+ * { column: 'created_at', cast: 'text' }
+ *
+ * // JSON path: data->settings->theme
+ * { column: 'data', json: ['settings', 'theme'] }
+ *
+ * // JSON as text: data->>name
+ * { column: 'data', jsonText: ['name'] }
+ *
+ * // Aggregate: id.sum()
+ * { column: 'id', aggregate: 'sum' }
+ */
+export interface FieldSpec {
+  /** Column name */
+  column: string
+  /** Alias for the result (alias:column) */
+  as?: string
+  /** Type cast (::type) */
+  cast?: string
+  /** JSON path using -> operator (returns JSON) */
+  json?: string[]
+  /** JSON path using ->> operator (returns text) */
+  jsonText?: string[]
+  /** Aggregate function to apply (.func()) */
+  aggregate?: AggregateFunction
+}
+
+/**
+ * Relation/join selection specification.
+ *
+ * @example
+ * // Simple relation: posts(id, title)
+ * { relation: 'posts', select: ['id', 'title'] }
+ *
+ * // With alias: author:users(id, name)
+ * { relation: 'users', as: 'author', select: ['id', 'name'] }
+ *
+ * // Inner join: posts!inner(id)
+ * { relation: 'posts', inner: true, select: ['id'] }
+ *
+ * // FK hint: users!author_id(id)
+ * { relation: 'users', hint: 'author_id', select: ['id'] }
+ *
+ * // Hint + inner: users!author_id!inner(id)
+ * { relation: 'users', hint: 'author_id', inner: true, select: ['id'] }
+ */
+export interface RelationSpec {
+  /** Relation/table name */
+  relation: string
+  /** Alias for the result (alias:relation) */
+  as?: string
+  /** Foreign key hint for disambiguation (!hint) */
+  hint?: string
+  /** Inner join - filter parent if no match (!inner) */
+  inner?: boolean
+  /** Left join - explicit, currently no-op in PostgREST (!left) */
+  left?: boolean
+  /** Nested selection for the relation */
+  select: SelectSpec
+}
+
+/**
+ * Spread operation specification.
+ *
+ * @example
+ * // Spread: ...profile(status, bio)
+ * { spread: true, relation: 'profile', select: ['status', 'bio'] }
+ *
+ * // Spread with hint: ...users!author_id(name)
+ * { spread: true, relation: 'users', hint: 'author_id', select: ['name'] }
+ */
+export interface SpreadSpec {
+  /** Marks this as a spread operation */
+  spread: true
+  /** Relation to spread from */
+  relation: string
+  /** Foreign key hint for disambiguation */
+  hint?: string
+  /** Fields to select from the spread relation */
+  select: SelectSpec
+}
+
+/**
+ * Top-level count specification.
+ *
+ * @example
+ * // Simple count: count()
+ * { count: true }
+ *
+ * // With alias: total:count()
+ * { count: true, as: 'total' }
+ *
+ * // With cast: count()::text
+ * { count: true, cast: 'text' }
+ */
+export interface CountSpec {
+  /** Marks this as a count operation */
+  count: true
+  /** Alias for the count result */
+  as?: string
+  /** Type cast for the count result */
+  cast?: string
+}
+
+/**
+ * Single item in a select array.
+ *
+ * Can be:
+ * - A string (column name)
+ * - A FieldSpec (column with options)
+ * - A RelationSpec (embedded relation)
+ * - A SpreadSpec (spread operation)
+ * - A CountSpec (count operation)
+ */
+export type SelectItem = string | FieldSpec | RelationSpec | SpreadSpec | CountSpec
+
+/**
+ * Full select specification.
+ *
+ * Can be:
+ * - A string (for backward compatibility with existing string queries)
+ * - An array of SelectItem (the new typed API)
+ */
+export type SelectSpec = string | SelectItem[]
+
+// ============================================================================
+// Type Guards
+// ============================================================================
+
+function isFieldSpec(item: SelectItem): item is FieldSpec {
+  return typeof item === 'object' && 'column' in item
+}
+
+function isRelationSpec(item: SelectItem): item is RelationSpec {
+  return typeof item === 'object' && 'relation' in item && !('spread' in item)
+}
+
+function isSpreadSpec(item: SelectItem): item is SpreadSpec {
+  return typeof item === 'object' && 'spread' in item && item.spread === true
+}
+
+function isCountSpec(item: SelectItem): item is CountSpec {
+  return typeof item === 'object' && 'count' in item && item.count === true
+}
+
+// ============================================================================
+// Serialization
+// ============================================================================
+
+/**
+ * Serializes a FieldSpec to PostgREST query string format.
+ */
+function serializeFieldSpec(spec: FieldSpec): string {
+  let result = ''
+
+  // Handle alias prefix: alias:column
+  if (spec.as) {
+    result += `${spec.as}:`
+  }
+
+  // Add column name
+  result += spec.column
+
+  // Handle JSON path
+  if (spec.json && spec.json.length > 0) {
+    result += '->' + spec.json.join('->')
+  } else if (spec.jsonText && spec.jsonText.length > 0) {
+    // For jsonText, all but the last use ->, the last uses ->>
+    if (spec.jsonText.length === 1) {
+      result += '->>' + spec.jsonText[0]
+    } else {
+      const allButLast = spec.jsonText.slice(0, -1)
+      const last = spec.jsonText[spec.jsonText.length - 1]
+      result += '->' + allButLast.join('->') + '->>' + last
+    }
+  }
+
+  // Handle aggregate: .func()
+  if (spec.aggregate) {
+    result += `.${spec.aggregate}()`
+  }
+
+  // Handle type cast: ::type (comes after aggregate if present)
+  if (spec.cast) {
+    result += `::${spec.cast}`
+  }
+
+  return result
+}
+
+/**
+ * Serializes a CountSpec to PostgREST query string format.
+ */
+function serializeCountSpec(spec: CountSpec): string {
+  let result = ''
+
+  // Handle alias prefix: alias:count()
+  if (spec.as) {
+    result += `${spec.as}:`
+  }
+
+  result += 'count()'
+
+  // Handle type cast: ::type
+  if (spec.cast) {
+    result += `::${spec.cast}`
+  }
+
+  return result
+}
+
+/**
+ * Serializes a RelationSpec to PostgREST query string format.
+ */
+function serializeRelationSpec(spec: RelationSpec): string {
+  let result = ''
+
+  // Handle alias prefix: alias:relation
+  if (spec.as) {
+    result += `${spec.as}:`
+  }
+
+  // Add relation name
+  result += spec.relation
+
+  // Handle hint: !hint
+  if (spec.hint) {
+    result += `!${spec.hint}`
+  }
+
+  // Handle inner join: !inner
+  if (spec.inner) {
+    result += '!inner'
+  }
+
+  // Handle left join: !left
+  if (spec.left) {
+    result += '!left'
+  }
+
+  // Add nested select: (fields)
+  result += `(${serializeSelectSpec(spec.select)})`
+
+  return result
+}
+
+/**
+ * Serializes a SpreadSpec to PostgREST query string format.
+ */
+function serializeSpreadSpec(spec: SpreadSpec): string {
+  let result = '...'
+
+  // Add relation name
+  result += spec.relation
+
+  // Handle hint: !hint
+  if (spec.hint) {
+    result += `!${spec.hint}`
+  }
+
+  // Add nested select: (fields)
+  result += `(${serializeSelectSpec(spec.select)})`
+
+  return result
+}
+
+/**
+ * Serializes a single SelectItem to PostgREST query string format.
+ */
+function serializeSelectItem(item: SelectItem): string {
+  // String items are just column names
+  if (typeof item === 'string') {
+    return item
+  }
+
+  // Handle different spec types
+  if (isCountSpec(item)) {
+    return serializeCountSpec(item)
+  }
+
+  if (isSpreadSpec(item)) {
+    return serializeSpreadSpec(item)
+  }
+
+  if (isRelationSpec(item)) {
+    return serializeRelationSpec(item)
+  }
+
+  if (isFieldSpec(item)) {
+    return serializeFieldSpec(item)
+  }
+
+  // Fallback (should never happen with proper types)
+  return ''
+}
+
+/**
+ * Serializes a SelectSpec to PostgREST query string format.
+ *
+ * @param spec - The select specification (string or array of SelectItem)
+ * @returns The serialized query string
+ *
+ * @example
+ * // String passthrough
+ * serializeSelectSpec('id, name') // 'id, name'
+ *
+ * // Simple columns
+ * serializeSelectSpec(['id', 'name', 'email']) // 'id,name,email'
+ *
+ * // With alias
+ * serializeSelectSpec([{ column: 'username', as: 'display_name' }])
+ * // 'display_name:username'
+ *
+ * // With relation
+ * serializeSelectSpec(['id', { relation: 'posts', select: ['id', 'title'] }])
+ * // 'id,posts(id,title)'
+ *
+ * // Complex
+ * serializeSelectSpec([
+ *   'id',
+ *   { column: 'name', as: 'display_name' },
+ *   { relation: 'posts', inner: true, select: ['id'] }
+ * ])
+ * // 'id,display_name:name,posts!inner(id)'
+ */
+export function serializeSelectSpec(spec: SelectSpec): string {
+  // String specs pass through unchanged
+  if (typeof spec === 'string') {
+    return spec
+  }
+
+  // Serialize each item and join with commas
+  return spec.map(serializeSelectItem).join(',')
+}
+
+/**
+ * Checks if a SelectSpec is an array-based spec (vs string).
+ */
+export function isArraySelectSpec(spec: SelectSpec): spec is SelectItem[] {
+  return Array.isArray(spec)
+}

--- a/packages/core/postgrest-js/test/select-builder-integration.test.ts
+++ b/packages/core/postgrest-js/test/select-builder-integration.test.ts
@@ -37,48 +37,38 @@ describe('Array-based select with typed Database', () => {
     })
 
     it('should serialize field specs with aliases', async () => {
-      const builder = postgrest.from('users').select([
-        { column: 'username', as: 'name' },
-        'status',
-      ])
+      const builder = postgrest.from('users').select([{ column: 'username', as: 'name' }, 'status'])
       expect((builder as any).url.searchParams.get('select')).toBe('name:username,status')
     })
 
     it('should serialize field specs with casts', async () => {
-      const builder = postgrest.from('users').select([
-        { column: 'username', cast: 'text' },
-      ])
+      const builder = postgrest.from('users').select([{ column: 'username', cast: 'text' }])
       expect((builder as any).url.searchParams.get('select')).toBe('username::text')
     })
 
     it('should serialize relation specs', async () => {
-      const builder = postgrest.from('users').select([
-        'username',
-        { relation: 'messages', select: ['id', 'message'] },
-      ])
+      const builder = postgrest
+        .from('users')
+        .select(['username', { relation: 'messages', select: ['id', 'message'] }])
       expect((builder as any).url.searchParams.get('select')).toBe('username,messages(id,message)')
     })
 
     it('should serialize inner join', async () => {
-      const builder = postgrest.from('users').select([
-        'username',
-        { relation: 'messages', inner: true, select: ['id'] },
-      ])
+      const builder = postgrest
+        .from('users')
+        .select(['username', { relation: 'messages', inner: true, select: ['id'] }])
       expect((builder as any).url.searchParams.get('select')).toBe('username,messages!inner(id)')
     })
 
     it('should serialize spread specs', async () => {
-      const builder = postgrest.from('messages').select([
-        'id',
-        { spread: true, relation: 'channels', select: ['slug'] },
-      ])
+      const builder = postgrest
+        .from('messages')
+        .select(['id', { spread: true, relation: 'channels', select: ['slug'] }])
       expect((builder as any).url.searchParams.get('select')).toBe('id,...channels(slug)')
     })
 
     it('should serialize count specs', async () => {
-      const builder = postgrest.from('users').select([
-        { count: true, as: 'total' },
-      ])
+      const builder = postgrest.from('users').select([{ count: true, as: 'total' }])
       expect((builder as any).url.searchParams.get('select')).toBe('total:count()')
     })
 
@@ -87,11 +77,7 @@ describe('Array-based select with typed Database', () => {
         'username',
         {
           relation: 'messages',
-          select: [
-            'id',
-            'message',
-            { relation: 'channels', select: ['slug'] },
-          ],
+          select: ['id', 'message', { relation: 'channels', select: ['slug'] }],
         },
       ])
       expect((builder as any).url.searchParams.get('select')).toBe(
@@ -121,11 +107,7 @@ describe('Array-based select with typed Database', () => {
     })
 
     it('should accept array-based select spec after delete', async () => {
-      const builder = postgrest
-        .from('messages')
-        .delete()
-        .eq('id', 1)
-        .select(['id', 'message'])
+      const builder = postgrest.from('messages').delete().eq('id', 1).select(['id', 'message'])
 
       expect((builder as any).url.searchParams.get('select')).toBe('id,message')
     })
@@ -157,14 +139,16 @@ describe('Array-based select without typed Database (any schema)', () => {
     })
 
     it('should serialize complex queries without type information', () => {
-      const builder = (postgrest as any).from('users').select([
-        'id',
-        { column: 'name', as: 'display_name' },
-        { column: 'data', json: ['settings', 'theme'] },
-        { relation: 'posts', inner: true, select: ['id', 'title'] },
-        { spread: true, relation: 'profile', select: ['status'] },
-        { count: true, as: 'total' },
-      ])
+      const builder = (postgrest as any)
+        .from('users')
+        .select([
+          'id',
+          { column: 'name', as: 'display_name' },
+          { column: 'data', json: ['settings', 'theme'] },
+          { relation: 'posts', inner: true, select: ['id', 'title'] },
+          { spread: true, relation: 'profile', select: ['status'] },
+          { count: true, as: 'total' },
+        ])
       expect((builder as any).url.searchParams.get('select')).toBe(
         'id,display_name:name,data->settings->theme,posts!inner(id,title),...profile(status),total:count()'
       )

--- a/packages/core/postgrest-js/test/select-builder-integration.test.ts
+++ b/packages/core/postgrest-js/test/select-builder-integration.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Integration tests for the array-based select query builder.
+ *
+ * These tests verify that the array-based select API integrates correctly
+ * with PostgrestClient, PostgrestQueryBuilder, and PostgrestTransformBuilder,
+ * both with and without typed Database schemas.
+ */
+
+import { PostgrestClient } from '../src/index'
+import { Database } from './types.override'
+
+const REST_URL = 'http://localhost:54321/rest/v1'
+
+describe('Array-based select with typed Database', () => {
+  const postgrest = new PostgrestClient<Database>(REST_URL)
+
+  describe('PostgrestQueryBuilder.select()', () => {
+    it('should accept array-based select spec', async () => {
+      const builder = postgrest.from('users').select(['username', 'status'])
+      // Verify the URL contains the serialized select
+      expect((builder as any).url.searchParams.get('select')).toBe('username,status')
+    })
+
+    it('should accept string-based select spec (backward compat)', async () => {
+      const builder = postgrest.from('users').select('username, status')
+      expect((builder as any).url.searchParams.get('select')).toBe('username,status')
+    })
+
+    it('should accept * (star) string select', async () => {
+      const builder = postgrest.from('users').select('*')
+      expect((builder as any).url.searchParams.get('select')).toBe('*')
+    })
+
+    it('should accept empty select (defaults to *)', async () => {
+      const builder = postgrest.from('users').select()
+      expect((builder as any).url.searchParams.get('select')).toBe('*')
+    })
+
+    it('should serialize field specs with aliases', async () => {
+      const builder = postgrest.from('users').select([
+        { column: 'username', as: 'name' },
+        'status',
+      ])
+      expect((builder as any).url.searchParams.get('select')).toBe('name:username,status')
+    })
+
+    it('should serialize field specs with casts', async () => {
+      const builder = postgrest.from('users').select([
+        { column: 'username', cast: 'text' },
+      ])
+      expect((builder as any).url.searchParams.get('select')).toBe('username::text')
+    })
+
+    it('should serialize relation specs', async () => {
+      const builder = postgrest.from('users').select([
+        'username',
+        { relation: 'messages', select: ['id', 'message'] },
+      ])
+      expect((builder as any).url.searchParams.get('select')).toBe('username,messages(id,message)')
+    })
+
+    it('should serialize inner join', async () => {
+      const builder = postgrest.from('users').select([
+        'username',
+        { relation: 'messages', inner: true, select: ['id'] },
+      ])
+      expect((builder as any).url.searchParams.get('select')).toBe('username,messages!inner(id)')
+    })
+
+    it('should serialize spread specs', async () => {
+      const builder = postgrest.from('messages').select([
+        'id',
+        { spread: true, relation: 'channels', select: ['slug'] },
+      ])
+      expect((builder as any).url.searchParams.get('select')).toBe('id,...channels(slug)')
+    })
+
+    it('should serialize count specs', async () => {
+      const builder = postgrest.from('users').select([
+        { count: true, as: 'total' },
+      ])
+      expect((builder as any).url.searchParams.get('select')).toBe('total:count()')
+    })
+
+    it('should serialize complex nested queries', async () => {
+      const builder = postgrest.from('users').select([
+        'username',
+        {
+          relation: 'messages',
+          select: [
+            'id',
+            'message',
+            { relation: 'channels', select: ['slug'] },
+          ],
+        },
+      ])
+      expect((builder as any).url.searchParams.get('select')).toBe(
+        'username,messages(id,message,channels(slug))'
+      )
+    })
+  })
+
+  describe('PostgrestTransformBuilder.select()', () => {
+    it('should accept array-based select spec after insert', async () => {
+      const builder = postgrest
+        .from('messages')
+        .insert({ message: 'test', username: 'test', channel_id: 1 })
+        .select(['id', 'message'])
+
+      expect((builder as any).url.searchParams.get('select')).toBe('id,message')
+    })
+
+    it('should accept array-based select spec after update', async () => {
+      const builder = postgrest
+        .from('messages')
+        .update({ message: 'updated' })
+        .eq('id', 1)
+        .select(['id', 'message'])
+
+      expect((builder as any).url.searchParams.get('select')).toBe('id,message')
+    })
+
+    it('should accept array-based select spec after delete', async () => {
+      const builder = postgrest
+        .from('messages')
+        .delete()
+        .eq('id', 1)
+        .select(['id', 'message'])
+
+      expect((builder as any).url.searchParams.get('select')).toBe('id,message')
+    })
+
+    it('should accept array-based select spec after upsert', async () => {
+      const builder = postgrest
+        .from('messages')
+        .upsert({ id: 1, message: 'test', username: 'test', channel_id: 1 })
+        .select(['id', 'message'])
+
+      expect((builder as any).url.searchParams.get('select')).toBe('id,message')
+    })
+  })
+})
+
+describe('Array-based select without typed Database (any schema)', () => {
+  // Using any schema by not providing Database type
+  const postgrest = new PostgrestClient('http://localhost:54321/rest/v1')
+
+  describe('PostgrestQueryBuilder.select()', () => {
+    it('should accept array-based select spec', () => {
+      const builder = (postgrest as any).from('users').select(['username', 'status'])
+      expect((builder as any).url.searchParams.get('select')).toBe('username,status')
+    })
+
+    it('should accept string-based select spec (backward compat)', () => {
+      const builder = (postgrest as any).from('users').select('username, status')
+      expect((builder as any).url.searchParams.get('select')).toBe('username,status')
+    })
+
+    it('should serialize complex queries without type information', () => {
+      const builder = (postgrest as any).from('users').select([
+        'id',
+        { column: 'name', as: 'display_name' },
+        { column: 'data', json: ['settings', 'theme'] },
+        { relation: 'posts', inner: true, select: ['id', 'title'] },
+        { spread: true, relation: 'profile', select: ['status'] },
+        { count: true, as: 'total' },
+      ])
+      expect((builder as any).url.searchParams.get('select')).toBe(
+        'id,display_name:name,data->settings->theme,posts!inner(id,title),...profile(status),total:count()'
+      )
+    })
+  })
+})
+
+describe('Whitespace handling', () => {
+  const postgrest = new PostgrestClient<Database>(REST_URL)
+
+  it('should remove whitespace from array-based select (after serialization)', () => {
+    // The serializer doesn't add whitespace, but the whitespace cleaner still runs
+    const builder = postgrest.from('users').select(['username', 'status'])
+    expect((builder as any).url.searchParams.get('select')).toBe('username,status')
+  })
+
+  it('should remove whitespace from string-based select', () => {
+    const builder = postgrest.from('users').select('username,    status')
+    expect((builder as any).url.searchParams.get('select')).toBe('username,status')
+  })
+
+  it('should preserve whitespace in quoted identifiers', () => {
+    const builder = postgrest.from('users').select('"column name"')
+    expect((builder as any).url.searchParams.get('select')).toBe('"column name"')
+  })
+})
+
+describe('Options handling', () => {
+  const postgrest = new PostgrestClient<Database>(REST_URL)
+
+  it('should respect head option with array select', () => {
+    const builder = postgrest.from('users').select(['username'], { head: true })
+    expect((builder as any).method).toBe('HEAD')
+    expect((builder as any).url.searchParams.get('select')).toBe('username')
+  })
+
+  it('should respect count option with array select', () => {
+    const builder = postgrest.from('users').select(['username'], { count: 'exact' })
+    expect((builder as any).headers.get('Prefer')).toContain('count=exact')
+    expect((builder as any).url.searchParams.get('select')).toBe('username')
+  })
+
+  it('should respect both head and count options with array select', () => {
+    const builder = postgrest.from('users').select(['username'], { head: true, count: 'exact' })
+    expect((builder as any).method).toBe('HEAD')
+    expect((builder as any).headers.get('Prefer')).toContain('count=exact')
+    expect((builder as any).url.searchParams.get('select')).toBe('username')
+  })
+})

--- a/packages/core/postgrest-js/test/select-builder.test-d.ts
+++ b/packages/core/postgrest-js/test/select-builder.test-d.ts
@@ -1,0 +1,351 @@
+/**
+ * Type tests for the array-based select query builder.
+ *
+ * These tests verify that:
+ * 1. Valid select specs compile correctly
+ * 2. Invalid select specs produce compile-time errors
+ * 3. String-based select still works with full type inference
+ */
+
+import { expectType, TypeEqual } from './types'
+import { PostgrestClient } from '../src/index'
+import type {
+  SelectSpec,
+  SelectItem,
+  FieldSpec,
+  RelationSpec,
+  SpreadSpec,
+  CountSpec,
+} from '../src/select-query-parser/select-builder'
+import { Database } from './types.override'
+
+const REST_URL = 'http://localhost:54321/rest/v1'
+const postgrest = new PostgrestClient<Database>(REST_URL)
+
+// =============================================================================
+// Type Definitions - Valid Cases
+// =============================================================================
+
+// string is a valid SelectSpec
+{
+  const spec: SelectSpec = 'id, name'
+  expectType<SelectSpec>(spec)
+}
+
+// SelectItem array is a valid SelectSpec
+{
+  const spec: SelectSpec = ['id', 'name']
+  expectType<SelectSpec>(spec)
+}
+
+// string array is a valid SelectItem array (column names)
+{
+  const spec: SelectItem[] = ['id', 'name', 'email']
+  expectType<SelectItem[]>(spec)
+}
+
+// FieldSpec is a valid SelectItem
+{
+  const spec: FieldSpec = { column: 'id' }
+  const items: SelectItem[] = [spec]
+  expectType<SelectItem[]>(items)
+}
+
+// RelationSpec is a valid SelectItem
+{
+  const spec: RelationSpec = { relation: 'posts', select: ['id'] }
+  const items: SelectItem[] = [spec]
+  expectType<SelectItem[]>(items)
+}
+
+// SpreadSpec is a valid SelectItem
+{
+  const spec: SpreadSpec = { spread: true, relation: 'profile', select: ['status'] }
+  const items: SelectItem[] = [spec]
+  expectType<SelectItem[]>(items)
+}
+
+// CountSpec is a valid SelectItem
+{
+  const spec: CountSpec = { count: true }
+  const items: SelectItem[] = [spec]
+  expectType<SelectItem[]>(items)
+}
+
+// =============================================================================
+// PostgrestQueryBuilder.select() - Valid Cases
+// =============================================================================
+
+// accepts no arguments (defaults to *)
+{
+  const query = postgrest.from('users').select()
+  // Should compile without error
+}
+
+// accepts string argument
+{
+  const query = postgrest.from('users').select('username, status')
+}
+
+// accepts * string
+{
+  const query = postgrest.from('users').select('*')
+}
+
+// accepts string array (column names)
+{
+  const query = postgrest.from('users').select(['username', 'status'])
+}
+
+// accepts FieldSpec array
+{
+  const query = postgrest.from('users').select([
+    { column: 'username' },
+    { column: 'status', as: 'user_status' },
+  ])
+}
+
+// accepts mixed string and FieldSpec array
+{
+  const query = postgrest.from('users').select([
+    'username',
+    { column: 'status', as: 'user_status' },
+  ])
+}
+
+// accepts RelationSpec
+{
+  const query = postgrest.from('users').select([
+    'username',
+    { relation: 'messages', select: ['id', 'message'] },
+  ])
+}
+
+// accepts SpreadSpec
+{
+  const query = postgrest.from('messages').select([
+    'id',
+    { spread: true, relation: 'channels', select: ['slug'] },
+  ])
+}
+
+// accepts CountSpec
+{
+  const query = postgrest.from('users').select([{ count: true }])
+}
+
+// accepts complex nested query
+{
+  const query = postgrest.from('users').select([
+    'username',
+    { column: 'status', as: 'user_status' },
+    {
+      relation: 'messages',
+      inner: true,
+      select: [
+        'id',
+        'message',
+        { relation: 'channels', select: ['slug'] },
+      ],
+    },
+    { count: true, as: 'total' },
+  ])
+}
+
+// =============================================================================
+// String-based select still has type inference
+// =============================================================================
+
+// infers exact column types from string literal
+{
+  const result = await postgrest.from('users').select('username, status')
+  if (result.data) {
+    expectType<{ username: string; status: Database['public']['Enums']['user_status'] | null }[]>(
+      result.data
+    )
+  }
+}
+
+// =============================================================================
+// FieldSpec - Valid Cases
+// =============================================================================
+
+// accepts column only
+{
+  const spec: FieldSpec = { column: 'id' }
+}
+
+// accepts column with alias
+{
+  const spec: FieldSpec = { column: 'id', as: 'user_id' }
+}
+
+// accepts column with cast
+{
+  const spec: FieldSpec = { column: 'created_at', cast: 'text' }
+}
+
+// accepts column with json path
+{
+  const spec: FieldSpec = { column: 'data', json: ['settings', 'theme'] }
+}
+
+// accepts column with jsonText path
+{
+  const spec: FieldSpec = { column: 'data', jsonText: ['name'] }
+}
+
+// accepts column with aggregate
+{
+  const spec: FieldSpec = { column: 'id', aggregate: 'count' }
+}
+
+// accepts all aggregate functions
+{
+  const specs: FieldSpec[] = [
+    { column: 'id', aggregate: 'count' },
+    { column: 'amount', aggregate: 'sum' },
+    { column: 'price', aggregate: 'avg' },
+    { column: 'quantity', aggregate: 'min' },
+    { column: 'total', aggregate: 'max' },
+  ]
+}
+
+// =============================================================================
+// RelationSpec - Valid Cases
+// =============================================================================
+
+// accepts relation with string select
+{
+  const spec: RelationSpec = { relation: 'posts', select: 'id, title' }
+}
+
+// accepts relation with array select
+{
+  const spec: RelationSpec = { relation: 'posts', select: ['id', 'title'] }
+}
+
+// accepts relation with alias
+{
+  const spec: RelationSpec = { relation: 'users', as: 'author', select: ['name'] }
+}
+
+// accepts relation with hint
+{
+  const spec: RelationSpec = { relation: 'users', hint: 'author_id', select: ['name'] }
+}
+
+// accepts relation with inner join
+{
+  const spec: RelationSpec = { relation: 'posts', inner: true, select: ['id'] }
+}
+
+// accepts relation with left join
+{
+  const spec: RelationSpec = { relation: 'posts', left: true, select: ['id'] }
+}
+
+// accepts relation with hint and inner join
+{
+  const spec: RelationSpec = {
+    relation: 'users',
+    hint: 'author_id',
+    inner: true,
+    select: ['name'],
+  }
+}
+
+// =============================================================================
+// SpreadSpec - Valid Cases
+// =============================================================================
+
+// accepts spread with string select
+{
+  const spec: SpreadSpec = { spread: true, relation: 'profile', select: 'status, bio' }
+}
+
+// accepts spread with array select
+{
+  const spec: SpreadSpec = { spread: true, relation: 'profile', select: ['status', 'bio'] }
+}
+
+// accepts spread with hint
+{
+  const spec: SpreadSpec = {
+    spread: true,
+    relation: 'users',
+    hint: 'author_id',
+    select: ['name'],
+  }
+}
+
+// =============================================================================
+// CountSpec - Valid Cases
+// =============================================================================
+
+// accepts simple count
+{
+  const spec: CountSpec = { count: true }
+}
+
+// accepts count with alias
+{
+  const spec: CountSpec = { count: true, as: 'total' }
+}
+
+// accepts count with cast
+{
+  const spec: CountSpec = { count: true, cast: 'int4' }
+}
+
+// =============================================================================
+// Invalid Cases - Should NOT compile
+// =============================================================================
+
+// FieldSpec requires column property
+{
+  // @ts-expect-error Property 'column' is missing in type
+  const spec: FieldSpec = { as: 'alias' }
+}
+
+// RelationSpec requires relation property
+{
+  // @ts-expect-error Property 'relation' is missing in type
+  const spec: RelationSpec = { select: ['id'] }
+}
+
+// RelationSpec requires select property
+{
+  // @ts-expect-error Property 'select' is missing in type
+  const spec: RelationSpec = { relation: 'posts' }
+}
+
+// SpreadSpec requires spread: true
+{
+  // @ts-expect-error Property 'spread' is missing in type
+  const spec: SpreadSpec = { relation: 'profile', select: ['status'] }
+}
+
+// SpreadSpec requires relation property
+{
+  // @ts-expect-error Property 'relation' is missing in type
+  const spec: SpreadSpec = { spread: true, select: ['status'] }
+}
+
+// SpreadSpec requires select property
+{
+  // @ts-expect-error Property 'select' is missing in type
+  const spec: SpreadSpec = { spread: true, relation: 'profile' }
+}
+
+// CountSpec requires count: true
+{
+  // @ts-expect-error Property 'count' is missing in type
+  const spec: CountSpec = { as: 'total' }
+}
+
+// invalid aggregate function is rejected
+{
+  // @ts-expect-error Type '"invalid"' is not assignable to type
+  const spec: FieldSpec = { column: 'id', aggregate: 'invalid' }
+}

--- a/packages/core/postgrest-js/test/select-builder.test-d.ts
+++ b/packages/core/postgrest-js/test/select-builder.test-d.ts
@@ -99,34 +99,30 @@ const postgrest = new PostgrestClient<Database>(REST_URL)
 
 // accepts FieldSpec array
 {
-  const query = postgrest.from('users').select([
-    { column: 'username' },
-    { column: 'status', as: 'user_status' },
-  ])
+  const query = postgrest
+    .from('users')
+    .select([{ column: 'username' }, { column: 'status', as: 'user_status' }])
 }
 
 // accepts mixed string and FieldSpec array
 {
-  const query = postgrest.from('users').select([
-    'username',
-    { column: 'status', as: 'user_status' },
-  ])
+  const query = postgrest
+    .from('users')
+    .select(['username', { column: 'status', as: 'user_status' }])
 }
 
 // accepts RelationSpec
 {
-  const query = postgrest.from('users').select([
-    'username',
-    { relation: 'messages', select: ['id', 'message'] },
-  ])
+  const query = postgrest
+    .from('users')
+    .select(['username', { relation: 'messages', select: ['id', 'message'] }])
 }
 
 // accepts SpreadSpec
 {
-  const query = postgrest.from('messages').select([
-    'id',
-    { spread: true, relation: 'channels', select: ['slug'] },
-  ])
+  const query = postgrest
+    .from('messages')
+    .select(['id', { spread: true, relation: 'channels', select: ['slug'] }])
 }
 
 // accepts CountSpec
@@ -142,11 +138,7 @@ const postgrest = new PostgrestClient<Database>(REST_URL)
     {
       relation: 'messages',
       inner: true,
-      select: [
-        'id',
-        'message',
-        { relation: 'channels', select: ['slug'] },
-      ],
+      select: ['id', 'message', { relation: 'channels', select: ['slug'] }],
     },
     { count: true, as: 'total' },
   ])

--- a/packages/core/postgrest-js/test/select-builder.test.ts
+++ b/packages/core/postgrest-js/test/select-builder.test.ts
@@ -1,0 +1,538 @@
+import {
+  serializeSelectSpec,
+  SelectSpec,
+  FieldSpec,
+  RelationSpec,
+  SpreadSpec,
+  CountSpec,
+} from '../src/select-query-parser/select-builder'
+
+/**
+ * Tests for the array-based select query builder.
+ *
+ * These tests verify that the serializeSelectSpec function correctly converts
+ * array-based SelectSpec objects into PostgREST query string format.
+ *
+ * Each test case corresponds to a feature from the plan:
+ * 1. Simple Column Selection
+ * 2. Star Selection (Not Supported in Array API)
+ * 3. Column Alias
+ * 4. Type Cast
+ * 5. JSON Path Access (->)
+ * 6. JSON Path as Text (->>)
+ * 7. Column Aggregate
+ * 8. Top-Level Count
+ * 9. Embedded Relation (Join)
+ * 10. Relation Alias
+ * 11. Inner Join
+ * 12. Left Join (Explicit)
+ * 13. Foreign Key Hint (Disambiguation)
+ * 14. Hint + Inner Join
+ * 15. Spread Relation
+ * 16. Spread with Hint
+ * 17. Nested Relations
+ * 18. Complex Combined Example
+ */
+
+describe('serializeSelectSpec', () => {
+  // ============================================================================
+  // 1. Simple Column Selection
+  // ============================================================================
+  describe('1. Simple Column Selection', () => {
+    it('should serialize simple column names', () => {
+      const spec: SelectSpec = ['id', 'name', 'email']
+      expect(serializeSelectSpec(spec)).toBe('id,name,email')
+    })
+
+    it('should serialize a single column', () => {
+      const spec: SelectSpec = ['id']
+      expect(serializeSelectSpec(spec)).toBe('id')
+    })
+
+    it('should pass through string specs unchanged', () => {
+      const spec: SelectSpec = 'id, name, email'
+      expect(serializeSelectSpec(spec)).toBe('id, name, email')
+    })
+
+    it('should pass through star selection as string', () => {
+      // Star selection is only supported via string syntax
+      const spec: SelectSpec = '*'
+      expect(serializeSelectSpec(spec)).toBe('*')
+    })
+  })
+
+  // ============================================================================
+  // 2. Star Selection (Not Supported in Array API)
+  // ============================================================================
+  describe('2. Star Selection', () => {
+    it('should pass through star as string (backward compat)', () => {
+      const spec: SelectSpec = '*'
+      expect(serializeSelectSpec(spec)).toBe('*')
+    })
+
+    it('should pass through mixed star and columns as string', () => {
+      const spec: SelectSpec = '*, posts(id)'
+      expect(serializeSelectSpec(spec)).toBe('*, posts(id)')
+    })
+  })
+
+  // ============================================================================
+  // 3. Column Alias
+  // ============================================================================
+  describe('3. Column Alias', () => {
+    it('should serialize column with alias', () => {
+      const spec: SelectSpec = [{ column: 'username', as: 'display_name' }]
+      expect(serializeSelectSpec(spec)).toBe('display_name:username')
+    })
+
+    it('should serialize mixed columns and aliases', () => {
+      const spec: SelectSpec = ['id', { column: 'username', as: 'display_name' }, 'email']
+      expect(serializeSelectSpec(spec)).toBe('id,display_name:username,email')
+    })
+  })
+
+  // ============================================================================
+  // 4. Type Cast
+  // ============================================================================
+  describe('4. Type Cast', () => {
+    it('should serialize column with type cast', () => {
+      const spec: SelectSpec = [{ column: 'created_at', cast: 'text' }]
+      expect(serializeSelectSpec(spec)).toBe('created_at::text')
+    })
+
+    it('should serialize column with alias and type cast', () => {
+      const spec: SelectSpec = [{ column: 'created_at', as: 'creation_date', cast: 'text' }]
+      expect(serializeSelectSpec(spec)).toBe('creation_date:created_at::text')
+    })
+
+    it('should serialize multiple columns with different casts', () => {
+      const spec: SelectSpec = [
+        { column: 'id', cast: 'text' },
+        { column: 'created_at', cast: 'date' },
+        { column: 'amount', cast: 'int4' },
+      ]
+      expect(serializeSelectSpec(spec)).toBe('id::text,created_at::date,amount::int4')
+    })
+  })
+
+  // ============================================================================
+  // 5. JSON Path Access (->)
+  // ============================================================================
+  describe('5. JSON Path Access (->)', () => {
+    it('should serialize single-level JSON path', () => {
+      const spec: SelectSpec = [{ column: 'data', json: ['settings'] }]
+      expect(serializeSelectSpec(spec)).toBe('data->settings')
+    })
+
+    it('should serialize multi-level JSON path', () => {
+      const spec: SelectSpec = [{ column: 'data', json: ['settings', 'theme'] }]
+      expect(serializeSelectSpec(spec)).toBe('data->settings->theme')
+    })
+
+    it('should serialize JSON path with alias', () => {
+      const spec: SelectSpec = [{ column: 'data', as: 'theme', json: ['settings', 'theme'] }]
+      expect(serializeSelectSpec(spec)).toBe('theme:data->settings->theme')
+    })
+
+    it('should serialize deep JSON path', () => {
+      const spec: SelectSpec = [{ column: 'data', json: ['a', 'b', 'c', 'd'] }]
+      expect(serializeSelectSpec(spec)).toBe('data->a->b->c->d')
+    })
+  })
+
+  // ============================================================================
+  // 6. JSON Path as Text (->>)
+  // ============================================================================
+  describe('6. JSON Path as Text (->>) ', () => {
+    it('should serialize single-level JSON text path', () => {
+      const spec: SelectSpec = [{ column: 'data', jsonText: ['name'] }]
+      expect(serializeSelectSpec(spec)).toBe('data->>name')
+    })
+
+    it('should serialize multi-level JSON text path (last uses ->>)', () => {
+      const spec: SelectSpec = [{ column: 'data', jsonText: ['settings', 'theme'] }]
+      expect(serializeSelectSpec(spec)).toBe('data->settings->>theme')
+    })
+
+    it('should serialize deep JSON text path', () => {
+      const spec: SelectSpec = [{ column: 'data', jsonText: ['a', 'b', 'c'] }]
+      expect(serializeSelectSpec(spec)).toBe('data->a->b->>c')
+    })
+
+    it('should serialize JSON text path with alias', () => {
+      const spec: SelectSpec = [{ column: 'data', as: 'theme_name', jsonText: ['settings', 'theme'] }]
+      expect(serializeSelectSpec(spec)).toBe('theme_name:data->settings->>theme')
+    })
+  })
+
+  // ============================================================================
+  // 7. Column Aggregate
+  // ============================================================================
+  describe('7. Column Aggregate', () => {
+    it('should serialize column with sum aggregate', () => {
+      const spec: SelectSpec = [{ column: 'id', aggregate: 'sum' }]
+      expect(serializeSelectSpec(spec)).toBe('id.sum()')
+    })
+
+    it('should serialize column with count aggregate', () => {
+      const spec: SelectSpec = [{ column: 'id', aggregate: 'count' }]
+      expect(serializeSelectSpec(spec)).toBe('id.count()')
+    })
+
+    it('should serialize column with avg aggregate', () => {
+      const spec: SelectSpec = [{ column: 'price', aggregate: 'avg' }]
+      expect(serializeSelectSpec(spec)).toBe('price.avg()')
+    })
+
+    it('should serialize column with min aggregate', () => {
+      const spec: SelectSpec = [{ column: 'quantity', aggregate: 'min' }]
+      expect(serializeSelectSpec(spec)).toBe('quantity.min()')
+    })
+
+    it('should serialize column with max aggregate', () => {
+      const spec: SelectSpec = [{ column: 'total', aggregate: 'max' }]
+      expect(serializeSelectSpec(spec)).toBe('total.max()')
+    })
+
+    it('should serialize aggregate with alias', () => {
+      const spec: SelectSpec = [{ column: 'amount', as: 'total_amount', aggregate: 'sum' }]
+      expect(serializeSelectSpec(spec)).toBe('total_amount:amount.sum()')
+    })
+
+    it('should serialize aggregate with cast', () => {
+      const spec: SelectSpec = [{ column: 'id', aggregate: 'count', cast: 'int4' }]
+      expect(serializeSelectSpec(spec)).toBe('id.count()::int4')
+    })
+
+    it('should serialize multiple aggregates', () => {
+      const spec: SelectSpec = [
+        { column: 'id', aggregate: 'count' },
+        { column: 'amount', aggregate: 'sum' },
+        { column: 'price', aggregate: 'avg' },
+      ]
+      expect(serializeSelectSpec(spec)).toBe('id.count(),amount.sum(),price.avg()')
+    })
+  })
+
+  // ============================================================================
+  // 8. Top-Level Count
+  // ============================================================================
+  describe('8. Top-Level Count', () => {
+    it('should serialize simple count', () => {
+      const spec: SelectSpec = [{ count: true }]
+      expect(serializeSelectSpec(spec)).toBe('count()')
+    })
+
+    it('should serialize count with alias', () => {
+      const spec: SelectSpec = [{ count: true, as: 'total' }]
+      expect(serializeSelectSpec(spec)).toBe('total:count()')
+    })
+
+    it('should serialize count with cast', () => {
+      const spec: SelectSpec = [{ count: true, cast: 'text' }]
+      expect(serializeSelectSpec(spec)).toBe('count()::text')
+    })
+
+    it('should serialize count with alias and cast', () => {
+      const spec: SelectSpec = [{ count: true, as: 'total', cast: 'int4' }]
+      expect(serializeSelectSpec(spec)).toBe('total:count()::int4')
+    })
+  })
+
+  // ============================================================================
+  // 9. Embedded Relation (Join)
+  // ============================================================================
+  describe('9. Embedded Relation (Join)', () => {
+    it('should serialize simple relation', () => {
+      const spec: SelectSpec = [{ relation: 'posts', select: ['id', 'title'] }]
+      expect(serializeSelectSpec(spec)).toBe('posts(id,title)')
+    })
+
+    it('should serialize relation with parent columns', () => {
+      const spec: SelectSpec = [
+        'id',
+        'name',
+        { relation: 'posts', select: ['id', 'title', 'created_at'] },
+      ]
+      expect(serializeSelectSpec(spec)).toBe('id,name,posts(id,title,created_at)')
+    })
+
+    it('should serialize multiple relations', () => {
+      const spec: SelectSpec = [
+        'id',
+        { relation: 'posts', select: ['id'] },
+        { relation: 'comments', select: ['text'] },
+      ]
+      expect(serializeSelectSpec(spec)).toBe('id,posts(id),comments(text)')
+    })
+  })
+
+  // ============================================================================
+  // 10. Relation Alias
+  // ============================================================================
+  describe('10. Relation Alias', () => {
+    it('should serialize relation with alias', () => {
+      const spec: SelectSpec = [{ relation: 'users', as: 'author', select: ['id', 'name'] }]
+      expect(serializeSelectSpec(spec)).toBe('author:users(id,name)')
+    })
+
+    it('should serialize multiple aliased relations', () => {
+      const spec: SelectSpec = [
+        { relation: 'users', as: 'author', select: ['name'] },
+        { relation: 'users', as: 'editor', select: ['name'] },
+      ]
+      expect(serializeSelectSpec(spec)).toBe('author:users(name),editor:users(name)')
+    })
+  })
+
+  // ============================================================================
+  // 11. Inner Join
+  // ============================================================================
+  describe('11. Inner Join', () => {
+    it('should serialize inner join', () => {
+      const spec: SelectSpec = [{ relation: 'posts', inner: true, select: ['id', 'title'] }]
+      expect(serializeSelectSpec(spec)).toBe('posts!inner(id,title)')
+    })
+
+    it('should serialize inner join with parent columns', () => {
+      const spec: SelectSpec = [
+        'id',
+        'name',
+        { relation: 'posts', inner: true, select: ['id'] },
+      ]
+      expect(serializeSelectSpec(spec)).toBe('id,name,posts!inner(id)')
+    })
+  })
+
+  // ============================================================================
+  // 12. Left Join (Explicit)
+  // ============================================================================
+  describe('12. Left Join (Explicit)', () => {
+    it('should serialize left join', () => {
+      const spec: SelectSpec = [{ relation: 'posts', left: true, select: ['id', 'title'] }]
+      expect(serializeSelectSpec(spec)).toBe('posts!left(id,title)')
+    })
+  })
+
+  // ============================================================================
+  // 13. Foreign Key Hint (Disambiguation)
+  // ============================================================================
+  describe('13. Foreign Key Hint (Disambiguation)', () => {
+    it('should serialize relation with FK hint', () => {
+      const spec: SelectSpec = [{ relation: 'users', hint: 'author_id', select: ['id', 'name'] }]
+      expect(serializeSelectSpec(spec)).toBe('users!author_id(id,name)')
+    })
+
+    it('should serialize relation with full FK name hint', () => {
+      const spec: SelectSpec = [
+        { relation: 'users', hint: 'posts_author_id_fkey', select: ['id', 'name'] },
+      ]
+      expect(serializeSelectSpec(spec)).toBe('users!posts_author_id_fkey(id,name)')
+    })
+  })
+
+  // ============================================================================
+  // 14. Hint + Inner Join
+  // ============================================================================
+  describe('14. Hint + Inner Join', () => {
+    it('should serialize hint with inner join', () => {
+      const spec: SelectSpec = [
+        { relation: 'users', hint: 'author_id', inner: true, select: ['id', 'name'] },
+      ]
+      expect(serializeSelectSpec(spec)).toBe('users!author_id!inner(id,name)')
+    })
+
+    it('should serialize aliased hint with inner join', () => {
+      const spec: SelectSpec = [
+        { relation: 'users', as: 'author', hint: 'author_id', inner: true, select: ['id'] },
+      ]
+      expect(serializeSelectSpec(spec)).toBe('author:users!author_id!inner(id)')
+    })
+  })
+
+  // ============================================================================
+  // 15. Spread Relation
+  // ============================================================================
+  describe('15. Spread Relation', () => {
+    it('should serialize spread relation', () => {
+      const spec: SelectSpec = [{ spread: true, relation: 'profile', select: ['status', 'bio'] }]
+      expect(serializeSelectSpec(spec)).toBe('...profile(status,bio)')
+    })
+
+    it('should serialize spread with regular columns', () => {
+      const spec: SelectSpec = [
+        'id',
+        'name',
+        { spread: true, relation: 'profile', select: ['status', 'bio'] },
+      ]
+      expect(serializeSelectSpec(spec)).toBe('id,name,...profile(status,bio)')
+    })
+  })
+
+  // ============================================================================
+  // 16. Spread with Hint
+  // ============================================================================
+  describe('16. Spread with Hint', () => {
+    it('should serialize spread with FK hint', () => {
+      const spec: SelectSpec = [
+        { spread: true, relation: 'users', hint: 'author_id', select: ['username'] },
+      ]
+      expect(serializeSelectSpec(spec)).toBe('...users!author_id(username)')
+    })
+  })
+
+  // ============================================================================
+  // 17. Nested Relations
+  // ============================================================================
+  describe('17. Nested Relations', () => {
+    it('should serialize nested relations', () => {
+      const spec: SelectSpec = [
+        {
+          relation: 'posts',
+          select: [
+            'id',
+            {
+              relation: 'comments',
+              select: [
+                'id',
+                'text',
+                { relation: 'users', as: 'author', select: ['name'] },
+              ],
+            },
+          ],
+        },
+      ]
+      expect(serializeSelectSpec(spec)).toBe('posts(id,comments(id,text,author:users(name)))')
+    })
+
+    it('should serialize deeply nested relations', () => {
+      const spec: SelectSpec = [
+        {
+          relation: 'a',
+          select: [
+            {
+              relation: 'b',
+              select: [
+                {
+                  relation: 'c',
+                  select: ['id'],
+                },
+              ],
+            },
+          ],
+        },
+      ]
+      expect(serializeSelectSpec(spec)).toBe('a(b(c(id)))')
+    })
+  })
+
+  // ============================================================================
+  // 18. Complex Combined Example
+  // ============================================================================
+  describe('18. Complex Combined Example', () => {
+    it('should serialize complex query with multiple features', () => {
+      const spec: SelectSpec = [
+        'id',
+        { column: 'name', as: 'display_name' },
+        { column: 'data', as: 'config', json: ['settings'] },
+        {
+          relation: 'posts',
+          inner: true,
+          select: [
+            'id',
+            'title',
+            {
+              relation: 'comments',
+              as: 'comment_count',
+              select: [{ count: true }],
+            },
+          ],
+        },
+      ]
+      expect(serializeSelectSpec(spec)).toBe(
+        'id,display_name:name,config:data->settings,posts!inner(id,title,comment_count:comments(count()))'
+      )
+    })
+
+    it('should serialize another complex query', () => {
+      const spec: SelectSpec = [
+        'id',
+        { column: 'created_at', cast: 'text' },
+        { column: 'data', json: ['settings', 'theme'] },
+        { relation: 'posts', hint: 'fk_author', inner: true, select: ['id'] },
+        { spread: true, relation: 'profile', select: ['status'] },
+        { count: true, as: 'total' },
+      ]
+      expect(serializeSelectSpec(spec)).toBe(
+        'id,created_at::text,data->settings->theme,posts!fk_author!inner(id),...profile(status),total:count()'
+      )
+    })
+
+    it('should handle all features in one query', () => {
+      const spec: SelectSpec = [
+        'simple_col',
+        { column: 'aliased_col', as: 'alias' },
+        { column: 'casted_col', cast: 'text' },
+        { column: 'json_col', json: ['path'] },
+        { column: 'json_text_col', jsonText: ['path'] },
+        { column: 'agg_col', aggregate: 'sum' },
+        { count: true },
+        { relation: 'rel', select: ['id'] },
+        { relation: 'aliased_rel', as: 'ar', select: ['id'] },
+        { relation: 'inner_rel', inner: true, select: ['id'] },
+        { relation: 'left_rel', left: true, select: ['id'] },
+        { relation: 'hint_rel', hint: 'fk', select: ['id'] },
+        { relation: 'hint_inner_rel', hint: 'fk', inner: true, select: ['id'] },
+        { spread: true, relation: 'spread_rel', select: ['id'] },
+        { spread: true, relation: 'spread_hint_rel', hint: 'fk', select: ['id'] },
+      ]
+      expect(serializeSelectSpec(spec)).toBe(
+        'simple_col,' +
+        'alias:aliased_col,' +
+        'casted_col::text,' +
+        'json_col->path,' +
+        'json_text_col->>path,' +
+        'agg_col.sum(),' +
+        'count(),' +
+        'rel(id),' +
+        'ar:aliased_rel(id),' +
+        'inner_rel!inner(id),' +
+        'left_rel!left(id),' +
+        'hint_rel!fk(id),' +
+        'hint_inner_rel!fk!inner(id),' +
+        '...spread_rel(id),' +
+        '...spread_hint_rel!fk(id)'
+      )
+    })
+  })
+
+  // ============================================================================
+  // Edge Cases
+  // ============================================================================
+  describe('Edge Cases', () => {
+    it('should handle empty array', () => {
+      const spec: SelectSpec = []
+      expect(serializeSelectSpec(spec)).toBe('')
+    })
+
+    it('should handle empty string', () => {
+      const spec: SelectSpec = ''
+      expect(serializeSelectSpec(spec)).toBe('')
+    })
+
+    it('should handle relation with string select (backward compat)', () => {
+      const spec: SelectSpec = [{ relation: 'posts', select: 'id, title' }]
+      expect(serializeSelectSpec(spec)).toBe('posts(id, title)')
+    })
+
+    it('should handle relation with empty select', () => {
+      const spec: SelectSpec = [{ relation: 'posts', select: [] }]
+      expect(serializeSelectSpec(spec)).toBe('posts()')
+    })
+
+    it('should handle column without any options', () => {
+      const spec: SelectSpec = [{ column: 'id' }]
+      expect(serializeSelectSpec(spec)).toBe('id')
+    })
+  })
+})

--- a/packages/core/postgrest-js/test/select-builder.test.ts
+++ b/packages/core/postgrest-js/test/select-builder.test.ts
@@ -160,7 +160,9 @@ describe('serializeSelectSpec', () => {
     })
 
     it('should serialize JSON text path with alias', () => {
-      const spec: SelectSpec = [{ column: 'data', as: 'theme_name', jsonText: ['settings', 'theme'] }]
+      const spec: SelectSpec = [
+        { column: 'data', as: 'theme_name', jsonText: ['settings', 'theme'] },
+      ]
       expect(serializeSelectSpec(spec)).toBe('theme_name:data->settings->>theme')
     })
   })
@@ -295,11 +297,7 @@ describe('serializeSelectSpec', () => {
     })
 
     it('should serialize inner join with parent columns', () => {
-      const spec: SelectSpec = [
-        'id',
-        'name',
-        { relation: 'posts', inner: true, select: ['id'] },
-      ]
+      const spec: SelectSpec = ['id', 'name', { relation: 'posts', inner: true, select: ['id'] }]
       expect(serializeSelectSpec(spec)).toBe('id,name,posts!inner(id)')
     })
   })
@@ -393,11 +391,7 @@ describe('serializeSelectSpec', () => {
             'id',
             {
               relation: 'comments',
-              select: [
-                'id',
-                'text',
-                { relation: 'users', as: 'author', select: ['name'] },
-              ],
+              select: ['id', 'text', { relation: 'users', as: 'author', select: ['name'] }],
             },
           ],
         },
@@ -488,20 +482,20 @@ describe('serializeSelectSpec', () => {
       ]
       expect(serializeSelectSpec(spec)).toBe(
         'simple_col,' +
-        'alias:aliased_col,' +
-        'casted_col::text,' +
-        'json_col->path,' +
-        'json_text_col->>path,' +
-        'agg_col.sum(),' +
-        'count(),' +
-        'rel(id),' +
-        'ar:aliased_rel(id),' +
-        'inner_rel!inner(id),' +
-        'left_rel!left(id),' +
-        'hint_rel!fk(id),' +
-        'hint_inner_rel!fk!inner(id),' +
-        '...spread_rel(id),' +
-        '...spread_hint_rel!fk(id)'
+          'alias:aliased_col,' +
+          'casted_col::text,' +
+          'json_col->path,' +
+          'json_text_col->>path,' +
+          'agg_col.sum(),' +
+          'count(),' +
+          'rel(id),' +
+          'ar:aliased_rel(id),' +
+          'inner_rel!inner(id),' +
+          'left_rel!left(id),' +
+          'hint_rel!fk(id),' +
+          'hint_inner_rel!fk!inner(id),' +
+          '...spread_rel(id),' +
+          '...spread_hint_rel!fk(id)'
       )
     })
   })


### PR DESCRIPTION
## 🔍 Description

### What changed?

Added array-based `select()` API to postgrest-js that provides IDE autocomplete while maintaining full backward compatibility with string-based queries.

- New `select-builder.ts` with typed specs (`FieldSpec`, `RelationSpec`, `SpreadSpec`, `CountSpec`) and `serializeSelectSpec()`
- Updated `PostgrestQueryBuilder.select()` and `PostgrestTransformBuilder.select()` to accept arrays
- Exported new types from package index
- claude code plan [can be viewed here](https://github.com/supabase/supabase-js/pull/2083/changes#diff-b923cfc47fff3e556d167a2632af6688d76b798865931d61a91e87145df03c3a) to help with review

### Why was this change needed?

The string-based select API doesn't provide IDE autocomplete or compile-time validation. This array-based alternative enables better developer experience while keeping full backward compatibility.

```typescript
// String (still works)
.select('id, display_name:username, posts!inner(id)')

// Array (new - with autocomplete)
.select([
  'id',
  { column: 'username', as: 'display_name' },
  { relation: 'posts', inner: true, select: ['id'] }
])
```

## 🔄 Breaking changes

- [x] This PR contains no breaking changes

## 📋 Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/supabase/supabase-js/blob/master/CONTRIBUTING.md)
- [x] My PR title follows the [conventional commit format](https://www.conventionalcommits.org/)
- [x] I have run `nx format` to ensure consistent code formatting
- [x] I have added tests for new functionality (if applicable)
- [x] I have updated documentation (if applicable)
