### PR TITLE
feat(auth): add currentPassword to UserAttributes type

### DIFF
--- a/packages/core/auth-js/src/lib/types.ts
+++ b/packages/core/auth-js/src/lib/types.ts
@@ -464,6 +464,15 @@ export interface User {
 
 export interface UserAttributes {
   /**
+   * The user's current password
+   *
+   * This is only ever present when the user is resetting
+   * their password and GOTRUE_SECURITY_UPDATE_PASSWORD_REQUIRE_CURRENT_PASSWORD is true.
+   *
+   */
+  currentPassword?: string
+
+  /**
    * The user's email.
    */
   email?: string


### PR DESCRIPTION


<!-- Your PR title should follow the conventional commit format:
<type>(<scope>): <description> -->

## 🔍 Description

Auth will require the currentPassword when a user is changing their password if GOTRUE_SECURITY_UPDATE_PASSWORD_REQUIRE_CURRENT_PASSWORD is set to true

### What changed?

adds optional `currentPassword` to `UserAttributes` type

### Why was this change needed?

https://github.com/supabase/auth/pull/2364



## 📋 Checklist

<!-- Ensure all items are checked before submitting -->

- [x] I have read the [Contributing Guidelines](https://github.com/supabase/supabase-js/blob/master/CONTRIBUTING.md)
- [x] My PR title follows the [conventional commit format](https://www.conventionalcommits.org/): `<type>(<scope>): <description>`
- [x] I have run `npx nx format` to ensure consistent code formatting
- [x] I have added tests for new functionality (if applicable)
- [] I have updated documentation (if applicable)


