### PR TITLE
feat(postgrest): add helpful hints for permission errors

### DIFF
--- a/packages/core/postgrest-js/test/embeded_functions_join.test.ts
+++ b/packages/core/postgrest-js/test/embeded_functions_join.test.ts
@@ -1264,7 +1264,13 @@ describe('embeded functions select', () => {
         "error": {
           "code": "PGRST202",
           "details": "Searched for the function public.created_ago with parameter id or with a single unnamed json/jsonb parameter, but no matches were found in the schema cache.",
-          "hint": null,
+          "hint": "Function 'public.created_ago' not found. This could mean:
+      1. The function doesn't exist, OR
+      2. You don't have permission to see it
+
+      If the function exists, grant permission with:
+
+      GRANT EXECUTE ON FUNCTION public.created_ago TO anon, authenticated, service_role;",
           "message": "Could not find the function public.created_ago(id) in the schema cache",
         },
         "status": 404,
@@ -1319,7 +1325,13 @@ describe('embeded functions select', () => {
         "error": {
           "code": "PGRST202",
           "details": "Searched for the function public.days_since_event with parameter id or with a single unnamed json/jsonb parameter, but no matches were found in the schema cache.",
-          "hint": null,
+          "hint": "Function 'public.days_since_event' not found. This could mean:
+      1. The function doesn't exist, OR
+      2. You don't have permission to see it
+
+      If the function exists, grant permission with:
+
+      GRANT EXECUTE ON FUNCTION public.days_since_event TO anon, authenticated, service_role;",
           "message": "Could not find the function public.days_since_event(id) in the schema cache",
         },
         "status": 404,

--- a/packages/core/postgrest-js/test/permission-error-hints.test.ts
+++ b/packages/core/postgrest-js/test/permission-error-hints.test.ts
@@ -1,0 +1,579 @@
+import { PostgrestClient } from '../src/index'
+import { Database } from './types.override'
+
+describe('Permission error hints', () => {
+  describe('42501 - Permission Denied', () => {
+    test('should enhance table permission denied with null hint (GET request)', async () => {
+      const mockFetch = jest.fn().mockResolvedValue({
+        ok: false,
+        status: 403,
+        statusText: 'Forbidden',
+        headers: new Headers(),
+        text: async () =>
+          JSON.stringify({
+            code: '42501',
+            message: 'permission denied for table test',
+            hint: null,
+            details: null,
+          }),
+      })
+
+      const postgrest = new PostgrestClient<Database>('https://example.com', {
+        fetch: mockFetch as any,
+      })
+
+      const res = await postgrest.from('test' as any).select()
+
+      expect(res.error).toBeTruthy()
+      expect(res.error!.code).toBe('42501')
+      expect(res.error!.hint).toBeTruthy()
+      expect(res.error!.hint).toContain('GRANT SELECT ON public.test')
+      expect(res.error!.hint).toContain('anon, authenticated, service_role')
+    })
+
+    test('should enhance table permission denied with operation-specific hints (POST)', async () => {
+      const mockFetch = jest.fn().mockResolvedValue({
+        ok: false,
+        status: 403,
+        statusText: 'Forbidden',
+        headers: new Headers(),
+        text: async () =>
+          JSON.stringify({
+            code: '42501',
+            message: 'permission denied for table test',
+            hint: null,
+            details: null,
+          }),
+      })
+
+      const postgrest = new PostgrestClient<Database>('https://example.com', {
+        fetch: mockFetch as any,
+      })
+
+      const res = await postgrest.from('test' as any).insert({ id: 1 })
+
+      expect(res.error).toBeTruthy()
+      expect(res.error!.code).toBe('42501')
+      expect(res.error!.hint).toBeTruthy()
+      expect(res.error!.hint).toContain('GRANT INSERT ON public.test')
+      expect(res.error!.hint).toContain('anon, authenticated, service_role')
+    })
+
+    test('should enhance table permission denied with operation-specific hints (PATCH)', async () => {
+      const mockFetch = jest.fn().mockResolvedValue({
+        ok: false,
+        status: 403,
+        statusText: 'Forbidden',
+        headers: new Headers(),
+        text: async () =>
+          JSON.stringify({
+            code: '42501',
+            message: 'permission denied for table test',
+            hint: null,
+            details: null,
+          }),
+      })
+
+      const postgrest = new PostgrestClient<Database>('https://example.com', {
+        fetch: mockFetch as any,
+      })
+
+      const res = await postgrest
+        .from('test' as any)
+        .update({ id: 1 })
+        .eq('id', 1)
+
+      expect(res.error).toBeTruthy()
+      expect(res.error!.code).toBe('42501')
+      expect(res.error!.hint).toBeTruthy()
+      expect(res.error!.hint).toContain('GRANT UPDATE ON public.test')
+      expect(res.error!.hint).toContain('anon, authenticated, service_role')
+    })
+
+    test('should enhance table permission denied with operation-specific hints (DELETE)', async () => {
+      const mockFetch = jest.fn().mockResolvedValue({
+        ok: false,
+        status: 403,
+        statusText: 'Forbidden',
+        headers: new Headers(),
+        text: async () =>
+          JSON.stringify({
+            code: '42501',
+            message: 'permission denied for table test',
+            hint: null,
+            details: null,
+          }),
+      })
+
+      const postgrest = new PostgrestClient<Database>('https://example.com', {
+        fetch: mockFetch as any,
+      })
+
+      const res = await postgrest
+        .from('test' as any)
+        .delete()
+        .eq('id', 1)
+
+      expect(res.error).toBeTruthy()
+      expect(res.error!.code).toBe('42501')
+      expect(res.error!.hint).toBeTruthy()
+      expect(res.error!.hint).toContain('GRANT DELETE ON public.test')
+      expect(res.error!.hint).toContain('anon, authenticated, service_role')
+    })
+
+    test('should enhance view permission denied', async () => {
+      const mockFetch = jest.fn().mockResolvedValue({
+        ok: false,
+        status: 403,
+        statusText: 'Forbidden',
+        headers: new Headers(),
+        text: async () =>
+          JSON.stringify({
+            code: '42501',
+            message: 'permission denied for view limited_article_stars',
+            hint: null,
+            details: null,
+          }),
+      })
+
+      const postgrest = new PostgrestClient<Database>('https://example.com', {
+        fetch: mockFetch as any,
+      })
+
+      const res = await postgrest.from('limited_article_stars' as any).select()
+
+      expect(res.error).toBeTruthy()
+      expect(res.error!.code).toBe('42501')
+      expect(res.error!.hint).toBeTruthy()
+      expect(res.error!.hint).toContain('GRANT SELECT ON public.limited_article_stars')
+      expect(res.error!.hint).toContain('view')
+    })
+
+    test('should enhance function permission denied', async () => {
+      const mockFetch = jest.fn().mockResolvedValue({
+        ok: false,
+        status: 403,
+        statusText: 'Forbidden',
+        headers: new Headers(),
+        text: async () =>
+          JSON.stringify({
+            code: '42501',
+            message: 'permission denied for function hello_world',
+            hint: null,
+            details: null,
+          }),
+      })
+
+      const postgrest = new PostgrestClient<Database>('https://example.com', {
+        fetch: mockFetch as any,
+      })
+
+      const res = await postgrest.rpc('hello_world' as any)
+
+      expect(res.error).toBeTruthy()
+      expect(res.error!.code).toBe('42501')
+      expect(res.error!.hint).toBeTruthy()
+      expect(res.error!.hint).toContain('GRANT EXECUTE ON FUNCTION public.hello_world')
+      expect(res.error!.hint).toContain('anon, authenticated, service_role')
+    })
+
+    test('should NOT override existing hint from PostgREST', async () => {
+      const mockFetch = jest.fn().mockResolvedValue({
+        ok: false,
+        status: 403,
+        statusText: 'Forbidden',
+        headers: new Headers(),
+        text: async () =>
+          JSON.stringify({
+            code: '42501',
+            message: 'permission denied for table test',
+            hint: 'Custom hint from PostgREST',
+            details: null,
+          }),
+      })
+
+      const postgrest = new PostgrestClient<Database>('https://example.com', {
+        fetch: mockFetch as any,
+      })
+
+      const res = await postgrest.from('test' as any).select()
+
+      expect(res.error).toBeTruthy()
+      expect(res.error!.code).toBe('42501')
+      expect(res.error!.hint).toBe('Custom hint from PostgREST')
+      expect(res.error!.hint).not.toContain('GRANT')
+    })
+
+    test('should NOT enhance schema permission denied', async () => {
+      const mockFetch = jest.fn().mockResolvedValue({
+        ok: false,
+        status: 403,
+        statusText: 'Forbidden',
+        headers: new Headers(),
+        text: async () =>
+          JSON.stringify({
+            code: '42501',
+            message: 'permission denied for schema auth',
+            hint: null,
+            details: null,
+          }),
+      })
+
+      const postgrest = new PostgrestClient<Database>('https://example.com', {
+        fetch: mockFetch as any,
+      })
+
+      const res = await postgrest.from('test' as any).select()
+
+      expect(res.error).toBeTruthy()
+      expect(res.error!.code).toBe('42501')
+      // Should enhance schema errors too
+      expect(res.error!.hint).toBeTruthy()
+      expect(res.error!.hint).toContain('schema')
+    })
+  })
+
+  describe('PGRST205 - Table Not Found', () => {
+    test('should enhance table not found with null hint', async () => {
+      const mockFetch = jest.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+        headers: new Headers(),
+        text: async () =>
+          JSON.stringify({
+            code: 'PGRST205',
+            message: "Could not find the table 'public.test' in the schema cache",
+            hint: null,
+            details: null,
+          }),
+      })
+
+      const postgrest = new PostgrestClient<Database>('https://example.com', {
+        fetch: mockFetch as any,
+      })
+
+      const res = await postgrest.from('test' as any).select()
+
+      expect(res.error).toBeTruthy()
+      expect(res.error!.code).toBe('PGRST205')
+      expect(res.error!.hint).toBeTruthy()
+      expect(res.error!.hint).toContain('This could mean')
+      expect(res.error!.hint).toContain("doesn't exist")
+      expect(res.error!.hint).toContain("don't have permission")
+      expect(res.error!.hint).toContain('GRANT SELECT ON public.test')
+    })
+
+    test('should enhance table not found with single quotes', async () => {
+      const mockFetch = jest.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+        headers: new Headers(),
+        text: async () =>
+          JSON.stringify({
+            code: 'PGRST205',
+            message: "Could not find the table 'test' in the schema cache",
+            hint: null,
+            details: null,
+          }),
+      })
+
+      const postgrest = new PostgrestClient<Database>('https://example.com', {
+        fetch: mockFetch as any,
+      })
+
+      const res = await postgrest.from('test' as any).select()
+
+      expect(res.error).toBeTruthy()
+      expect(res.error!.code).toBe('PGRST205')
+      expect(res.error!.hint).toBeTruthy()
+      expect(res.error!.hint).toContain('GRANT SELECT ON public.test')
+    })
+
+    test('should NOT override existing PostgREST hint (similar tables)', async () => {
+      const mockFetch = jest.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+        headers: new Headers(),
+        text: async () =>
+          JSON.stringify({
+            code: 'PGRST205',
+            message: "Could not find the table 'public.test2' in the schema cache",
+            hint: "Perhaps you meant the table 'public.test'",
+            details: null,
+          }),
+      })
+
+      const postgrest = new PostgrestClient<Database>('https://example.com', {
+        fetch: mockFetch as any,
+      })
+
+      const res = await postgrest.from('test2' as any).select()
+
+      expect(res.error).toBeTruthy()
+      expect(res.error!.code).toBe('PGRST205')
+      expect(res.error!.hint).toBe("Perhaps you meant the table 'public.test'")
+      expect(res.error!.hint).not.toContain('This could mean')
+    })
+
+    test('should provide operation-specific hint for INSERT', async () => {
+      const mockFetch = jest.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+        headers: new Headers(),
+        text: async () =>
+          JSON.stringify({
+            code: 'PGRST205',
+            message: "Could not find the table 'test' in the schema cache",
+            hint: null,
+            details: null,
+          }),
+      })
+
+      const postgrest = new PostgrestClient<Database>('https://example.com', {
+        fetch: mockFetch as any,
+      })
+
+      const res = await postgrest.from('test' as any).insert({ id: 1 })
+
+      expect(res.error).toBeTruthy()
+      expect(res.error!.code).toBe('PGRST205')
+      expect(res.error!.hint).toContain('GRANT INSERT ON public.test')
+    })
+  })
+
+  describe('PGRST202 - Function Not Found', () => {
+    test('should enhance function not found with null hint', async () => {
+      const mockFetch = jest.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+        headers: new Headers(),
+        text: async () =>
+          JSON.stringify({
+            code: 'PGRST202',
+            message:
+              'Could not find the function public.hello_world without parameters in the schema cache',
+            hint: null,
+            details: null,
+          }),
+      })
+
+      const postgrest = new PostgrestClient<Database>('https://example.com', {
+        fetch: mockFetch as any,
+      })
+
+      const res = await postgrest.rpc('hello_world' as any)
+
+      expect(res.error).toBeTruthy()
+      expect(res.error!.code).toBe('PGRST202')
+      expect(res.error!.hint).toBeTruthy()
+      expect(res.error!.hint).toContain('This could mean')
+      expect(res.error!.hint).toContain("doesn't exist")
+      expect(res.error!.hint).toContain("don't have permission")
+      expect(res.error!.hint).toContain('GRANT EXECUTE ON FUNCTION public.hello_world')
+    })
+
+    test('should extract function name without quotes', async () => {
+      const mockFetch = jest.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+        headers: new Headers(),
+        text: async () =>
+          JSON.stringify({
+            code: 'PGRST202',
+            message: 'Could not find the function my_func without parameters in the schema cache',
+            hint: null,
+            details: null,
+          }),
+      })
+
+      const postgrest = new PostgrestClient<Database>('https://example.com', {
+        fetch: mockFetch as any,
+      })
+
+      const res = await postgrest.rpc('my_func' as any)
+
+      expect(res.error).toBeTruthy()
+      expect(res.error!.code).toBe('PGRST202')
+      expect(res.error!.hint).toContain('GRANT EXECUTE ON FUNCTION public.my_func')
+    })
+
+    test('should NOT override existing PostgREST hint (similar functions)', async () => {
+      const mockFetch = jest.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+        headers: new Headers(),
+        text: async () =>
+          JSON.stringify({
+            code: 'PGRST202',
+            message:
+              'Could not find the function public.hello_world2 without parameters in the schema cache',
+            hint: 'Perhaps you meant to call the function public.hello_world',
+            details: null,
+          }),
+      })
+
+      const postgrest = new PostgrestClient<Database>('https://example.com', {
+        fetch: mockFetch as any,
+      })
+
+      const res = await postgrest.rpc('hello_world2' as any)
+
+      expect(res.error).toBeTruthy()
+      expect(res.error!.code).toBe('PGRST202')
+      expect(res.error!.hint).toBe('Perhaps you meant to call the function public.hello_world')
+      expect(res.error!.hint).not.toContain('This could mean')
+    })
+  })
+
+  describe('Edge Cases', () => {
+    test('should handle malformed error message without crashing (42501)', async () => {
+      const mockFetch = jest.fn().mockResolvedValue({
+        ok: false,
+        status: 403,
+        statusText: 'Forbidden',
+        headers: new Headers(),
+        text: async () =>
+          JSON.stringify({
+            code: '42501',
+            message: 'permission denied',
+            hint: null,
+            details: null,
+          }),
+      })
+
+      const postgrest = new PostgrestClient<Database>('https://example.com', {
+        fetch: mockFetch as any,
+      })
+
+      const res = await postgrest.from('test' as any).select()
+
+      expect(res.error).toBeTruthy()
+      expect(res.error!.code).toBe('42501')
+      // Should not have added a hint since pattern didn't match
+      expect(res.error!.hint).toBeNull()
+    })
+
+    test('should not affect other error codes', async () => {
+      const mockFetch = jest.fn().mockResolvedValue({
+        ok: false,
+        status: 406,
+        statusText: 'Not Acceptable',
+        headers: new Headers(),
+        text: async () =>
+          JSON.stringify({
+            code: 'PGRST116',
+            message: 'JSON object requested, multiple (or no) rows returned',
+            hint: null,
+            details: 'Results contain 2 rows, application/vnd.pgrst.object+json requires 1 row',
+          }),
+      })
+
+      const postgrest = new PostgrestClient<Database>('https://example.com', {
+        fetch: mockFetch as any,
+      })
+
+      const res = await postgrest
+        .from('test' as any)
+        .select()
+        .maybeSingle()
+
+      expect(res.error).toBeTruthy()
+      expect(res.error!.code).toBe('PGRST116')
+      // Should not have modified the hint
+      expect(res.error!.hint).toBeNull()
+    })
+
+    test('should handle error without hint field', async () => {
+      const mockFetch = jest.fn().mockResolvedValue({
+        ok: false,
+        status: 403,
+        statusText: 'Forbidden',
+        headers: new Headers(),
+        text: async () =>
+          JSON.stringify({
+            code: '42501',
+            message: 'permission denied for table test',
+            details: null,
+          }),
+      })
+
+      const postgrest = new PostgrestClient<Database>('https://example.com', {
+        fetch: mockFetch as any,
+      })
+
+      const res = await postgrest.from('test' as any).select()
+
+      expect(res.error).toBeTruthy()
+      expect(res.error!.code).toBe('42501')
+      // Should have added the hint field
+      expect(res.error!.hint).toBeTruthy()
+      expect(res.error!.hint).toContain('GRANT SELECT')
+    })
+
+    test('should handle HEAD request (same as GET)', async () => {
+      const mockFetch = jest.fn().mockResolvedValue({
+        ok: false,
+        status: 403,
+        statusText: 'Forbidden',
+        headers: new Headers(),
+        text: async () =>
+          JSON.stringify({
+            code: '42501',
+            message: 'permission denied for table test',
+            hint: null,
+            details: null,
+          }),
+      })
+
+      const postgrest = new PostgrestClient<Database>('https://example.com', {
+        fetch: mockFetch as any,
+      })
+
+      const res = await postgrest.from('test' as any).select('*', { head: true })
+
+      expect(res.error).toBeTruthy()
+      expect(res.error!.code).toBe('42501')
+      expect(res.error!.hint).toContain('GRANT SELECT')
+    })
+  })
+
+  describe('throwOnError behavior', () => {
+    test('should throw enhanced error when using throwOnError', async () => {
+      const mockFetch = jest.fn().mockResolvedValue({
+        ok: false,
+        status: 403,
+        statusText: 'Forbidden',
+        headers: new Headers(),
+        text: async () =>
+          JSON.stringify({
+            code: '42501',
+            message: 'permission denied for table test',
+            hint: null,
+            details: null,
+          }),
+      })
+
+      const postgrest = new PostgrestClient<Database>('https://example.com', {
+        fetch: mockFetch as any,
+      })
+
+      try {
+        await postgrest
+          .from('test' as any)
+          .select()
+          .throwOnError()
+        fail('Should have thrown error')
+      } catch (error: any) {
+        expect(error.code).toBe('42501')
+        expect(error.hint).toContain('GRANT SELECT ON public.test')
+      }
+    })
+  })
+})


