### PR TITLE
docs(supabase): document UNUSED_EXTERNAL_IMPORT build warning as false positive

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ We support Cloudflare Workers runtime environments. Cloudflare Workers provides 
 ### Important Notes
 
 - **Experimental features**: Features marked as experimental may be removed or changed without notice
+- **Build warnings**: If you see `UNUSED_EXTERNAL_IMPORT` warnings from Vite/Nuxt, see the [supabase-js README](./packages/core/supabase-js/README.md#known-build-warnings) — these are false positives
 
 ## 🚀 Quick Start
 


### PR DESCRIPTION
## Description

Adds a **"Known Build Warnings"** section to `packages/core/supabase-js/README.md` and a short pointer note to the root `README.md`, addressing the `UNUSED_EXTERNAL_IMPORT` warnings that Vite/Rollup/Nuxt users have been reporting (tracked in #2010).

## Why now

The warning appears because `supabase-js` re-exports types like `PostgrestError` and `FunctionsError` for consumer convenience. The bundler merges all imports from the same package into a single statement, then flags re-exported names as "unused" because they only appear in an `export` statement rather than in the code body.
This is a known Rollup/Vite limitation. Nothing is broken and tree-shaking is unaffected.

Changing the build output to work around a bundler heuristic would add complexity and risk for no real gain. Documentation + an `onwarn` snippet is the right fix for consumers who want clean output.

## Changes

- `packages/core/supabase-js/README.md` — new "Known Build Warnings" section with explanation, Vite/Rollup snippet, Nuxt snippet
- `README.md` (monorepo root) — one-liner pointing to the section above

## Type of Change

- [x] Documentation update (docs)