### PR TITLE
feat(auth): add skipAutoInitialize option to prevent constructor auto-init

### DIFF
--- a/packages/core/auth-js/src/GoTrueClient.ts
+++ b/packages/core/auth-js/src/GoTrueClient.ts
@@ -175,6 +175,7 @@ const DEFAULT_OPTIONS: Omit<
   hasCustomAuthorizationHeader: false,
   throwOnError: false,
   lockAcquireTimeout: 10000, // 10 seconds
+  skipAutoInitialize: false,
 }
 
 async function lockNoOp<R>(name: string, acquireTimeout: number, fn: () => Promise<R>): Promise<R> {
@@ -406,9 +407,14 @@ export default class GoTrueClient {
       })
     }
 
-    this.initialize().catch((error) => {
-      this._debug('#initialize()', 'error', error)
-    })
+    // Only auto-initialize if not explicitly disabled. Skipped in SSR contexts
+    // where initialization timing must be controlled. All public methods have
+    // lazy initialization, so the client remains fully functional.
+    if (!settings.skipAutoInitialize) {
+      this.initialize().catch((error) => {
+        this._debug('#initialize()', 'error', error)
+      })
+    }
   }
 
   /**

--- a/packages/core/auth-js/src/lib/types.ts
+++ b/packages/core/auth-js/src/lib/types.ts
@@ -170,6 +170,15 @@ export type GoTrueClientOptions = {
    * ```
    */
   lockAcquireTimeout?: number
+
+  /**
+   * If true, skips automatic initialization in constructor. Useful for SSR
+   * contexts where initialization timing must be controlled to prevent race
+   * conditions with HTTP response generation.
+   *
+   * @default false
+   */
+  skipAutoInitialize?: boolean
 }
 
 const WeakPasswordReasons = ['length', 'characters', 'pwned'] as const


### PR DESCRIPTION
## Problem

Currently, `GoTrueClient` constructor automatically calls `this.initialize()` as a fire-and-forget promise. This starts async operations (URL detection, session recovery, token refresh) immediately without waiting for completion.

In SSR contexts, this causes a race condition:
1. Client created in request handler
2. Constructor fires off `initialize()` promise (doesn't await)
3. SSR framework generates and sends HTTP response
4. Token refresh completes AFTER response sent
5. Cookie setting fails: `Error: Cannot use cookies.set(...) after the response has been generated`

## Solution

Add `skipAutoInitialize` option to `GoTrueClientOptions` that:
- When `true`: Skip automatic `initialize()` call in constructor
- When `false` (default): Maintain existing auto-initialization behavior
- Rely on existing lazy initialization in all public methods (already present)
- Allow SSR packages to control initialization timing

## Changes

- Add `skipAutoInitialize?: boolean` to `GoTrueClientOptions` interface
- Update `DEFAULT_OPTIONS` with `skipAutoInitialize: false`
- Conditionally skip auto-init in constructor when option is true

## Related

- This enables `@supabase/ssr` (and other SSR integrations) to prevent race conditions by setting `skipAutoInitialize: true` and controlling initialization timing within the request lifecycle. 
- https://github.com/supabase/ssr/pull/131