### PR TITLE
fix(auth): correct OAuth authorization types to match API responses

### DIFF
--- a/packages/core/auth-js/src/GoTrueClient.ts
+++ b/packages/core/auth-js/src/GoTrueClient.ts
@@ -3523,7 +3523,7 @@ export default class GoTrueClient {
    * Only relevant when the OAuth 2.1 server is enabled in Supabase Auth.
    *
    * Returns authorization details including client info, scopes, and user information.
-   * If the API returns a redirect_uri, it means consent was already given - the caller
+   * If the response includes only a redirect_url field, it means consent was already given - the caller
    * should handle the redirect manually if needed.
    */
   private async _getAuthorizationDetails(


### PR DESCRIPTION
Fixed incorrect field names and enhanced type safety for OAuth 2.1 authorization server APIs.            
                                                                                                           
## Changes:                                                                                                 
  - Changed `OAuthAuthorizationDetails.redirect_url` → `redirect_uri` (matches `GoTrueAPI` field name)
  - Made `redirect_uri` required (API always returns this field when consent is needed)                      
  - Added `OAuthRedirect` type for already-consented/post-consent responses                                  
  - Added union type to `AuthOAuthAuthorizationDetailsResponse` (`OAuthAuthorizationDetails` | `OAuthRedirect`)  
  - Consolidated duplicate redirect response types by reusing `OAuthRedirect`                            
  - Fixed JSDoc comments in `types.ts` and `GoTrueClient.ts` to reference correct field names                  
  - Enhanced JSDoc with usage examples, type narrowing guidance, and behavioral details                    
                                                                                                           
## Root Cause:                                                                                              
PR #1891 (Nov 2025) incorrectly changed `redirect_uri` to `redirect_url`. However, the GoTrue API intentionally uses two different field names:                                                                                             
  - `redirect_uri`: Base redirect URI from client registration (in `AuthorizationDetailsResponse`)             
  - `redirect_url`: Complete redirect URL with code/state parameters (in `ConsentResponse`)                    

From Auth server code:
  - AuthorizationDetailsResponse (consent needed) → [redirect_uri (line 39)](https://github.com/supabase/auth/blob/master/internal/api/oauthserver/authorize.go#L39)
  - ConsentResponse (already consented/after decision) → [redirect_url (line 66)](https://github.com/supabase/auth/blob/master/internal/api/oauthserver/authorize.go#L66)

The original implementation in PR #1793 (Oct 2025) had the correct field name.                           
                                                                                                           
### Type Safety Impact:                                                                                      
The union type now requires developers to narrow the response type using TypeScript's discriminated unions (`'authorization_id'` in data), preventing runtime errors when accessing fields that may not exist in the already-consented case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added OAuth grant management: ability to list and revoke user OAuth grants
  * Enhanced OAuth redirect handling in authorization flow

* **Documentation**
  * Updated OAuth authorization documentation with improved type guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->