### PR DESCRIPTION
 ## Description

Enhances error handling in postgrest-js to provide actionable hints when users encounter permission-related errors. When Supabase projects revoke default GRANT permissions on tables/functions, users now receive helpful guidance with copy-paste ready SQL commands instead of cryptic error messages.

### What Changed

- Added permission error detection for three error codes:
- **42501** (PostgreSQL insufficient privilege) - Direct permission denied
- **PGRST205** (PostgREST table not found) - Could be missing permissions or doesn't exist
- **PGRST202** (PostgREST function not found) - Could be missing permissions or doesn't exist

- Implemented `generatePermissionHint()` method that provides:
  - Operation-specific GRANT commands (SELECT for GET, INSERT for POST, UPDATE for PATCH, DELETE for DELETE)
  - EXECUTE grants for functions
  - Schema-qualified object names (handles both `table` and `schema.table` formats)
  - Copy-paste ready SQL for Supabase SQL Editor

- Only enhances errors when `hint` is `null` (preserves existing PostgREST hints)

### Example Output

Before:

  ```json
  {
    "code": "42501",
    "message": "permission denied for table test",
    "hint": null
  }
```

After (GET request):

```json
 {
    "code": "42501",
    "message": "permission denied for table test",
    "hint": "Missing SELECT permission on table 'test'. Grant permission with:\n\nGRANT SELECT ON
  public.test TO anon, authenticated, service_role;\n\nNote: Adjust schema if not 'public', and
  specify only the roles you want to grant access to."
  }
```

After (POST request - operation-specific):

```json
  {
    "code": "42501",
    "message": "permission denied for table test",
    "hint": "Missing INSERT permission on table 'test'. Grant permission with:\n\nGRANT INSERT ON
  public.test TO anon, authenticated, service_role;\n\nNote: Adjust schema if not 'public', and
  specify only the roles you want to grant access to."
  }
```


## Context

This addresses the issue where AI assistants suggest incorrect solutions (like "modify RLS policies") when users encounter permission errors after revoking default GRANT permissions. The hints now correctly guide users to add GRANT permissions (table-level security) rather than RLS policies (row-level security), which are different security layers.