### PR TITLE
fix(auth): recover from orphaned navigator locks via steal fallback

### DIFF
--- a/packages/core/auth-js/test/lib/locks.test.ts
+++ b/packages/core/auth-js/test/lib/locks.test.ts
@@ -18,9 +18,9 @@ describe('navigatorLock', () => {
 
   it('should acquire and release lock successfully', async () => {
     const mockLock = { name: 'test-lock' }
-    ;(globalThis.navigator.locks.request as jest.Mock).mockImplementation((_, __, callback) =>
-      Promise.resolve(callback(mockLock))
-    )
+      ; (globalThis.navigator.locks.request as jest.Mock).mockImplementation((_, __, callback) =>
+        Promise.resolve(callback(mockLock))
+      )
 
     const result = await navigatorLock('test', -1, async () => 'success')
     expect(result).toBe('success')
@@ -28,7 +28,7 @@ describe('navigatorLock', () => {
   })
 
   it('should handle immediate acquisition failure', async () => {
-    ;(globalThis.navigator.locks.request as jest.Mock).mockImplementation((_, __, callback) =>
+    ; (globalThis.navigator.locks.request as jest.Mock).mockImplementation((_, __, callback) =>
       Promise.resolve(callback(null))
     )
 
@@ -39,30 +39,71 @@ describe('navigatorLock', () => {
     await expect(navigatorLock('test-lock', 1, async () => 'success')).resolves.toBe('success')
   })
 
-  it('should convert AbortError to NavigatorLockAcquireTimeoutError with isAcquireTimeout property', async () => {
-    // Mock navigator.locks.request to simulate an AbortError being thrown when timeout occurs
-    const abortError = new Error('AbortError')
-    abortError.name = 'AbortError'
-    ;(globalThis.navigator.locks.request as jest.Mock).mockRejectedValue(abortError)
-
-    // Call navigatorLock with a timeout - should convert AbortError to timeout error
-    await expect(navigatorLock('test-lock', 100, async () => 'success')).rejects.toMatchObject({
-      isAcquireTimeout: true,
-      message: expect.stringContaining('timed out'),
-    })
-  })
-
   it('should rethrow non-AbortError errors unchanged', async () => {
     // Mock navigator.locks.request to throw a different error
     const customError = new Error('Some other error')
     customError.name = 'CustomError'
-    ;(globalThis.navigator.locks.request as jest.Mock).mockRejectedValue(customError)
+      ; (globalThis.navigator.locks.request as jest.Mock).mockRejectedValue(customError)
 
     // Should rethrow the error unchanged (no isAcquireTimeout property)
     await expect(navigatorLock('test-lock', 100, async () => 'success')).rejects.toMatchObject({
       message: 'Some other error',
       name: 'CustomError',
     })
+  })
+
+  it('should recover from orphaned lock by stealing after acquire timeout', async () => {
+    let callCount = 0
+    const mockLock = { name: 'test-lock' }
+
+      ; (globalThis.navigator.locks.request as jest.Mock).mockImplementation(
+        (name: string, options: any, callback: (lock: any) => Promise<any>) => {
+          callCount++
+
+          if (callCount === 1) {
+            // First call: simulate an orphaned lock by aborting via the signal
+            // (mimics the acquireTimeout firing while a lock is held by another caller)
+            return new Promise((_, reject) => {
+              if (options.signal) {
+                options.signal.addEventListener('abort', () => {
+                  reject(new DOMException('signal is aborted without reason', 'AbortError'))
+                })
+              }
+            })
+          }
+
+          // Second call (steal: true): grant the lock immediately
+          expect(options.steal).toBe(true)
+          return Promise.resolve(callback(mockLock))
+        }
+      )
+
+    const result = await navigatorLock('test', 100, async () => 'recovered')
+    expect(result).toBe('recovered')
+    expect(callCount).toBe(2)
+  })
+
+  it('should propagate non-AbortError errors without attempting steal', async () => {
+    ; (globalThis.navigator.locks.request as jest.Mock).mockImplementation(() => {
+      return Promise.reject(new Error('some other error'))
+    })
+
+    await expect(navigatorLock('test', 100, async () => 'success')).rejects.toThrow(
+      'some other error'
+    )
+    // Should only be called once (no steal retry)
+    expect(globalThis.navigator.locks.request).toHaveBeenCalledTimes(1)
+  })
+
+  it('should not attempt steal when acquireTimeout is negative (no timeout)', async () => {
+    ; (globalThis.navigator.locks.request as jest.Mock).mockImplementation(() => {
+      const error = new DOMException('aborted', 'AbortError')
+      return Promise.reject(error)
+    })
+
+    await expect(navigatorLock('test', -1, async () => 'success')).rejects.toThrow()
+    // Should only be called once (no steal retry for negative timeout)
+    expect(globalThis.navigator.locks.request).toHaveBeenCalledTimes(1)
   })
 })
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/supabase/supabase-js/issues/2111

When a Navigator Lock is held indefinitely (e.g., due to React Strict Mode's double-mount/unmount leaving an orphaned lock callback in `GoTrueClient._acquireLock`'s `pendingInLock` drain loop), all subsequent auth operations (`getUser()`, `signInWithPassword()`, etc.) hang forever.

**Root cause:** The existing `acquireTimeout` mechanism uses `AbortController.abort()` to cancel pending lock requests. Per the [Web Locks API spec](https://developer.mozilla.org/en-US/docs/Web/API/LockManager/request), aborting the signal only removes **pending** (waiting-to-acquire) requests from the queue — it has **no effect** on an already-held lock. So when a lock is orphaned:

1. The held lock callback never returns → lock stays held forever
2. Subsequent callers queue up, timeout, get `AbortError`, and give up
3. The auth system is permanently broken until all tabs are closed

**Fix:** When lock acquisition times out with `AbortError`, instead of propagating the error, retry with `{ steal: true }`. Per the spec, this releases any currently held lock with the same name and grants the request immediately. The previous holder's callback continues running to completion but no longer blocks other callers.

### Changes
- `packages/core/auth-js/src/lib/locks.ts` — Wrap `navigator.locks.request()` in try/catch; on `AbortError` with positive `acquireTimeout`, retry with `{ steal: true }` to recover from orphaned locks
- `packages/core/auth-js/test/lib/locks.test.ts` — Add 3 tests covering: orphaned lock recovery via steal, non-AbortError passthrough, no steal attempt with negative timeout

## Test plan
- [x] All 10 existing + new unit tests pass (`jest --testPathPattern='test/lib/locks'`)
- [x] Manual verification: create a Next.js app with React Strict Mode, call `getUser()` in a `useEffect`, trigger the orphaned lock scenario (visible via `navigator.locks.query()`), confirm auth recovers instead of hanging
- [ ] Verify no regression in multi-tab session synchronization

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved lock acquisition reliability with enhanced timeout handling and automatic recovery from orphaned locks.
  * Enhanced error messages and logging for timeout scenarios to clarify potential causes and recovery actions.

* **Tests**
  * Added test coverage for lock recovery from timeouts, error propagation, and timeout configuration edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->