### PR TITLE
fix(auth) : use schema specific storage keys for multi schema auth isolation

### DIFF
--- a/packages/core/supabase-js/src/SupabaseClient.ts
+++ b/packages/core/supabase-js/src/SupabaseClient.ts
@@ -124,7 +124,9 @@ export default class SupabaseClient<
     this.functionsUrl = new URL('functions/v1', baseUrl)
 
     // default storage key uses the supabase project ref as a namespace
-    const defaultStorageKey = `sb-${baseUrl.hostname.split('.')[0]}-auth-token`
+    const schemaName = options?.db?.schema
+    const schemaSuffix = schemaName && schemaName !== 'public' ? `-${schemaName}` : ''
+    const defaultStorageKey = `sb-${baseUrl.hostname.split('.')[0]}-auth-token${schemaSuffix}`
     const DEFAULTS = {
       db: DEFAULT_DB_OPTIONS,
       realtime: DEFAULT_REALTIME_OPTIONS,

--- a/packages/core/supabase-js/test/unit/SupabaseClient.test.ts
+++ b/packages/core/supabase-js/test/unit/SupabaseClient.test.ts
@@ -135,6 +135,63 @@ describe('SupabaseClient', () => {
       // @ts-ignore
       expect(client.headers).toHaveProperty('X-Client-Info')
     })
+
+    test('should append schema name to storage key for non-public schemas', () => {
+      const client = createClient('https://project-ref.supabase.co', KEY, {
+        db: { schema: 'personal' },
+      })
+      // @ts-ignore
+      expect(client.storageKey).toBe('sb-project-ref-auth-token-personal')
+    })
+
+    test('should not append schema name for public schema', () => {
+      const client = createClient('https://project-ref.supabase.co', KEY, {
+        db: { schema: 'public' },
+      })
+      // @ts-ignore
+      expect(client.storageKey).toBe('sb-project-ref-auth-token')
+    })
+
+    test('should create unique storage keys for different schemas', () => {
+      const client1 = createClient('https://project-ref.supabase.co', KEY, {
+        db: { schema: 'public' },
+      })
+      const client2 = createClient('https://project-ref.supabase.co', KEY, {
+        db: { schema: 'personal' },
+      })
+
+      // @ts-ignore
+      expect(client1.storageKey).toBe('sb-project-ref-auth-token')
+      // @ts-ignore
+      expect(client2.storageKey).toBe('sb-project-ref-auth-token-personal')
+
+      // @ts-ignore
+      expect(client1.storageKey).not.toBe(client2.storageKey)
+    })
+
+    test('should respect custom storage key even with schema specified', () => {
+      const customStorageKey = 'my-custom-key'
+      const client = createClient(URL, KEY, {
+        db: { schema: 'personal' },
+        auth: { storageKey: customStorageKey },
+      })
+      // @ts-ignore
+      expect(client.storageKey).toBe(customStorageKey)
+    })
+
+    test('should handle schema names with special characters', () => {
+      const client = createClient('https://project-ref.supabase.co', KEY, {
+        db: { schema: 'my_schema-v2' },
+      })
+      // @ts-ignore
+      expect(client.storageKey).toBe('sb-project-ref-auth-token-my_schema-v2')
+    })
+
+    test('should not append when schema is undefined', () => {
+      const client = createClient('https://project-ref.supabase.co', KEY)
+      // @ts-ignore
+      expect(client.storageKey).toBe('sb-project-ref-auth-token')
+    })
   })
 
   describe('Client Methods', () => {


### PR DESCRIPTION
## Summary

Fixes auth state collision when multiple Supabase clients use different schemas but share the same storage key.

## Problem
When creating multiple clients with different schemas (`public` and `private`), 
they shared the same storage key, causing auth state to overwrite each other. 
This broke multi tenant applications using schema-based isolation and triggered the "Multiple GoTrueClient instances detected" warning even with `isSingleton: false`

## Solution
Modified storage key generation to include the schema name, 
ensuring each schema gets its own isolated storage namespace. 
BC cause clients using the default `public` schema continue using the same storage key format.

## Related
- Closes https://github.com/supabase/supabase-js/issues/1394


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Authentication tokens are now isolated by database schema, preventing conflicts when using multiple schemas in the same project.

* **Tests**
  * Added unit tests to verify correct token storage behavior across different database schemas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->