### PR TITLE
feat(storage): add version parameter for download

### DIFF
--- a/packages/core/storage-js/src/packages/StorageFileApi.ts
+++ b/packages/core/storage-js/src/packages/StorageFileApi.ts
@@ -700,7 +700,7 @@ export default class StorageFileApi extends BaseApiClient<StorageError> {
       return data.map((datum: { signedURL: string }) => ({
         ...datum,
         signedUrl: datum.signedURL
-          ? encodeURI(`${this.url}${datum.signedURL}${queryString ? `?${queryString}` : ''}`)
+          ? encodeURI(`${this.url}${datum.signedURL}&${queryString}`)
           : null,
       }))
     })

--- a/packages/core/storage-js/test/storageFileApi.test.ts
+++ b/packages/core/storage-js/test/storageFileApi.test.ts
@@ -715,10 +715,7 @@ describe('Object API', () => {
 
       const parsedUrl = global.URL.parse(res.data.signedUrl)
       assert(parsedUrl)
-      assert(
-        parsedUrl.searchParams.has('_v', version),
-        `params should contain '_v=${version}' (is '${parsedUrl.searchParams.toString()}')`
-      )
+      assert(parsedUrl.searchParams.has('_v', version))
     }
 
     // `createSignedUrl` without transform
@@ -765,6 +762,24 @@ describe('Object API', () => {
       const parsedUrl = global.URL.parse(res.data.publicUrl)
       assert(parsedUrl)
       assert(parsedUrl.searchParams.has('_v', version))
+    }
+
+    // `createSignedUrls` with download
+    {
+      const res = await storage.from(bucketName).createSignedUrls([uploadPath], 60000, {
+        version,
+        download: true,
+      })
+
+      expect(res.error).toBeNull()
+      assert(res.data)
+      expect(res.data).toHaveLength(1)
+      expect(res.data[0].error).toBeNull()
+
+      const parsedUrl = global.URL.parse(res.data[0].signedUrl)
+      assert(parsedUrl)
+      assert(parsedUrl.searchParams.has('_v', version))
+      assert(parsedUrl.searchParams.has('token'))
     }
   })
 })


### PR DESCRIPTION
<!-- Your PR title should follow the conventional commit format:
<type>(<scope>): <description> -->

## 🔍 Description

As the documentation already suggests (see [here](https://supabase.com/docs/guides/storage/cdn/smart-cdn#bypassing-cache)), I implemented a version parameter that can be attached to the download request.

### What changed?

<!-- Describe the changes made in this PR -->

### Why was this change needed?

Currently, the Supabase CDN unavoidably caches files for 1 minute. This leads to stale data being served after a file is replaced.

## 📸 Screenshots/Examples

```ts
download<Options extends { transform?: TransformOptions; version?: string | number }>(
  path: string,
  options?: Options,
  parameters?: FetchParameters
): BlobDownloadBuilder {
  const wantsTransformation = typeof options?.transform !== 'undefined'
  const renderPath = wantsTransformation ? 'render/image/authenticated' : 'object'
  const queryString: string = [
    // transformation
    options?.transform && this.transformOptsToQueryString(options.transform),
    // versioning
    options?.version != null && `_v=${encodeURIComponent(options.version)}`,
  ]
    .filter(Boolean)
    .join('&')
  const _path = this._getFinalPath(path)
  const downloadFn = () =>
    get(
      this.fetch,
      `${this.url}/${renderPath}/${_path}${queryString ? `?${queryString}` : ''}`,
      {
        headers: this.headers,
        noResolveJson: true,
      },
      parameters
    )
  return new BlobDownloadBuilder(downloadFn, this.shouldThrowOnError)
}
```

## 🔄 Breaking changes

<!-- If this PR contains breaking changes, describe them here -->

- [x] This PR contains no breaking changes

## 📋 Checklist

<!-- Ensure all items are checked before submitting -->

- [x] I have read the [Contributing Guidelines](https://github.com/supabase/supabase-js/blob/master/CONTRIBUTING.md)
- [x] My PR title follows the [conventional commit format](https://www.conventionalcommits.org/): `<type>(<scope>): <description>`
- [x] I have run `npx nx format` to ensure consistent code formatting
- [x] I have added tests for new functionality (if applicable)
- [x] I have updated documentation (if applicable)

## 📝 Additional notes

<!-- Add any additional notes, context, or concerns for reviewers -->

<!-- Thank you for contributing to Supabase! 💚 -->
