### PR TITLE
feat(postgrest): add schema-based type inference to fluent query builder

### DIFF
--- a/packages/core/postgrest-js/src/fluent-query-builder/FluentQueryBuilder.ts
+++ b/packages/core/postgrest-js/src/fluent-query-builder/FluentQueryBuilder.ts
@@ -36,10 +36,7 @@ import { GenericSchema } from '../types/common/common'
  *     postTitle: posts.title,
  *   }))
  */
-export class FluentQueryBuilder<
-  Schema = unknown,
-  Tables extends readonly string[] = readonly []
-> {
+export class FluentQueryBuilder<Schema = unknown, Tables extends readonly string[] = readonly []> {
   private readonly state: QueryBuilderState
 
   constructor(state: QueryBuilderState = createInitialState()) {
@@ -124,9 +121,7 @@ export class FluentQueryBuilder<
     selector: (...tables: SchemaAwareTableProxies<Schema, Tables>) => Selection
   ): FluentQueryBuilder<Schema, Tables> {
     const proxies = this.createProxiesArray()
-    const selection = selector(
-      ...(proxies as unknown as SchemaAwareTableProxies<Schema, Tables>)
-    )
+    const selection = selector(...(proxies as unknown as SchemaAwareTableProxies<Schema, Tables>))
 
     const newState: QueryBuilderState = {
       ...this.state,
@@ -173,9 +168,7 @@ export class FluentQueryBuilder<
     options: { ascending?: boolean } = {}
   ): FluentQueryBuilder<Schema, Tables> {
     const proxies = this.createProxiesArray()
-    const resolvedField = field(
-      ...(proxies as unknown as SchemaAwareTableProxies<Schema, Tables>)
-    )
+    const resolvedField = field(...(proxies as unknown as SchemaAwareTableProxies<Schema, Tables>))
 
     const newState: QueryBuilderState = {
       ...this.state,

--- a/packages/core/postgrest-js/src/fluent-query-builder/FluentQueryBuilder.ts
+++ b/packages/core/postgrest-js/src/fluent-query-builder/FluentQueryBuilder.ts
@@ -1,0 +1,238 @@
+/**
+ * FluentQueryBuilder
+ *
+ * A fluent, type-safe query builder for PostgREST with join support.
+ */
+
+import {
+  QueryBuilderState,
+  createInitialState,
+  FieldRef,
+  AnyCondition,
+  JoinedTable,
+} from './types'
+import { createTableProxy, TableProxy } from './proxy'
+
+/**
+ * Helper type to create a tuple of TableProxy types from a tuple of table names
+ */
+type TableProxies<T extends readonly string[]> = {
+  [K in keyof T]: T[K] extends string ? TableProxy<T[K]> : never
+}
+
+/**
+ * The main fluent query builder class.
+ *
+ * @example
+ * const query = q()
+ *   .from('users')
+ *   .join('posts')
+ *   .select((users, posts) => ({
+ *     userName: users.name,
+ *     postTitle: posts.title,
+ *   }))
+ */
+export class FluentQueryBuilder<Tables extends readonly string[] = readonly []> {
+  private readonly state: QueryBuilderState
+
+  constructor(state: QueryBuilderState = createInitialState()) {
+    this.state = state
+  }
+
+  /**
+   * Start a query from a base table.
+   *
+   * @example
+   * q().from('users')
+   */
+  from<TableName extends string>(tableName: TableName): FluentQueryBuilder<readonly [TableName]> {
+    const newState: QueryBuilderState = {
+      ...this.state,
+      baseTable: tableName,
+    }
+
+    return new FluentQueryBuilder(newState)
+  }
+
+  /**
+   * Join another table to the query.
+   * The condition is optional - only needed when disambiguating multiple FKs.
+   *
+   * @example
+   * // Simple join (FK auto-resolved)
+   * q().from('users').join('posts')
+   *
+   * // With disambiguation
+   * q().from('users').join('messages', (users, messages) =>
+   *   eq(users.id, messages.senderId)
+   * )
+   */
+  join<TableName extends string>(
+    tableName: TableName,
+    condition?: (...tables: TableProxies<readonly [...Tables, TableName]>) => AnyCondition
+  ): FluentQueryBuilder<readonly [...Tables, TableName]> {
+    // Evaluate the condition if provided
+    let resolvedCondition: AnyCondition | undefined
+    if (condition) {
+      const proxies = this.createProxiesArray(tableName)
+      resolvedCondition = condition(
+        ...(proxies as unknown as TableProxies<readonly [...Tables, TableName]>)
+      )
+    }
+
+    const joinedTable: JoinedTable = {
+      tableName,
+      condition: resolvedCondition,
+    }
+
+    const newState: QueryBuilderState = {
+      ...this.state,
+      joins: [...this.state.joins, joinedTable],
+    }
+
+    return new FluentQueryBuilder(newState)
+  }
+
+  /**
+   * Define the fields to select from the query.
+   *
+   * @example
+   * q()
+   *   .from('users')
+   *   .join('posts')
+   *   .select((users, posts) => ({
+   *     userName: users.name,
+   *     postTitle: posts.title,
+   *   }))
+   */
+  select<Selection extends Record<string, FieldRef>>(
+    selector: (...tables: TableProxies<Tables>) => Selection
+  ): FluentQueryBuilder<Tables> {
+    const proxies = this.createProxiesArray()
+    const selection = selector(...(proxies as unknown as TableProxies<Tables>))
+
+    const newState: QueryBuilderState = {
+      ...this.state,
+      selectFields: selection,
+    }
+
+    return new FluentQueryBuilder(newState)
+  }
+
+  /**
+   * Add a where condition to filter results.
+   *
+   * @example
+   * q()
+   *   .from('users')
+   *   .where((users) => eq(users.status, 'active'))
+   */
+  where(
+    condition: (...tables: TableProxies<Tables>) => AnyCondition
+  ): FluentQueryBuilder<Tables> {
+    const proxies = this.createProxiesArray()
+    const resolvedCondition = condition(...(proxies as unknown as TableProxies<Tables>))
+
+    const newState: QueryBuilderState = {
+      ...this.state,
+      whereConditions: [...this.state.whereConditions, resolvedCondition],
+    }
+
+    return new FluentQueryBuilder(newState)
+  }
+
+  /**
+   * Add ordering to the query.
+   *
+   * @example
+   * q()
+   *   .from('users')
+   *   .orderBy((users) => users.createdAt, { ascending: false })
+   */
+  orderBy(
+    field: (...tables: TableProxies<Tables>) => FieldRef,
+    options: { ascending?: boolean } = {}
+  ): FluentQueryBuilder<Tables> {
+    const proxies = this.createProxiesArray()
+    const resolvedField = field(...(proxies as unknown as TableProxies<Tables>))
+
+    const newState: QueryBuilderState = {
+      ...this.state,
+      orderBy: [
+        ...this.state.orderBy,
+        { field: resolvedField, ascending: options.ascending ?? true },
+      ],
+    }
+
+    return new FluentQueryBuilder(newState)
+  }
+
+  /**
+   * Limit the number of results.
+   *
+   * @example
+   * q().from('users').limit(10)
+   */
+  limit(count: number): FluentQueryBuilder<Tables> {
+    const newState: QueryBuilderState = {
+      ...this.state,
+      limit: count,
+    }
+
+    return new FluentQueryBuilder(newState)
+  }
+
+  /**
+   * Get the current query state (for debugging or query generation).
+   */
+  getState(): QueryBuilderState {
+    return this.state
+  }
+
+  /**
+   * Get the list of table names in order (base table + joins).
+   */
+  private getTableList(additionalTable?: string): string[] {
+    const tables: string[] = []
+
+    if (this.state.baseTable) {
+      tables.push(this.state.baseTable)
+    }
+
+    for (const join of this.state.joins) {
+      tables.push(join.tableName)
+    }
+
+    if (additionalTable) {
+      tables.push(additionalTable)
+    }
+
+    return tables
+  }
+
+  /**
+   * Create an array of table proxies in order.
+   */
+  private createProxiesArray(additionalTable?: string): TableProxy<string>[] {
+    const tables = this.getTableList(additionalTable)
+    return tables.map((tableName) => createTableProxy(tableName))
+  }
+}
+
+/**
+ * Create a new fluent query builder.
+ *
+ * @example
+ * import { q, eq } from './fluent-query-builder'
+ *
+ * const query = q()
+ *   .from('users')
+ *   .join('posts')
+ *   .select((users, posts) => ({
+ *     userName: users.name,
+ *     postTitle: posts.title,
+ *   }))
+ */
+export function q(): FluentQueryBuilder<readonly []> {
+  return new FluentQueryBuilder()
+}

--- a/packages/core/postgrest-js/src/fluent-query-builder/TODO.md
+++ b/packages/core/postgrest-js/src/fluent-query-builder/TODO.md
@@ -1,0 +1,144 @@
+# Fluent Query Builder - TODOs
+
+## Current Status
+
+The fluent query builder is functional with basic features:
+- `q().from('table').join('table').select().where().orderBy().limit()`
+- Operators: `eq`, `neq`, `gt`, `gte`, `lt`, `lte`, `and`, `or`, `isNull`, `isNotNull`
+- Query generation: `generateQuery()`, `toPostgrestQuery()`
+- 30 passing tests
+
+## Remaining Tasks
+
+### 1. Schema-Based Type Inference
+**Priority: High**
+
+Add TypeScript type inference from database schema types so users get autocomplete and compile-time errors.
+
+```typescript
+// Goal: This should error if 'users' table doesn't have 'foo' column
+q<Database>().from('users').select((users) => ({ x: users.foo }))
+//                                                      ^^^ Error: Property 'foo' does not exist
+
+// Goal: Table names should autocomplete from schema
+q<Database>().from('use') // autocomplete suggests 'users'
+```
+
+Files to modify:
+- `FluentQueryBuilder.ts` - Add schema generic parameter
+- `proxy.ts` - Type proxies based on table columns
+- Leverage existing types from `../types/common/common.ts`
+
+### 2. Integration with PostgrestClient
+**Priority: High**
+
+Allow executing queries directly without manual conversion.
+
+```typescript
+// Option A: Add to PostgrestClient
+const { data, error } = await supabase.q
+  .from('users')
+  .join('posts')
+  .select((users, posts) => ({ name: users.name, title: posts.title }))
+
+// Option B: Add execute() method to builder
+const { data, error } = await q()
+  .from('users')
+  .execute(supabaseClient)
+```
+
+Files to modify:
+- `FluentQueryBuilder.ts` - Add `execute()` method
+- `PostgrestClient.ts` - Add `q` property (optional)
+
+### 3. Wire isNull/isNotNull in Query Generator
+**Priority: Medium**
+
+The operators exist but aren't fully wired in the query generator for `where()` clauses.
+
+```typescript
+q().from('users').where((users) => isNull(users.deletedAt))
+// Should generate: /users?deletedAt=is.null
+```
+
+Files to modify:
+- `query-generator.ts` - Handle `IsNullCondition` and `IsNotNullCondition` in `conditionToFilter()`
+
+### 4. Add offset() for Pagination
+**Priority: Medium**
+
+```typescript
+q().from('users').limit(10).offset(20)
+// Should generate: /users?limit=10&offset=20
+```
+
+Files to modify:
+- `types.ts` - Add `offset` to `QueryBuilderState`
+- `FluentQueryBuilder.ts` - Add `offset()` method
+- `query-generator.ts` - Include offset in output
+
+### 5. Add single() / maybeSingle() Modifiers
+**Priority: Medium**
+
+```typescript
+q().from('users').where((users) => eq(users.id, 1)).single()
+// Should set Accept header to return single object instead of array
+```
+
+Files to modify:
+- `types.ts` - Add `returnType` to state ('array' | 'single' | 'maybeSingle')
+- `FluentQueryBuilder.ts` - Add `single()` and `maybeSingle()` methods
+- `query-generator.ts` - Include in `GeneratedQuery`
+
+### 6. Add Inner Join Hint (!inner)
+**Priority: Low**
+
+PostgREST supports `!inner` to filter out null relationships.
+
+```typescript
+q().from('users').innerJoin('posts').select(...)
+// Should generate: /users?select=posts!inner(...)
+```
+
+Files to modify:
+- `types.ts` - Add `inner` flag to `JoinedTable`
+- `FluentQueryBuilder.ts` - Add `innerJoin()` method or option to `join()`
+- `query-generator.ts` - Include `!inner` hint in select
+
+### 7. Add in() Operator
+**Priority: Low**
+
+```typescript
+q().from('users').where((users) => in_(users.role, ['admin', 'mod']))
+// Should generate: /users?role=in.(admin,mod)
+```
+
+Files to modify:
+- `types.ts` - Add `InCondition` type
+- `operators.ts` - Add `in_()` function (underscore to avoid JS keyword)
+- `query-generator.ts` - Handle `InCondition`
+
+### 8. Add like/ilike Operators
+**Priority: Low**
+
+```typescript
+q().from('users').where((users) => like(users.name, '%john%'))
+// Should generate: /users?name=like.*john*
+```
+
+Files to modify:
+- `types.ts` - Add `LikeCondition` type
+- `operators.ts` - Add `like()` and `ilike()` functions
+- `query-generator.ts` - Handle pattern conversion
+
+---
+
+## Testing Notes
+
+Run tests with:
+```bash
+cd packages/core/postgrest-js
+npx jest test/fluent-query-builder.test.ts
+```
+
+All new features should have corresponding tests in `test/fluent-query-builder.test.ts`.

--- a/packages/core/postgrest-js/src/fluent-query-builder/TODO.md
+++ b/packages/core/postgrest-js/src/fluent-query-builder/TODO.md
@@ -3,6 +3,7 @@
 ## Current Status
 
 The fluent query builder is functional with basic features:
+
 - `q().from('table').join('table').select().where().orderBy().limit()`
 - Operators: `eq`, `neq`, `gt`, `gte`, `lt`, `lte`, `and`, `or`, `isNull`, `isNotNull`
 - Query generation: `generateQuery()`, `toPostgrestQuery()`
@@ -11,13 +12,16 @@ The fluent query builder is functional with basic features:
 ## Remaining Tasks
 
 ### 1. Schema-Based Type Inference
+
 **Priority: High**
 
 Add TypeScript type inference from database schema types so users get autocomplete and compile-time errors.
 
 ```typescript
 // Goal: This should error if 'users' table doesn't have 'foo' column
-q<Database>().from('users').select((users) => ({ x: users.foo }))
+q<Database>()
+  .from('users')
+  .select((users) => ({ x: users.foo }))
 //                                                      ^^^ Error: Property 'foo' does not exist
 
 // Goal: Table names should autocomplete from schema
@@ -25,11 +29,13 @@ q<Database>().from('use') // autocomplete suggests 'users'
 ```
 
 Files to modify:
+
 - `FluentQueryBuilder.ts` - Add schema generic parameter
 - `proxy.ts` - Type proxies based on table columns
 - Leverage existing types from `../types/common/common.ts`
 
 ### 2. Integration with PostgrestClient
+
 **Priority: High**
 
 Allow executing queries directly without manual conversion.
@@ -42,29 +48,33 @@ const { data, error } = await supabase.q
   .select((users, posts) => ({ name: users.name, title: posts.title }))
 
 // Option B: Add execute() method to builder
-const { data, error } = await q()
-  .from('users')
-  .execute(supabaseClient)
+const { data, error } = await q().from('users').execute(supabaseClient)
 ```
 
 Files to modify:
+
 - `FluentQueryBuilder.ts` - Add `execute()` method
 - `PostgrestClient.ts` - Add `q` property (optional)
 
 ### 3. Wire isNull/isNotNull in Query Generator
+
 **Priority: Medium**
 
 The operators exist but aren't fully wired in the query generator for `where()` clauses.
 
 ```typescript
-q().from('users').where((users) => isNull(users.deletedAt))
+q()
+  .from('users')
+  .where((users) => isNull(users.deletedAt))
 // Should generate: /users?deletedAt=is.null
 ```
 
 Files to modify:
+
 - `query-generator.ts` - Handle `IsNullCondition` and `IsNotNullCondition` in `conditionToFilter()`
 
 ### 4. Add offset() for Pagination
+
 **Priority: Medium**
 
 ```typescript
@@ -73,24 +83,31 @@ q().from('users').limit(10).offset(20)
 ```
 
 Files to modify:
+
 - `types.ts` - Add `offset` to `QueryBuilderState`
 - `FluentQueryBuilder.ts` - Add `offset()` method
 - `query-generator.ts` - Include offset in output
 
 ### 5. Add single() / maybeSingle() Modifiers
+
 **Priority: Medium**
 
 ```typescript
-q().from('users').where((users) => eq(users.id, 1)).single()
+q()
+  .from('users')
+  .where((users) => eq(users.id, 1))
+  .single()
 // Should set Accept header to return single object instead of array
 ```
 
 Files to modify:
+
 - `types.ts` - Add `returnType` to state ('array' | 'single' | 'maybeSingle')
 - `FluentQueryBuilder.ts` - Add `single()` and `maybeSingle()` methods
 - `query-generator.ts` - Include in `GeneratedQuery`
 
 ### 6. Add Inner Join Hint (!inner)
+
 **Priority: Low**
 
 PostgREST supports `!inner` to filter out null relationships.
@@ -101,32 +118,41 @@ q().from('users').innerJoin('posts').select(...)
 ```
 
 Files to modify:
+
 - `types.ts` - Add `inner` flag to `JoinedTable`
 - `FluentQueryBuilder.ts` - Add `innerJoin()` method or option to `join()`
 - `query-generator.ts` - Include `!inner` hint in select
 
 ### 7. Add in() Operator
+
 **Priority: Low**
 
 ```typescript
-q().from('users').where((users) => in_(users.role, ['admin', 'mod']))
+q()
+  .from('users')
+  .where((users) => in_(users.role, ['admin', 'mod']))
 // Should generate: /users?role=in.(admin,mod)
 ```
 
 Files to modify:
+
 - `types.ts` - Add `InCondition` type
 - `operators.ts` - Add `in_()` function (underscore to avoid JS keyword)
 - `query-generator.ts` - Handle `InCondition`
 
 ### 8. Add like/ilike Operators
+
 **Priority: Low**
 
 ```typescript
-q().from('users').where((users) => like(users.name, '%john%'))
+q()
+  .from('users')
+  .where((users) => like(users.name, '%john%'))
 // Should generate: /users?name=like.*john*
 ```
 
 Files to modify:
+
 - `types.ts` - Add `LikeCondition` type
 - `operators.ts` - Add `like()` and `ilike()` functions
 - `query-generator.ts` - Handle pattern conversion
@@ -136,6 +162,7 @@ Files to modify:
 ## Testing Notes
 
 Run tests with:
+
 ```bash
 cd packages/core/postgrest-js
 npx jest test/fluent-query-builder.test.ts

--- a/packages/core/postgrest-js/src/fluent-query-builder/index.ts
+++ b/packages/core/postgrest-js/src/fluent-query-builder/index.ts
@@ -20,6 +20,10 @@ export type {
   TableList,
   JoinedTable,
   QueryBuilderState,
+  // Schema helper types
+  TablesAndViews,
+  TableRow,
+  ValidTableName,
 } from './types'
 
 export { createInitialState } from './types'
@@ -27,7 +31,7 @@ export { createInitialState } from './types'
 // Proxy utilities
 export { createFieldRef, createTableProxy, isFieldRef, isTableProxy } from './proxy'
 
-export type { TableProxy } from './proxy'
+export type { TableProxy, SchemaAwareTableProxy, SchemaAwareTableProxies } from './proxy'
 
 // Operators
 export {

--- a/packages/core/postgrest-js/src/fluent-query-builder/index.ts
+++ b/packages/core/postgrest-js/src/fluent-query-builder/index.ts
@@ -1,0 +1,51 @@
+/**
+ * Fluent Query Builder
+ *
+ * A more ergonomic, type-safe query builder API for PostgREST.
+ */
+
+// Main builder
+export { FluentQueryBuilder, q } from './FluentQueryBuilder'
+
+// Types
+export type {
+  FieldRef,
+  Condition,
+  AndCondition,
+  OrCondition,
+  AnyCondition,
+  IsNullCondition,
+  IsNotNullCondition,
+  ComparisonOperator,
+  TableList,
+  JoinedTable,
+  QueryBuilderState,
+} from './types'
+
+export { createInitialState } from './types'
+
+// Proxy utilities
+export { createFieldRef, createTableProxy, isFieldRef, isTableProxy } from './proxy'
+
+export type { TableProxy } from './proxy'
+
+// Operators
+export {
+  eq,
+  neq,
+  gt,
+  gte,
+  lt,
+  lte,
+  and,
+  or,
+  isNull,
+  isNotNull,
+  isCondition,
+  isAndCondition,
+  isOrCondition,
+} from './operators'
+
+// Query generator
+export { generateQuery, toPostgrestQuery } from './query-generator'
+export type { GeneratedQuery } from './query-generator'

--- a/packages/core/postgrest-js/src/fluent-query-builder/operators.ts
+++ b/packages/core/postgrest-js/src/fluent-query-builder/operators.ts
@@ -1,0 +1,184 @@
+/**
+ * Condition operators for the fluent query builder
+ *
+ * These operators create condition objects that can be used in
+ * join disambiguation and where clauses.
+ */
+
+import {
+    FieldRef,
+    Condition,
+    AndCondition,
+    OrCondition,
+    AnyCondition,
+    IsNullCondition,
+    IsNotNullCondition,
+  } from './types'
+  import { isFieldRef } from './proxy'
+  
+  /**
+   * Creates an equality condition (=)
+   *
+   * @example
+   * eq(user.id, post.userId)  // user.id = post.userId
+   * eq(user.status, 'active') // user.status = 'active'
+   */
+  export function eq(left: FieldRef, right: FieldRef | unknown): Condition {
+    return {
+      __type: 'Condition',
+      left,
+      operator: '=',
+      right,
+    }
+  }
+  
+  /**
+   * Creates a not-equal condition (!=)
+   *
+   * @example
+   * neq(user.status, 'deleted')
+   */
+  export function neq(left: FieldRef, right: FieldRef | unknown): Condition {
+    return {
+      __type: 'Condition',
+      left,
+      operator: '!=',
+      right,
+    }
+  }
+  
+  /**
+   * Creates a greater-than condition (>)
+   *
+   * @example
+   * gt(user.age, 18)
+   */
+  export function gt(left: FieldRef, right: FieldRef | unknown): Condition {
+    return {
+      __type: 'Condition',
+      left,
+      operator: '>',
+      right,
+    }
+  }
+  
+  /**
+   * Creates a greater-than-or-equal condition (>=)
+   *
+   * @example
+   * gte(user.age, 18)
+   */
+  export function gte(left: FieldRef, right: FieldRef | unknown): Condition {
+    return {
+      __type: 'Condition',
+      left,
+      operator: '>=',
+      right,
+    }
+  }
+  
+  /**
+   * Creates a less-than condition (<)
+   *
+   * @example
+   * lt(user.age, 65)
+   */
+  export function lt(left: FieldRef, right: FieldRef | unknown): Condition {
+    return {
+      __type: 'Condition',
+      left,
+      operator: '<',
+      right,
+    }
+  }
+  
+  /**
+   * Creates a less-than-or-equal condition (<=)
+   *
+   * @example
+   * lte(user.age, 65)
+   */
+  export function lte(left: FieldRef, right: FieldRef | unknown): Condition {
+    return {
+      __type: 'Condition',
+      left,
+      operator: '<=',
+      right,
+    }
+  }
+  
+  /**
+   * Creates an AND condition combining multiple conditions
+   *
+   * @example
+   * and(eq(user.status, 'active'), gt(user.age, 18))
+   */
+  export function and(...conditions: AnyCondition[]): AndCondition {
+    return {
+      __type: 'And',
+      conditions,
+    }
+  }
+  
+  /**
+   * Creates an OR condition combining multiple conditions
+   *
+   * @example
+   * or(eq(user.role, 'admin'), eq(user.role, 'moderator'))
+   */
+  export function or(...conditions: AnyCondition[]): OrCondition {
+    return {
+      __type: 'Or',
+      conditions,
+    }
+  }
+  
+  /**
+   * Creates an IS NULL condition
+   *
+   * @example
+   * isNull(user.deletedAt)
+   */
+  export function isNull(field: FieldRef): IsNullCondition {
+    return {
+      __type: 'IsNull',
+      field,
+    }
+  }
+  
+  /**
+   * Creates an IS NOT NULL condition
+   *
+   * @example
+   * isNotNull(user.email)
+   */
+  export function isNotNull(field: FieldRef): IsNotNullCondition {
+    return {
+      __type: 'IsNotNull',
+      field,
+    }
+  }
+  
+  /**
+   * Type guard to check if a condition is a comparison condition
+   */
+  export function isCondition(value: unknown): value is Condition {
+    return (
+      typeof value === 'object' && value !== null && (value as Condition).__type === 'Condition'
+    )
+  }
+  
+  /**
+   * Type guard for AND conditions
+   */
+  export function isAndCondition(value: unknown): value is AndCondition {
+    return typeof value === 'object' && value !== null && (value as AndCondition).__type === 'And'
+  }
+  
+  /**
+   * Type guard for OR conditions
+   */
+  export function isOrCondition(value: unknown): value is OrCondition {
+    return typeof value === 'object' && value !== null && (value as OrCondition).__type === 'Or'
+  }
+  

--- a/packages/core/postgrest-js/src/fluent-query-builder/operators.ts
+++ b/packages/core/postgrest-js/src/fluent-query-builder/operators.ts
@@ -6,179 +6,176 @@
  */
 
 import {
-    FieldRef,
-    Condition,
-    AndCondition,
-    OrCondition,
-    AnyCondition,
-    IsNullCondition,
-    IsNotNullCondition,
-  } from './types'
-  import { isFieldRef } from './proxy'
-  
-  /**
-   * Creates an equality condition (=)
-   *
-   * @example
-   * eq(user.id, post.userId)  // user.id = post.userId
-   * eq(user.status, 'active') // user.status = 'active'
-   */
-  export function eq(left: FieldRef, right: FieldRef | unknown): Condition {
-    return {
-      __type: 'Condition',
-      left,
-      operator: '=',
-      right,
-    }
+  FieldRef,
+  Condition,
+  AndCondition,
+  OrCondition,
+  AnyCondition,
+  IsNullCondition,
+  IsNotNullCondition,
+} from './types'
+import { isFieldRef } from './proxy'
+
+/**
+ * Creates an equality condition (=)
+ *
+ * @example
+ * eq(user.id, post.userId)  // user.id = post.userId
+ * eq(user.status, 'active') // user.status = 'active'
+ */
+export function eq(left: FieldRef, right: FieldRef | unknown): Condition {
+  return {
+    __type: 'Condition',
+    left,
+    operator: '=',
+    right,
   }
-  
-  /**
-   * Creates a not-equal condition (!=)
-   *
-   * @example
-   * neq(user.status, 'deleted')
-   */
-  export function neq(left: FieldRef, right: FieldRef | unknown): Condition {
-    return {
-      __type: 'Condition',
-      left,
-      operator: '!=',
-      right,
-    }
+}
+
+/**
+ * Creates a not-equal condition (!=)
+ *
+ * @example
+ * neq(user.status, 'deleted')
+ */
+export function neq(left: FieldRef, right: FieldRef | unknown): Condition {
+  return {
+    __type: 'Condition',
+    left,
+    operator: '!=',
+    right,
   }
-  
-  /**
-   * Creates a greater-than condition (>)
-   *
-   * @example
-   * gt(user.age, 18)
-   */
-  export function gt(left: FieldRef, right: FieldRef | unknown): Condition {
-    return {
-      __type: 'Condition',
-      left,
-      operator: '>',
-      right,
-    }
+}
+
+/**
+ * Creates a greater-than condition (>)
+ *
+ * @example
+ * gt(user.age, 18)
+ */
+export function gt(left: FieldRef, right: FieldRef | unknown): Condition {
+  return {
+    __type: 'Condition',
+    left,
+    operator: '>',
+    right,
   }
-  
-  /**
-   * Creates a greater-than-or-equal condition (>=)
-   *
-   * @example
-   * gte(user.age, 18)
-   */
-  export function gte(left: FieldRef, right: FieldRef | unknown): Condition {
-    return {
-      __type: 'Condition',
-      left,
-      operator: '>=',
-      right,
-    }
+}
+
+/**
+ * Creates a greater-than-or-equal condition (>=)
+ *
+ * @example
+ * gte(user.age, 18)
+ */
+export function gte(left: FieldRef, right: FieldRef | unknown): Condition {
+  return {
+    __type: 'Condition',
+    left,
+    operator: '>=',
+    right,
   }
-  
-  /**
-   * Creates a less-than condition (<)
-   *
-   * @example
-   * lt(user.age, 65)
-   */
-  export function lt(left: FieldRef, right: FieldRef | unknown): Condition {
-    return {
-      __type: 'Condition',
-      left,
-      operator: '<',
-      right,
-    }
+}
+
+/**
+ * Creates a less-than condition (<)
+ *
+ * @example
+ * lt(user.age, 65)
+ */
+export function lt(left: FieldRef, right: FieldRef | unknown): Condition {
+  return {
+    __type: 'Condition',
+    left,
+    operator: '<',
+    right,
   }
-  
-  /**
-   * Creates a less-than-or-equal condition (<=)
-   *
-   * @example
-   * lte(user.age, 65)
-   */
-  export function lte(left: FieldRef, right: FieldRef | unknown): Condition {
-    return {
-      __type: 'Condition',
-      left,
-      operator: '<=',
-      right,
-    }
+}
+
+/**
+ * Creates a less-than-or-equal condition (<=)
+ *
+ * @example
+ * lte(user.age, 65)
+ */
+export function lte(left: FieldRef, right: FieldRef | unknown): Condition {
+  return {
+    __type: 'Condition',
+    left,
+    operator: '<=',
+    right,
   }
-  
-  /**
-   * Creates an AND condition combining multiple conditions
-   *
-   * @example
-   * and(eq(user.status, 'active'), gt(user.age, 18))
-   */
-  export function and(...conditions: AnyCondition[]): AndCondition {
-    return {
-      __type: 'And',
-      conditions,
-    }
+}
+
+/**
+ * Creates an AND condition combining multiple conditions
+ *
+ * @example
+ * and(eq(user.status, 'active'), gt(user.age, 18))
+ */
+export function and(...conditions: AnyCondition[]): AndCondition {
+  return {
+    __type: 'And',
+    conditions,
   }
-  
-  /**
-   * Creates an OR condition combining multiple conditions
-   *
-   * @example
-   * or(eq(user.role, 'admin'), eq(user.role, 'moderator'))
-   */
-  export function or(...conditions: AnyCondition[]): OrCondition {
-    return {
-      __type: 'Or',
-      conditions,
-    }
+}
+
+/**
+ * Creates an OR condition combining multiple conditions
+ *
+ * @example
+ * or(eq(user.role, 'admin'), eq(user.role, 'moderator'))
+ */
+export function or(...conditions: AnyCondition[]): OrCondition {
+  return {
+    __type: 'Or',
+    conditions,
   }
-  
-  /**
-   * Creates an IS NULL condition
-   *
-   * @example
-   * isNull(user.deletedAt)
-   */
-  export function isNull(field: FieldRef): IsNullCondition {
-    return {
-      __type: 'IsNull',
-      field,
-    }
+}
+
+/**
+ * Creates an IS NULL condition
+ *
+ * @example
+ * isNull(user.deletedAt)
+ */
+export function isNull(field: FieldRef): IsNullCondition {
+  return {
+    __type: 'IsNull',
+    field,
   }
-  
-  /**
-   * Creates an IS NOT NULL condition
-   *
-   * @example
-   * isNotNull(user.email)
-   */
-  export function isNotNull(field: FieldRef): IsNotNullCondition {
-    return {
-      __type: 'IsNotNull',
-      field,
-    }
+}
+
+/**
+ * Creates an IS NOT NULL condition
+ *
+ * @example
+ * isNotNull(user.email)
+ */
+export function isNotNull(field: FieldRef): IsNotNullCondition {
+  return {
+    __type: 'IsNotNull',
+    field,
   }
-  
-  /**
-   * Type guard to check if a condition is a comparison condition
-   */
-  export function isCondition(value: unknown): value is Condition {
-    return (
-      typeof value === 'object' && value !== null && (value as Condition).__type === 'Condition'
-    )
-  }
-  
-  /**
-   * Type guard for AND conditions
-   */
-  export function isAndCondition(value: unknown): value is AndCondition {
-    return typeof value === 'object' && value !== null && (value as AndCondition).__type === 'And'
-  }
-  
-  /**
-   * Type guard for OR conditions
-   */
-  export function isOrCondition(value: unknown): value is OrCondition {
-    return typeof value === 'object' && value !== null && (value as OrCondition).__type === 'Or'
-  }
-  
+}
+
+/**
+ * Type guard to check if a condition is a comparison condition
+ */
+export function isCondition(value: unknown): value is Condition {
+  return typeof value === 'object' && value !== null && (value as Condition).__type === 'Condition'
+}
+
+/**
+ * Type guard for AND conditions
+ */
+export function isAndCondition(value: unknown): value is AndCondition {
+  return typeof value === 'object' && value !== null && (value as AndCondition).__type === 'And'
+}
+
+/**
+ * Type guard for OR conditions
+ */
+export function isOrCondition(value: unknown): value is OrCondition {
+  return typeof value === 'object' && value !== null && (value as OrCondition).__type === 'Or'
+}

--- a/packages/core/postgrest-js/src/fluent-query-builder/proxy.ts
+++ b/packages/core/postgrest-js/src/fluent-query-builder/proxy.ts
@@ -1,0 +1,80 @@
+/**
+ * Proxy-based field reference tracking
+ *
+ * Creates proxy objects that track field access on tables,
+ * producing FieldRef objects that can be used in conditions and selects.
+ */
+
+import { FieldRef } from './types'
+
+/**
+ * Symbol to identify proxy objects
+ */
+const PROXY_MARKER = Symbol('TableProxy')
+
+/**
+ * Creates a FieldRef for a specific table and column
+ */
+export function createFieldRef<T extends string, C extends string>(
+  tableAlias: T,
+  column: C
+): FieldRef<T, C> {
+  return {
+    __type: 'FieldRef',
+    __tableAlias: tableAlias,
+    __column: column,
+  }
+}
+
+/**
+ * Checks if a value is a FieldRef
+ */
+export function isFieldRef(value: unknown): value is FieldRef {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    '__type' in value &&
+    (value as FieldRef).__type === 'FieldRef'
+  )
+}
+
+/**
+ * Type for a proxy that creates FieldRefs when properties are accessed
+ */
+export type TableProxy<Alias extends string> = {
+  readonly [column: string]: FieldRef<Alias, string>
+} & {
+  readonly [PROXY_MARKER]: true
+  readonly __alias: Alias
+}
+
+/**
+ * Creates a proxy for a table that generates FieldRefs when columns are accessed.
+ *
+ * @example
+ * const user = createTableProxy('user')
+ * user.id    // Returns: FieldRef { __tableAlias: 'user', __column: 'id' }
+ * user.name  // Returns: FieldRef { __tableAlias: 'user', __column: 'name' }
+ */
+export function createTableProxy<Alias extends string>(alias: Alias): TableProxy<Alias> {
+  return new Proxy({} as TableProxy<Alias>, {
+    get(_target, prop) {
+      if (prop === PROXY_MARKER) return true
+      if (prop === '__alias') return alias
+
+      // For any property access, return a FieldRef
+      if (typeof prop === 'string') {
+        return createFieldRef(alias, prop)
+      }
+
+      return undefined
+    },
+  })
+}
+
+/**
+ * Checks if a value is a TableProxy
+ */
+export function isTableProxy(value: unknown): value is TableProxy<string> {
+  return typeof value === 'object' && value !== null && PROXY_MARKER in value
+}

--- a/packages/core/postgrest-js/src/fluent-query-builder/proxy.ts
+++ b/packages/core/postgrest-js/src/fluent-query-builder/proxy.ts
@@ -58,7 +58,7 @@ export type TableProxy<Alias extends string> = {
 export type SchemaAwareTableProxy<
   Schema extends GenericSchema,
   TableName extends string,
-  Alias extends string = TableName
+  Alias extends string = TableName,
 > = TableName extends keyof TablesAndViews<Schema>
   ? {
       readonly [Col in keyof TablesAndViews<Schema>[TableName]['Row'] & string]: FieldRef<
@@ -76,9 +76,13 @@ export type SchemaAwareTableProxy<
  */
 export type SchemaAwareTableProxies<
   Schema,
-  Tables extends readonly string[]
+  Tables extends readonly string[],
 > = Schema extends GenericSchema
-  ? { [K in keyof Tables]: Tables[K] extends string ? SchemaAwareTableProxy<Schema, Tables[K]> : never }
+  ? {
+      [K in keyof Tables]: Tables[K] extends string
+        ? SchemaAwareTableProxy<Schema, Tables[K]>
+        : never
+    }
   : { [K in keyof Tables]: Tables[K] extends string ? TableProxy<Tables[K]> : never }
 
 /**

--- a/packages/core/postgrest-js/src/fluent-query-builder/query-generator.ts
+++ b/packages/core/postgrest-js/src/fluent-query-builder/query-generator.ts
@@ -1,0 +1,350 @@
+/**
+ * Query Generator
+ *
+ * Converts FluentQueryBuilder state into PostgREST query format.
+ */
+
+import {
+  QueryBuilderState,
+  FieldRef,
+  AnyCondition,
+  Condition,
+  AndCondition,
+  OrCondition,
+  IsNullCondition,
+  IsNotNullCondition,
+} from './types'
+import { isFieldRef } from './proxy'
+import { isCondition, isAndCondition, isOrCondition } from './operators'
+
+/**
+ * Result of query generation - contains all PostgREST query components
+ */
+export interface GeneratedQuery {
+  /** The base table name (used as the endpoint) */
+  table: string
+  /** The select parameter value */
+  select: string
+  /** Filter conditions as PostgREST query params */
+  filters: Record<string, string>
+  /** Order parameter value */
+  order?: string
+  /** Limit parameter value */
+  limit?: number
+}
+
+/**
+ * Converts a GeneratedQuery to a PostgREST URL query string.
+ *
+ * @example
+ * const query = generateQuery(state)
+ * const url = toPostgrestQuery(query)
+ * // "/users?select=name,posts(title)&status=eq.active&order=createdAt.desc&limit=10"
+ */
+export function toPostgrestQuery(query: GeneratedQuery): string {
+  const params: string[] = []
+
+  // Add select parameter
+  if (query.select !== '*') {
+    params.push(`select=${query.select}`)
+  }
+
+  // Add filter parameters
+  for (const [key, value] of Object.entries(query.filters)) {
+    params.push(`${key}=${value}`)
+  }
+
+  // Add order parameter
+  if (query.order) {
+    params.push(`order=${query.order}`)
+  }
+
+  // Add limit parameter
+  if (query.limit !== undefined) {
+    params.push(`limit=${query.limit}`)
+  }
+
+  const queryString = params.join('&')
+  return `/${query.table}${queryString ? '?' + queryString : ''}`
+}
+
+/**
+ * Generates a PostgREST query from the builder state.
+ *
+ * @example
+ * const state = q()
+ *   .from('users')
+ *   .join('posts')
+ *   .select((users, posts) => ({ userName: users.name, postTitle: posts.title }))
+ *   .getState()
+ *
+ * const query = generateQuery(state)
+ * // { table: 'users', select: 'name,posts(title)', filters: {} }
+ */
+export function generateQuery(state: QueryBuilderState): GeneratedQuery {
+  if (!state.baseTable) {
+    throw new Error('Query must have a base table. Call from() first.')
+  }
+
+  const table = state.baseTable
+  const select = generateSelect(state)
+  const filters = generateFilters(state)
+  const order = generateOrder(state)
+
+  return {
+    table,
+    select,
+    filters,
+    ...(order && { order }),
+    ...(state.limit !== null && { limit: state.limit }),
+  }
+}
+
+/**
+ * Generate the select parameter for PostgREST.
+ *
+ * Maps the fluent select to PostgREST's embedded resource syntax:
+ * - Base table fields: just the column name
+ * - Joined table fields: tableName(column1,column2)
+ */
+function generateSelect(state: QueryBuilderState): string {
+  if (!state.selectFields || !state.baseTable) {
+    return '*'
+  }
+
+  const baseTableName = state.baseTable
+
+  // Group fields by their table name
+  const fieldsByTable = new Map<string, { outputAlias: string; column: string }[]>()
+
+  for (const [outputAlias, fieldRef] of Object.entries(state.selectFields)) {
+    const tableName = fieldRef.__tableAlias
+    if (!fieldsByTable.has(tableName)) {
+      fieldsByTable.set(tableName, [])
+    }
+    fieldsByTable.get(tableName)!.push({ outputAlias, column: fieldRef.__column })
+  }
+
+  const selectParts: string[] = []
+
+  // Process base table fields first
+  const baseFields = fieldsByTable.get(baseTableName)
+  if (baseFields) {
+    for (const field of baseFields) {
+      // For now, just use the column name (aliasing can be added later)
+      selectParts.push(field.column)
+    }
+    fieldsByTable.delete(baseTableName)
+  }
+
+  // Process joined tables - create embedded resources
+  for (const join of state.joins) {
+    const joinFields = fieldsByTable.get(join.tableName)
+    if (joinFields) {
+      const columns = joinFields.map((f) => f.column).join(',')
+      // Use the actual table name for the embedded resource
+      // If there's a disambiguation condition, we'd add the FK hint here
+      const hint = generateJoinHint(join, state)
+      selectParts.push(`${join.tableName}${hint}(${columns})`)
+      fieldsByTable.delete(join.tableName)
+    }
+  }
+
+  return selectParts.join(',')
+}
+
+/**
+ * Generate FK hint for join disambiguation.
+ * Returns empty string if no disambiguation needed.
+ */
+function generateJoinHint(
+  join: { tableName: string; condition?: AnyCondition },
+  state: QueryBuilderState
+): string {
+  if (!join.condition) {
+    return ''
+  }
+
+  // Extract the column from the condition that belongs to the joined table
+  // This is used as a hint for PostgREST to disambiguate multiple FKs
+  const condition = join.condition
+  if (isCondition(condition) && condition.operator === '=') {
+    // Check which side of the condition references the joined table
+    const leftRef = condition.left
+    const rightRef = condition.right
+
+    if (leftRef.__tableAlias === join.tableName) {
+      // The joined table's column is on the left
+      return `!${leftRef.__column}`
+    } else if (isFieldRef(rightRef) && rightRef.__tableAlias === join.tableName) {
+      // The joined table's column is on the right
+      return `!${rightRef.__column}`
+    }
+  }
+
+  return ''
+}
+
+/**
+ * Generate filter parameters for PostgREST.
+ */
+function generateFilters(state: QueryBuilderState): Record<string, string> {
+  const filters: Record<string, string> = {}
+
+  for (const condition of state.whereConditions) {
+    const filterEntries = conditionToFilter(condition, state)
+    Object.assign(filters, filterEntries)
+  }
+
+  return filters
+}
+
+/**
+ * Convert a condition to PostgREST filter format.
+ */
+function conditionToFilter(
+  condition: AnyCondition | IsNullCondition | IsNotNullCondition,
+  state: QueryBuilderState
+): Record<string, string> {
+  if (isCondition(condition)) {
+    return simpleConditionToFilter(condition, state)
+  }
+
+  if (isAndCondition(condition)) {
+    // For AND, we can just add multiple filters (PostgREST ANDs them by default)
+    const result: Record<string, string> = {}
+    for (const c of condition.conditions) {
+      Object.assign(result, conditionToFilter(c, state))
+    }
+    return result
+  }
+
+  if (isOrCondition(condition)) {
+    // For OR, we need to use PostgREST's or syntax
+    const orParts = condition.conditions.map((c) => conditionToFilterString(c, state))
+    return { or: `(${orParts.join(',')})` }
+  }
+
+  // IsNull / IsNotNull conditions
+  if ('__type' in condition) {
+    if (condition.__type === 'IsNull') {
+      const col = resolveColumnName(condition.field, state)
+      return { [col]: 'is.null' }
+    }
+    if (condition.__type === 'IsNotNull') {
+      const col = resolveColumnName(condition.field, state)
+      return { [col]: 'not.is.null' }
+    }
+  }
+
+  return {}
+}
+
+/**
+ * Convert a simple condition to PostgREST filter format.
+ */
+function simpleConditionToFilter(
+  condition: Condition,
+  state: QueryBuilderState
+): Record<string, string> {
+  const column = resolveColumnName(condition.left, state)
+  const operator = operatorToPostgrest(condition.operator)
+  const value = isFieldRef(condition.right)
+    ? resolveColumnName(condition.right, state)
+    : String(condition.right)
+
+  return { [column]: `${operator}.${value}` }
+}
+
+/**
+ * Convert a condition to a filter string (for use in or() expressions).
+ */
+function conditionToFilterString(
+  condition: AnyCondition | IsNullCondition | IsNotNullCondition,
+  state: QueryBuilderState
+): string {
+  if (isCondition(condition)) {
+    const column = resolveColumnName(condition.left, state)
+    const operator = operatorToPostgrest(condition.operator)
+    const value = isFieldRef(condition.right)
+      ? resolveColumnName(condition.right, state)
+      : String(condition.right)
+    return `${column}.${operator}.${value}`
+  }
+
+  if (isAndCondition(condition)) {
+    const andParts = condition.conditions.map((c) => conditionToFilterString(c, state))
+    return `and(${andParts.join(',')})`
+  }
+
+  if (isOrCondition(condition)) {
+    const orParts = condition.conditions.map((c) => conditionToFilterString(c, state))
+    return `or(${orParts.join(',')})`
+  }
+
+  // IsNull / IsNotNull
+  if ('__type' in condition) {
+    if (condition.__type === 'IsNull') {
+      const col = resolveColumnName(condition.field, state)
+      return `${col}.is.null`
+    }
+    if (condition.__type === 'IsNotNull') {
+      const col = resolveColumnName(condition.field, state)
+      return `${col}.not.is.null`
+    }
+  }
+
+  return ''
+}
+
+/**
+ * Resolve a FieldRef to a column name, potentially with table prefix for joined tables.
+ */
+function resolveColumnName(field: FieldRef, state: QueryBuilderState): string {
+  // For the base table, just use the column name
+  if (state.baseTable && field.__tableAlias === state.baseTable) {
+    return field.__column
+  }
+
+  // For joined tables, we might need to prefix with the table name
+  // For now, just use the column name (PostgREST handles this via the select)
+  return field.__column
+}
+
+/**
+ * Convert our operator to PostgREST operator.
+ */
+function operatorToPostgrest(operator: string): string {
+  switch (operator) {
+    case '=':
+      return 'eq'
+    case '!=':
+      return 'neq'
+    case '>':
+      return 'gt'
+    case '>=':
+      return 'gte'
+    case '<':
+      return 'lt'
+    case '<=':
+      return 'lte'
+    default:
+      return 'eq'
+  }
+}
+
+/**
+ * Generate the order parameter for PostgREST.
+ */
+function generateOrder(state: QueryBuilderState): string | undefined {
+  if (state.orderBy.length === 0) {
+    return undefined
+  }
+
+  return state.orderBy
+    .map((o) => {
+      const column = resolveColumnName(o.field, state)
+      return o.ascending ? column : `${column}.desc`
+    })
+    .join(',')
+}

--- a/packages/core/postgrest-js/src/fluent-query-builder/types.ts
+++ b/packages/core/postgrest-js/src/fluent-query-builder/types.ts
@@ -21,7 +21,7 @@ export type TablesAndViews<Schema extends GenericSchema> = Schema['Tables'] & Sc
  */
 export type TableRow<
   Schema extends GenericSchema,
-  TableName extends string
+  TableName extends string,
 > = TableName extends keyof TablesAndViews<Schema>
   ? TablesAndViews<Schema>[TableName] extends { Row: infer R }
     ? R
@@ -43,10 +43,7 @@ export type ValidTableName<Schema> = Schema extends GenericSchema
  * A reference to a specific column in a table.
  * Created by the proxy system when accessing table.column
  */
-export interface FieldRef<
-  TableAlias extends string = string,
-  ColumnName extends string = string,
-> {
+export interface FieldRef<TableAlias extends string = string, ColumnName extends string = string> {
   readonly __type: 'FieldRef'
   readonly __tableAlias: TableAlias
   readonly __column: ColumnName

--- a/packages/core/postgrest-js/src/fluent-query-builder/types.ts
+++ b/packages/core/postgrest-js/src/fluent-query-builder/types.ts
@@ -1,0 +1,101 @@
+/**
+ * Fluent Query Builder Types
+ *
+ * Core type definitions for the fluent query builder API.
+ */
+
+/**
+ * A reference to a specific column in a table.
+ * Created by the proxy system when accessing table.column
+ */
+export interface FieldRef<
+  TableAlias extends string = string,
+  ColumnName extends string = string,
+> {
+  readonly __type: 'FieldRef'
+  readonly __tableAlias: TableAlias
+  readonly __column: ColumnName
+}
+
+/**
+ * Supported comparison operators
+ */
+export type ComparisonOperator = '=' | '!=' | '>' | '>=' | '<' | '<='
+
+/**
+ * A condition comparing two values (used in join disambiguation and where clauses)
+ */
+export interface Condition {
+  readonly __type: 'Condition'
+  readonly left: FieldRef
+  readonly operator: ComparisonOperator
+  readonly right: FieldRef | unknown
+}
+
+/**
+ * Logical operators for combining conditions
+ */
+export interface AndCondition {
+  readonly __type: 'And'
+  readonly conditions: readonly (Condition | AndCondition | OrCondition)[]
+}
+
+export interface OrCondition {
+  readonly __type: 'Or'
+  readonly conditions: readonly (Condition | AndCondition | OrCondition)[]
+}
+
+export type AnyCondition = Condition | AndCondition | OrCondition
+
+/**
+ * Null check conditions
+ */
+export interface IsNullCondition {
+  readonly __type: 'IsNull'
+  readonly field: FieldRef
+}
+
+export interface IsNotNullCondition {
+  readonly __type: 'IsNotNull'
+  readonly field: FieldRef
+}
+
+/**
+ * List of table names in the query (base table + joins in order).
+ * e.g., ['users', 'posts', 'comments']
+ */
+export type TableList = readonly string[]
+
+/**
+ * Represents a joined table in the query
+ */
+export interface JoinedTable {
+  readonly tableName: string
+  readonly condition?: AnyCondition
+}
+
+/**
+ * Internal state of the query builder
+ */
+export interface QueryBuilderState {
+  readonly baseTable: string | null
+  readonly joins: readonly JoinedTable[]
+  readonly selectFields: Record<string, FieldRef> | null
+  readonly whereConditions: readonly AnyCondition[]
+  readonly orderBy: readonly { field: FieldRef; ascending: boolean }[]
+  readonly limit: number | null
+}
+
+/**
+ * Creates an empty initial state for the query builder
+ */
+export function createInitialState(): QueryBuilderState {
+  return {
+    baseTable: null,
+    joins: [],
+    selectFields: null,
+    whereConditions: [],
+    orderBy: [],
+    limit: null,
+  }
+}

--- a/packages/core/postgrest-js/src/fluent-query-builder/types.ts
+++ b/packages/core/postgrest-js/src/fluent-query-builder/types.ts
@@ -4,6 +4,41 @@
  * Core type definitions for the fluent query builder API.
  */
 
+import { GenericSchema } from '../types/common/common'
+
+// ============================================================================
+// Schema Helper Types
+// ============================================================================
+
+/**
+ * Combines Tables and Views from a schema for unified access.
+ */
+export type TablesAndViews<Schema extends GenericSchema> = Schema['Tables'] & Schema['Views']
+
+/**
+ * Extracts the Row type for a specific table/view from the schema.
+ * Falls back to Record<string, unknown> for unknown tables.
+ */
+export type TableRow<
+  Schema extends GenericSchema,
+  TableName extends string
+> = TableName extends keyof TablesAndViews<Schema>
+  ? TablesAndViews<Schema>[TableName] extends { Row: infer R }
+    ? R
+    : Record<string, unknown>
+  : Record<string, unknown>
+
+/**
+ * Gets valid table/view names from a schema, or string if schema is unknown.
+ */
+export type ValidTableName<Schema> = Schema extends GenericSchema
+  ? string & keyof TablesAndViews<Schema>
+  : string
+
+// ============================================================================
+// Field Reference Types
+// ============================================================================
+
 /**
  * A reference to a specific column in a table.
  * Created by the proxy system when accessing table.column

--- a/packages/core/postgrest-js/src/index.ts
+++ b/packages/core/postgrest-js/src/index.ts
@@ -51,9 +51,4 @@ export {
   toPostgrestQuery,
 } from './fluent-query-builder'
 
-export type {
-  FieldRef,
-  Condition,
-  AnyCondition,
-  GeneratedQuery,
-} from './fluent-query-builder'
+export type { FieldRef, Condition, AnyCondition, GeneratedQuery } from './fluent-query-builder'

--- a/packages/core/postgrest-js/src/index.ts
+++ b/packages/core/postgrest-js/src/index.ts
@@ -32,3 +32,28 @@ export type { ClientServerOptions as PostgrestClientOptions } from './types/comm
 // https://github.com/supabase/postgrest-js/issues/551
 // To be replaced with a helper type that only uses public types
 export type { GetResult as UnstableGetResult } from './select-query-parser/result'
+
+// Fluent Query Builder - experimental new API
+export {
+  FluentQueryBuilder,
+  q,
+  eq,
+  neq,
+  gt,
+  gte,
+  lt,
+  lte,
+  and,
+  or,
+  isNull,
+  isNotNull,
+  generateQuery,
+  toPostgrestQuery,
+} from './fluent-query-builder'
+
+export type {
+  FieldRef,
+  Condition,
+  AnyCondition,
+  GeneratedQuery,
+} from './fluent-query-builder'

--- a/packages/core/postgrest-js/test/fluent-query-builder.test-d.ts
+++ b/packages/core/postgrest-js/test/fluent-query-builder.test-d.ts
@@ -1,0 +1,358 @@
+/**
+ * Type-level tests for the fluent query builder's schema-based type inference.
+ *
+ * These tests verify compile-time behavior using @ts-expect-error comments.
+ * Run with: npx tsc --noEmit test/fluent-query-builder.test-d.ts
+ */
+
+import { expectType } from './types'
+import { q, eq, FluentQueryBuilder, FieldRef } from '../src/fluent-query-builder'
+import { GenericSchema } from '../src/types/common/common'
+
+// ============================================================================
+// Test Schema Definition
+// ============================================================================
+
+/**
+ * A simple test schema for type inference tests.
+ */
+type TestSchema = {
+  Tables: {
+    users: {
+      Row: {
+        id: number
+        username: string
+        email: string
+        status: 'active' | 'inactive'
+        created_at: string
+      }
+      Insert: {
+        id?: number
+        username: string
+        email: string
+        status?: 'active' | 'inactive'
+        created_at?: string
+      }
+      Update: {
+        id?: number
+        username?: string
+        email?: string
+        status?: 'active' | 'inactive'
+        created_at?: string
+      }
+      Relationships: []
+    }
+    posts: {
+      Row: {
+        id: number
+        title: string
+        content: string
+        author_id: number
+        published: boolean
+      }
+      Insert: {
+        id?: number
+        title: string
+        content: string
+        author_id: number
+        published?: boolean
+      }
+      Update: {
+        id?: number
+        title?: string
+        content?: string
+        author_id?: number
+        published?: boolean
+      }
+      Relationships: []
+    }
+    comments: {
+      Row: {
+        id: number
+        post_id: number
+        user_id: number
+        body: string
+      }
+      Insert: {
+        id?: number
+        post_id: number
+        user_id: number
+        body: string
+      }
+      Update: {
+        id?: number
+        post_id?: number
+        user_id?: number
+        body?: string
+      }
+      Relationships: []
+    }
+  }
+  Views: {
+    active_users: {
+      Row: {
+        id: number
+        username: string
+      }
+      Relationships: []
+    }
+  }
+  Functions: {}
+}
+
+// ============================================================================
+// Test 1: Table name validation
+// ============================================================================
+
+// Valid table names should work
+{
+  const builder = q<TestSchema>().from('users')
+  expectType<FluentQueryBuilder<TestSchema, readonly ['users']>>(builder)
+
+  const postsBuilder = q<TestSchema>().from('posts')
+  expectType<FluentQueryBuilder<TestSchema, readonly ['posts']>>(postsBuilder)
+
+  // Views should also work
+  const viewBuilder = q<TestSchema>().from('active_users')
+  expectType<FluentQueryBuilder<TestSchema, readonly ['active_users']>>(viewBuilder)
+}
+
+// Invalid table names should error
+{
+  // @ts-expect-error Argument of type '"nonexistent"' is not assignable to parameter of type
+  q<TestSchema>().from('nonexistent')
+
+  // @ts-expect-error Argument of type '"usrs"' is not assignable to parameter of type
+  q<TestSchema>().from('usrs')
+
+  // @ts-expect-error Argument of type '""' is not assignable to parameter of type
+  q<TestSchema>().from('')
+}
+
+// ============================================================================
+// Test 2: Column access validation in select()
+// ============================================================================
+
+// Valid column access should work
+{
+  q<TestSchema>()
+    .from('users')
+    .select((users) => ({
+      name: users.username, // valid column
+      mail: users.email, // valid column
+      userStatus: users.status, // valid column
+    }))
+}
+
+// Invalid column access should error
+{
+  q<TestSchema>()
+    .from('users')
+    .select((users) => ({
+      // @ts-expect-error Property 'foo' does not exist on type
+      x: users.foo,
+    }))
+
+  q<TestSchema>()
+    .from('users')
+    .select((users) => ({
+      // @ts-expect-error Property 'nonexistent_column' does not exist on type
+      bad: users.nonexistent_column,
+    }))
+}
+
+// ============================================================================
+// Test 3: Join with column validation
+// ============================================================================
+
+// Valid join should work
+{
+  q<TestSchema>()
+    .from('users')
+    .join('posts')
+    .select((users, posts) => ({
+      userName: users.username,
+      postTitle: posts.title,
+      postContent: posts.content,
+    }))
+}
+
+// Invalid join table should error
+{
+  // @ts-expect-error Argument of type '"invalid_table"' is not assignable to parameter of type
+  q<TestSchema>().from('users').join('invalid_table')
+}
+
+// Invalid column in join callback should error
+{
+  q<TestSchema>()
+    .from('users')
+    .join('posts')
+    .select((users, posts) => ({
+      userName: users.username,
+      // @ts-expect-error Property 'invalid_column' does not exist on type
+      bad: posts.invalid_column,
+    }))
+}
+
+// ============================================================================
+// Test 4: Where clause column validation
+// ============================================================================
+
+// Valid where clause should work
+{
+  q<TestSchema>()
+    .from('users')
+    .where((users) => eq(users.status, 'active'))
+
+  q<TestSchema>()
+    .from('users')
+    .where((users) => eq(users.username, 'john'))
+}
+
+// Invalid column in where clause should error
+{
+  q<TestSchema>()
+    .from('users')
+    // @ts-expect-error Property 'invalid_col' does not exist on type
+    .where((users) => eq(users.invalid_col, 'value'))
+}
+
+// ============================================================================
+// Test 5: OrderBy column validation
+// ============================================================================
+
+// Valid orderBy should work
+{
+  q<TestSchema>()
+    .from('users')
+    .orderBy((users) => users.username)
+
+  q<TestSchema>()
+    .from('users')
+    .orderBy((users) => users.created_at, { ascending: false })
+}
+
+// Invalid column in orderBy should error
+{
+  q<TestSchema>()
+    .from('users')
+    // @ts-expect-error Property 'nonexistent' does not exist on type
+    .orderBy((users) => users.nonexistent)
+}
+
+// ============================================================================
+// Test 6: Multiple joins
+// ============================================================================
+
+// Multiple joins should track all tables correctly
+{
+  q<TestSchema>()
+    .from('users')
+    .join('posts')
+    .join('comments')
+    .select((users, posts, comments) => ({
+      userName: users.username,
+      postTitle: posts.title,
+      commentBody: comments.body,
+    }))
+}
+
+// Invalid column access in multi-join should error
+{
+  q<TestSchema>()
+    .from('users')
+    .join('posts')
+    .join('comments')
+    .select((users, posts, comments) => ({
+      userName: users.username,
+      // @ts-expect-error Property 'body' does not exist on type
+      postBody: posts.body,
+      commentBody: comments.body,
+    }))
+}
+
+// ============================================================================
+// Test 7: Backward compatibility - untyped usage
+// ============================================================================
+
+// Without schema, any table/column should be allowed
+{
+  const untypedBuilder = q()
+    .from('any_table')
+    .select((t) => ({ x: t.any_column }))
+
+  // Should be FluentQueryBuilder with unknown schema
+  expectType<FluentQueryBuilder<unknown, readonly ['any_table']>>(untypedBuilder)
+
+  // Any chain should work
+  q()
+    .from('foo')
+    .join('bar')
+    .select((foo, bar) => ({
+      a: foo.whatever,
+      b: bar.anything,
+    }))
+    .where((foo) => eq(foo.col, 'value'))
+    .orderBy((foo) => foo.other_col)
+    .limit(10)
+}
+
+// ============================================================================
+// Test 8: FieldRef type inference
+// ============================================================================
+
+// FieldRef should carry table and column info
+{
+  q<TestSchema>()
+    .from('users')
+    .select((users) => {
+      const field = users.username
+      // FieldRef should have correct type parameters
+      expectType<FieldRef<'users', 'username'>>(field)
+      return { name: field }
+    })
+}
+
+// ============================================================================
+// Test 9: Method chaining preserves types
+// ============================================================================
+
+// All chained methods should preserve schema and tables
+{
+  const query = q<TestSchema>()
+    .from('users')
+    .join('posts')
+    .select((users, posts) => ({
+      name: users.username,
+      title: posts.title,
+    }))
+    .where((users) => eq(users.status, 'active'))
+    .orderBy((users) => users.created_at)
+    .limit(10)
+
+  expectType<FluentQueryBuilder<TestSchema, readonly ['users', 'posts']>>(query)
+}
+
+// ============================================================================
+// Test 10: Join with condition callback
+// ============================================================================
+
+// Join condition should have access to typed columns
+{
+  q<TestSchema>()
+    .from('users')
+    .join('posts', (users, posts) => eq(users.id, posts.author_id))
+    .select((users, posts) => ({
+      userName: users.username,
+      postTitle: posts.title,
+    }))
+}
+
+// Invalid column in join condition should error
+{
+  q<TestSchema>()
+    .from('users')
+    // @ts-expect-error Property 'invalid' does not exist on type
+    .join('posts', (users, posts) => eq(users.invalid, posts.author_id))
+}

--- a/packages/core/postgrest-js/test/fluent-query-builder.test.ts
+++ b/packages/core/postgrest-js/test/fluent-query-builder.test.ts
@@ -1,0 +1,315 @@
+import {
+  q,
+  eq,
+  neq,
+  gt,
+  gte,
+  lt,
+  lte,
+  and,
+  or,
+  isNull,
+  isNotNull,
+  generateQuery,
+  toPostgrestQuery,
+} from '../src/fluent-query-builder'
+
+/**
+ * Helper to build query and convert to PostgREST URL in one step
+ */
+function toUrl(builder: ReturnType<typeof q>): string {
+  return toPostgrestQuery(generateQuery(builder.getState()))
+}
+
+describe('FluentQueryBuilder - PostgREST Query Generation', () => {
+  describe('basic queries', () => {
+    it('should generate simple table query', () => {
+      const query = q().from('users')
+      expect(toUrl(query)).toBe('/users')
+    })
+
+    it('should generate query with select fields', () => {
+      const query = q()
+        .from('users')
+        .select((users) => ({
+          name: users.name,
+          email: users.email,
+        }))
+
+      expect(toUrl(query)).toBe('/users?select=name,email')
+    })
+  })
+
+  describe('joins', () => {
+    it('should generate query with single join', () => {
+      const query = q()
+        .from('users')
+        .join('posts')
+        .select((users, posts) => ({
+          userName: users.name,
+          postTitle: posts.title,
+        }))
+
+      expect(toUrl(query)).toBe('/users?select=name,posts(title)')
+    })
+
+    it('should generate query with multiple joins', () => {
+      const query = q()
+        .from('users')
+        .join('posts')
+        .join('comments')
+        .select((users, posts, comments) => ({
+          userName: users.name,
+          postTitle: posts.title,
+          commentText: comments.text,
+        }))
+
+      expect(toUrl(query)).toBe('/users?select=name,posts(title),comments(text)')
+    })
+
+    it('should generate query with join disambiguation hint', () => {
+      const query = q()
+        .from('users')
+        .join('messages', (users, messages) => eq(users.id, messages.senderId))
+        .select((users, messages) => ({
+          userName: users.name,
+          messageContent: messages.content,
+        }))
+
+      expect(toUrl(query)).toBe('/users?select=name,messages!senderId(content)')
+    })
+  })
+
+  describe('filters', () => {
+    it('should generate query with eq filter', () => {
+      const query = q()
+        .from('users')
+        .where((users) => eq(users.status, 'active'))
+
+      expect(toUrl(query)).toBe('/users?status=eq.active')
+    })
+
+    it('should generate query with neq filter', () => {
+      const query = q()
+        .from('users')
+        .where((users) => neq(users.status, 'deleted'))
+
+      expect(toUrl(query)).toBe('/users?status=neq.deleted')
+    })
+
+    it('should generate query with gt filter', () => {
+      const query = q()
+        .from('users')
+        .where((users) => gt(users.age, 18))
+
+      expect(toUrl(query)).toBe('/users?age=gt.18')
+    })
+
+    it('should generate query with gte filter', () => {
+      const query = q()
+        .from('users')
+        .where((users) => gte(users.age, 21))
+
+      expect(toUrl(query)).toBe('/users?age=gte.21')
+    })
+
+    it('should generate query with lt filter', () => {
+      const query = q()
+        .from('users')
+        .where((users) => lt(users.age, 65))
+
+      expect(toUrl(query)).toBe('/users?age=lt.65')
+    })
+
+    it('should generate query with lte filter', () => {
+      const query = q()
+        .from('users')
+        .where((users) => lte(users.score, 100))
+
+      expect(toUrl(query)).toBe('/users?score=lte.100')
+    })
+
+    it('should generate query with multiple filters', () => {
+      const query = q()
+        .from('users')
+        .where((users) => eq(users.status, 'active'))
+        .where((users) => gt(users.age, 18))
+
+      expect(toUrl(query)).toBe('/users?status=eq.active&age=gt.18')
+    })
+
+    it('should generate query with OR filter', () => {
+      const query = q()
+        .from('users')
+        .where((users) => or(eq(users.role, 'admin'), eq(users.role, 'moderator')))
+
+      expect(toUrl(query)).toBe('/users?or=(role.eq.admin,role.eq.moderator)')
+    })
+
+    it('should generate query with AND filter', () => {
+      const query = q()
+        .from('users')
+        .where((users) => and(eq(users.status, 'active'), gt(users.age, 18)))
+
+      // AND is implicit in PostgREST - multiple conditions are ANDed
+      expect(toUrl(query)).toBe('/users?status=eq.active&age=gt.18')
+    })
+  })
+
+  describe('ordering', () => {
+    it('should generate query with ascending order (default)', () => {
+      const query = q()
+        .from('users')
+        .orderBy((users) => users.createdAt)
+
+      expect(toUrl(query)).toBe('/users?order=createdAt')
+    })
+
+    it('should generate query with descending order', () => {
+      const query = q()
+        .from('users')
+        .orderBy((users) => users.createdAt, { ascending: false })
+
+      expect(toUrl(query)).toBe('/users?order=createdAt.desc')
+    })
+
+    it('should generate query with multiple order fields', () => {
+      const query = q()
+        .from('users')
+        .orderBy((users) => users.lastName)
+        .orderBy((users) => users.firstName)
+
+      expect(toUrl(query)).toBe('/users?order=lastName,firstName')
+    })
+  })
+
+  describe('limit', () => {
+    it('should generate query with limit', () => {
+      const query = q().from('users').limit(10)
+
+      expect(toUrl(query)).toBe('/users?limit=10')
+    })
+  })
+
+  describe('complete queries', () => {
+    it('should generate complete query with all options', () => {
+      const query = q()
+        .from('users')
+        .join('posts')
+        .select((users, posts) => ({
+          userName: users.name,
+          postTitle: posts.title,
+        }))
+        .where((users) => eq(users.status, 'active'))
+        .orderBy((users, posts) => posts.createdAt, { ascending: false })
+        .limit(10)
+
+      expect(toUrl(query)).toBe(
+        '/users?select=name,posts(title)&status=eq.active&order=createdAt.desc&limit=10'
+      )
+    })
+
+    it('should generate query matching original example syntax', () => {
+      // This is the example from the original request
+      const query = q()
+        .from('users')
+        .join('posts')
+        .join('comments')
+        .select((users, posts, comments) => ({
+          userName: users.name,
+          postTitle: posts.title,
+          commentText: comments.text,
+        }))
+
+      expect(toUrl(query)).toBe('/users?select=name,posts(title),comments(text)')
+    })
+  })
+})
+
+describe('toPostgrestQuery', () => {
+  it('should handle query with no parameters', () => {
+    const result = toPostgrestQuery({
+      table: 'users',
+      select: '*',
+      filters: {},
+    })
+    expect(result).toBe('/users')
+  })
+
+  it('should not encode special characters in select', () => {
+    const result = toPostgrestQuery({
+      table: 'users',
+      select: 'name,posts(title,content)',
+      filters: {},
+    })
+    expect(result).toBe('/users?select=name,posts(title,content)')
+  })
+
+  it('should include all query parameters', () => {
+    const result = toPostgrestQuery({
+      table: 'users',
+      select: 'name',
+      filters: { status: 'eq.active' },
+      order: 'createdAt.desc',
+      limit: 10,
+    })
+    expect(result).toBe('/users?select=name&status=eq.active&order=createdAt.desc&limit=10')
+  })
+})
+
+describe('operators', () => {
+  it('eq should create equality condition', () => {
+    const field = { __type: 'FieldRef' as const, __tableAlias: 'users', __column: 'id' }
+    const condition = eq(field, 5)
+    expect(condition.__type).toBe('Condition')
+    expect(condition.operator).toBe('=')
+  })
+
+  it('neq should create not-equal condition', () => {
+    const field = { __type: 'FieldRef' as const, __tableAlias: 'users', __column: 'status' }
+    const condition = neq(field, 'deleted')
+    expect(condition.operator).toBe('!=')
+  })
+
+  it('gt/gte/lt/lte should create comparison conditions', () => {
+    const field = { __type: 'FieldRef' as const, __tableAlias: 'users', __column: 'age' }
+    expect(gt(field, 18).operator).toBe('>')
+    expect(gte(field, 18).operator).toBe('>=')
+    expect(lt(field, 65).operator).toBe('<')
+    expect(lte(field, 65).operator).toBe('<=')
+  })
+
+  it('and should combine conditions', () => {
+    const f1 = { __type: 'FieldRef' as const, __tableAlias: 'users', __column: 'a' }
+    const f2 = { __type: 'FieldRef' as const, __tableAlias: 'users', __column: 'b' }
+    const c1 = eq(f1, 1)
+    const c2 = eq(f2, 2)
+
+    const combined = and(c1, c2)
+    expect(combined.__type).toBe('And')
+    expect(combined.conditions).toHaveLength(2)
+  })
+
+  it('or should combine conditions', () => {
+    const f1 = { __type: 'FieldRef' as const, __tableAlias: 'users', __column: 'a' }
+    const f2 = { __type: 'FieldRef' as const, __tableAlias: 'users', __column: 'b' }
+    const c1 = eq(f1, 1)
+    const c2 = eq(f2, 2)
+
+    const combined = or(c1, c2)
+    expect(combined.__type).toBe('Or')
+    expect(combined.conditions).toHaveLength(2)
+  })
+
+  it('isNull should create null check', () => {
+    const field = { __type: 'FieldRef' as const, __tableAlias: 'users', __column: 'deletedAt' }
+    const condition = isNull(field)
+    expect(condition.__type).toBe('IsNull')
+  })
+
+  it('isNotNull should create not-null check', () => {
+    const field = { __type: 'FieldRef' as const, __tableAlias: 'users', __column: 'email' }
+    const condition = isNotNull(field)
+    expect(condition.__type).toBe('IsNotNull')
+  })
+})


### PR DESCRIPTION
## 🔍 Description

This PR is a prototype for a new query builder. 

<img width="1598" height="744" alt="carbon" src="https://github.com/user-attachments/assets/9397a479-841a-496e-81a4-f4c071d6b92d" />

The order of clauses is intentional:
1. FROM 
2. JOIN
3. WHERE, ORDER, LIMIT
4. SELECT

`SELECT` can has to be after the `JOIN`. Known limitations are you can't do a nested join (join on a join).

There's more examples in the [tests](https://github.com/supabase/supabase-js/pull/2084/changes#diff-72f337b89b3976af5e811b24badc5baa3b2406145f3a5f3808536e724fe93096).

## 🔄 Breaking changes

- [x] This PR contains no breaking changes

## 📋 Checklist

- [x] I have read the Contributing Guidelines
- [x] My PR title follows the conventional commit format
- [x] I have run \`npx nx format\` to ensure consistent code formatting
- [x] I have added tests for new functionality
- [x] Tests and type checks pass