### PR TITLE
fix(auth): lower lockAcquireTimeout default to 5s and fix stale JSDoc

### DIFF
--- a/packages/core/auth-js/src/GoTrueClient.ts
+++ b/packages/core/auth-js/src/GoTrueClient.ts
@@ -174,7 +174,7 @@ const DEFAULT_OPTIONS: Omit<
   debug: false,
   hasCustomAuthorizationHeader: false,
   throwOnError: false,
-  lockAcquireTimeout: 10000, // 10 seconds
+  lockAcquireTimeout: 5000, // 5 seconds
   skipAutoInitialize: false,
 }
 

--- a/packages/core/auth-js/test/GoTrueClient.test.ts
+++ b/packages/core/auth-js/test/GoTrueClient.test.ts
@@ -237,7 +237,7 @@ describe('GoTrueClient', () => {
       // Error message varies between GoTrue versions
       expect(
         setSessionError?.message?.includes('Invalid Refresh Token') ||
-          setSessionError?.message?.includes('Refresh token is not valid')
+        setSessionError?.message?.includes('Refresh token is not valid')
       ).toBe(true)
       expect(session).toBeNull()
     })
@@ -1439,7 +1439,7 @@ describe('MFA', () => {
       // Create a valid JWT with aal1
       const jwt = require('jsonwebtoken')
       const { GOTRUE_JWT_SECRET } = require('./lib/clients')
-      
+
       const testJwt = jwt.sign(
         {
           sub: 'test-user-id',
@@ -1480,7 +1480,7 @@ describe('MFA', () => {
       // Create a valid JWT with aal1
       const jwt = require('jsonwebtoken')
       const { GOTRUE_JWT_SECRET } = require('./lib/clients')
-      
+
       const testJwt = jwt.sign(
         {
           sub: 'test-user-id',
@@ -1533,7 +1533,7 @@ describe('MFA', () => {
       // Create a valid JWT structure
       const jwt = require('jsonwebtoken')
       const { GOTRUE_JWT_SECRET } = require('./lib/clients')
-      
+
       const testJwt = jwt.sign(
         {
           sub: 'nonexistent-user-id',
@@ -1694,7 +1694,7 @@ describe('WebAuthn MFA', () => {
       static parseRequestOptionsFromJSON = deserializeCredentialRequestOptions
     }
 
-    ;(global as any).PublicKeyCredential = PublicKeyCredentialMock
+    ; (global as any).PublicKeyCredential = PublicKeyCredentialMock
   })
 
   afterAll(() => {
@@ -3054,7 +3054,7 @@ describe('Session Management Edge Cases', () => {
     // Error message varies between GoTrue versions
     expect(
       error?.message?.includes('Invalid Refresh Token') ||
-        error?.message?.includes('Refresh token is not valid')
+      error?.message?.includes('Refresh token is not valid')
     ).toBe(true)
     expect(data.session).toBeNull()
   })
@@ -3083,8 +3083,8 @@ describe('Storage adapter edge cases', () => {
       getItem: async () => {
         throw new Error('getItem failed message')
       },
-      setItem: async () => {},
-      removeItem: async () => {},
+      setItem: async () => { },
+      removeItem: async () => { },
     }
     const client = getClientWithSpecificStorage(brokenStorage)
     await expect(client.getSession()).rejects.toThrow('getItem failed message')
@@ -3096,7 +3096,7 @@ describe('Storage adapter edge cases', () => {
       setItem: async () => {
         throw new Error('setItem failed message')
       },
-      removeItem: async () => {},
+      removeItem: async () => { },
     }
     const client = getClientWithSpecificStorage(brokenStorage)
     const session = {
@@ -3117,7 +3117,7 @@ describe('Storage adapter edge cases', () => {
   test('should handle storage removeItem failure in _removeSession', async () => {
     const brokenStorage = {
       getItem: async () => '{}',
-      setItem: async () => {},
+      setItem: async () => { },
       removeItem: async () => {
         throw new Error('removeItem failed message')
       },
@@ -3130,8 +3130,8 @@ describe('Storage adapter edge cases', () => {
   test('should handle invalid JSON in storage', async () => {
     const invalidStorage = {
       getItem: async () => 'invalid-json',
-      setItem: async () => {},
-      removeItem: async () => {},
+      setItem: async () => { },
+      removeItem: async () => { },
     }
     const client = getClientWithSpecificStorage(invalidStorage)
     const { data, error } = await client.getSession()
@@ -3142,8 +3142,8 @@ describe('Storage adapter edge cases', () => {
   test('should handle null storage value', async () => {
     const nullStorage = {
       getItem: async () => null,
-      setItem: async () => {},
-      removeItem: async () => {},
+      setItem: async () => { },
+      removeItem: async () => { },
     }
     const client = getClientWithSpecificStorage(nullStorage)
     const { data, error } = await client.getSession()
@@ -3154,8 +3154,8 @@ describe('Storage adapter edge cases', () => {
   test('should handle empty storage value', async () => {
     const emptyStorage = {
       getItem: async () => '',
-      setItem: async () => {},
-      removeItem: async () => {},
+      setItem: async () => { },
+      removeItem: async () => { },
     }
     const client = getClientWithSpecificStorage(emptyStorage)
     const { data, error } = await client.getSession()
@@ -3166,8 +3166,8 @@ describe('Storage adapter edge cases', () => {
   test('should handle malformed session data', async () => {
     const malformedStorage = {
       getItem: async () => JSON.stringify({ access_token: 'test' }), // Missing required fields
-      setItem: async () => {},
-      removeItem: async () => {},
+      setItem: async () => { },
+      removeItem: async () => { },
     }
     const client = getClientWithSpecificStorage(malformedStorage)
     const { data, error } = await client.getSession()
@@ -3186,8 +3186,8 @@ describe('Storage adapter edge cases', () => {
           token_type: 'bearer',
           user: null,
         }),
-      setItem: async () => {},
-      removeItem: async () => {},
+      setItem: async () => { },
+      removeItem: async () => { },
     }
     const client = getClientWithSpecificStorage(expiredStorage)
     // @ts-expect-error private method
@@ -3397,14 +3397,14 @@ describe('Lock functionality', () => {
       lock: mockLock,
       autoRefreshToken: false,
       persistSession: false,
-      // lockAcquireTimeout not provided, should default to 10000
+      // lockAcquireTimeout not provided, should default to 5000
     })
 
     await client.initialize()
 
-    // Verify that the default timeout (10000ms = 10 seconds) was used
+    // Verify that the default timeout (5000 = 5 seconds) was used
     expect(mockLock).toHaveBeenCalled()
-    expect(capturedTimeouts).toContain(10000)
+    expect(capturedTimeouts).toContain(5000)
   })
 
   test('should pass negative timeout to lock for indefinite wait', async () => {


### PR DESCRIPTION
 ## Description

Follow-up to #2106 (steal-based orphaned-lock recovery).

- **Lower `lockAcquireTimeout` default** from 10 s to 5 s (`GoTrueClient.ts`). The auth team aligned on a shorter default in the original Slack thread; now that the steal fallback handles recovery, a shorter wait is safe.
- **Fix stale `lock` JSDoc** (`types.ts`): the previous comment claimed "no locking is done by default", which is false — `navigatorLock` (Web Locks API) has been the default in browser environments with `persistSession: true` for
   some time.
- **Rewrite `lockAcquireTimeout` JSDoc** (`types.ts`): the previous doc said a positive timeout throws `LockAcquireTimeoutError`. With #2106 merged, a positive timeout now triggers steal-based recovery instead. Updated `@default`, bullet descriptions, and the example snippet accordingly.