### PR TITLE
fix(auth): dont remove session in _callRefreshToken on non-retryable error

### DIFF
--- a/packages/core/auth-js/src/GoTrueClient.ts
+++ b/packages/core/auth-js/src/GoTrueClient.ts
@@ -2724,9 +2724,9 @@ export default class GoTrueClient {
       if (isAuthError(error)) {
         const result = { data: null, error }
 
-        if (!isAuthRetryableFetchError(error)) {
-          await this._removeSession()
-        }
+        // Don't remove session here — callers have context about whether
+        // the access token is still valid and should decide themselves.
+        // _recoverAndRefresh already handles cleanup for non-retryable errors.
 
         this.refreshingDeferred?.resolve(result)
 

--- a/packages/core/auth-js/test/GoTrueClient.test.ts
+++ b/packages/core/auth-js/test/GoTrueClient.test.ts
@@ -453,6 +453,58 @@ describe('GoTrueClient', () => {
       expect(session3).toHaveProperty('access_token')
     })
 
+    test('_callRefreshToken() should not remove session from storage on non-retryable error', async () => {
+      const store: { [key: string]: string } = {}
+      const storage = memoryLocalStorageAdapter(store)
+      const client = new GoTrueClient({
+        url: 'http://localhost:9999',
+        autoRefreshToken: false,
+        persistSession: true,
+        storage,
+      })
+
+      await client.initialize()
+
+      const expiresAt = Math.floor(Date.now() / 1000) + 30
+      const session = {
+        access_token: expiredAccessToken,
+        refresh_token: 'test-refresh-token',
+        expires_at: expiresAt,
+        expires_in: 30,
+        token_type: 'bearer',
+        user: {
+          id: 'test-user-id',
+          aud: 'authenticated',
+          role: 'authenticated',
+          email: 'test@example.com',
+          app_metadata: {},
+          user_metadata: {},
+          created_at: new Date().toISOString(),
+        },
+      }
+
+      await storage.setItem(STORAGE_KEY, JSON.stringify(session))
+
+      // @ts-expect-error 'Allow access to private _refreshAccessToken'
+      jest.spyOn(client, '_refreshAccessToken').mockResolvedValueOnce({
+        data: { session: null, user: null },
+        error: new AuthError('Invalid refresh token'),
+      })
+
+      const { data, error } = await client.getSession()
+
+      expect(error).not.toBeNull()
+      expect(error?.message).toBe('Invalid refresh token')
+      expect(data.session).toBeNull()
+
+      const storedSession = await storage.getItem(STORAGE_KEY)
+      expect(storedSession).not.toBeNull()
+      expect(JSON.parse(storedSession!)).toMatchObject({
+        access_token: expiredAccessToken,
+        refresh_token: 'test-refresh-token',
+      })
+    })
+
     test('_getSessionFromURL() can only be called from a browser', async () => {
       const {
         error,


### PR DESCRIPTION
## Change

Removes the `_removeSession()` call from `_callRefreshToken`'s catch block for non-retryable errors.

## Reason for change

When `getSession()` proactively refreshes a token within the 90s `EXPIRY_MARGIN_MS` window and the refresh fails (e.g. 400 `invalid_grant` from a rotation race), the session is permanently deleted from storage — even though the access token is still valid. Every subsequent `getSession()` call returns `{ session: null, error: null }` with no recovery path.

## How

`_callRefreshToken` is a low-level helper. It shouldn't own session lifecycle decisions. Callers that need to clean up already do so independently (`_recoverAndRefresh` has its own `_removeSession()` call for non-retryable errors). Removing the call here lets `__loadSession` (the `getSession()` path) degrade gracefully returning the error without nuking a still-valid session.

