### PR TITLE
fix(auth): fixes userattributes type

### DIFF
--- a/packages/core/auth-js/src/lib/types.ts
+++ b/packages/core/auth-js/src/lib/types.ts
@@ -471,7 +471,7 @@ export interface UserAttributes {
    * their password and GOTRUE_SECURITY_UPDATE_PASSWORD_REQUIRE_CURRENT_PASSWORD is true.
    *
    */
-  currentPassword?: string
+  current_password?: string
 
   /**
    * The user's email.


### PR DESCRIPTION

<!-- Your PR title should follow the conventional commit format:
<type>(<scope>): <description> -->

## 🔍 Description

The UserAttributes type used currentPassword (camel-case) but the Auth server expects current_password (snake-case)


### What changed?

`UserAttribute` type

### Why was this change needed?

Bad typing would cause the Auth server to reject all password change attempts if current_password was required



## 📝 Additional notes

This feature isn't active yet on any Auth servers, but will be soon
