### PR TITLE
fix(realtime): removeChannel when unsubscribe successfully

### DIFF
--- a/packages/core/realtime-js/src/RealtimeClient.ts
+++ b/packages/core/realtime-js/src/RealtimeClient.ts
@@ -308,6 +308,11 @@ export default class RealtimeClient {
   async removeChannel(channel: RealtimeChannel): Promise<RealtimeRemoveChannelResponse> {
     const status = await channel.unsubscribe()
 
+    // Only remove from channels list if unsubscribe was successful
+    if (status === 'ok') {
+      this._remove(channel)
+    }
+
     if (this.channels.length === 0) {
       this.disconnect()
     }

--- a/packages/core/realtime-js/test/RealtimeClient.channels.test.ts
+++ b/packages/core/realtime-js/test/RealtimeClient.channels.test.ts
@@ -147,6 +147,37 @@ describe('channel', () => {
     assert.equal(testSetup.socket.getChannels().length, 0)
     expect(disconnectStub).toHaveBeenCalled()
   })
+
+  test('removes channel from list when unsubscribe succeeds with ok', async () => {
+    const channel = testSetup.socket.channel('topic')
+    await channel.subscribe()
+
+    assert.equal(testSetup.socket.getChannels().length, 1)
+
+    // Mock unsubscribe to return 'ok'
+    vi.spyOn(channel, 'unsubscribe').mockResolvedValue('ok')
+
+    await testSetup.socket.removeChannel(channel)
+
+    // Channel should be removed from the list
+    assert.equal(testSetup.socket.getChannels().length, 0)
+  })
+
+  test('does NOT remove channel from list when unsubscribe fails with error', async () => {
+    const channel = testSetup.socket.channel('topic')
+    await channel.subscribe()
+
+    assert.equal(testSetup.socket.getChannels().length, 1)
+
+    // Mock unsubscribe to return 'error'
+    vi.spyOn(channel, 'unsubscribe').mockResolvedValue('error')
+
+    const result = await testSetup.socket.removeChannel(channel)
+
+    // Channel should NOT be removed from the list
+    assert.equal(testSetup.socket.getChannels().length, 1)
+    assert.equal(result, 'error')
+  })
 })
 
 describe('leaveOpenTopic', () => {


### PR DESCRIPTION
<!-- Your PR title should follow the conventional commit format:
<type>(<scope>): <description> -->

## 🔍 Description

<!-- Provide a clear and concise description of what this PR does -->

### What changed?

<!-- Describe the changes made in this PR -->

Actually remove channel from channels list after unsubscribing successfully

### Why was this change needed?

We were not removing the channel from the list of subscribed channels.

## 📸 Screenshots/Examples

<!-- If applicable, add screenshots or code examples to help explain your changes -->

## 🔄 Breaking changes

<!-- If this PR contains breaking changes, describe them here -->

- [x] This PR contains no breaking changes

## 📋 Checklist

<!-- Ensure all items are checked before submitting -->

- [x] I have read the [Contributing Guidelines](https://github.com/supabase/supabase-js/blob/master/CONTRIBUTING.md)
- [x] My PR title follows the [conventional commit format](https://www.conventionalcommits.org/): `<type>(<scope>): <description>`
- [x] I have run `npx nx format` to ensure consistent code formatting
- [x] I have added tests for new functionality (if applicable)
- [x] I have updated documentation (if applicable)

## 📝 Additional notes

<!-- Add any additional notes, context, or concerns for reviewers -->

<!-- Thank you for contributing to Supabase! 💚 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where real-time channels were being incorrectly removed from the active list even when unsubscribe operations failed. Channels are now properly retained when unsubscribe encounters an error and only removed upon successful unsubscribe.

* **Tests**
  * Added tests to verify channel removal behavior during successful and failed unsubscribe operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->