### PR TITLE
fix(supabase): resolve cryptic TypeScript tooltip for data from select()

### DIFF
--- a/packages/core/supabase-js/src/SupabaseClient.ts
+++ b/packages/core/supabase-js/src/SupabaseClient.ts
@@ -81,7 +81,7 @@ export default class SupabaseClient<
   protected authUrl: URL
   protected storageUrl: URL
   protected functionsUrl: URL
-  protected rest: PostgrestClient<Database, ClientOptions, SchemaName>
+  protected rest: PostgrestClient<Database, ClientOptions, SchemaName, Schema>
   protected storageKey: string
   protected fetch?: Fetch
   protected changedAccessToken?: string
@@ -171,13 +171,16 @@ export default class SupabaseClient<
         .catch((e) => console.warn('Failed to set initial Realtime auth token:', e))
     }
 
-    this.rest = new PostgrestClient(new URL('rest/v1', baseUrl).href, {
-      headers: this.headers,
-      schema: settings.db.schema,
-      fetch: this.fetch,
-      timeout: settings.db.timeout,
-      urlLengthLimit: settings.db.urlLengthLimit,
-    })
+    this.rest = new PostgrestClient<Database, ClientOptions, SchemaName, Schema>(
+      new URL('rest/v1', baseUrl).href,
+      {
+        headers: this.headers,
+        schema: settings.db.schema,
+        fetch: this.fetch,
+        timeout: settings.db.timeout,
+        urlLengthLimit: settings.db.urlLengthLimit,
+      }
+    )
 
     this.storage = new SupabaseStorageClient(
       this.storageUrl.href,

--- a/packages/core/supabase-js/src/index.ts
+++ b/packages/core/supabase-js/src/index.ts
@@ -1,5 +1,5 @@
 import SupabaseClient from './SupabaseClient'
-import type { SupabaseClientOptions } from './lib/types'
+import type { SupabaseClientOptions, ResolveSchema, ResolveClientOptions } from './lib/types'
 
 export * from '@supabase/auth-js'
 export type { User as AuthUser, Session as AuthSession } from '@supabase/auth-js'
@@ -56,12 +56,20 @@ export const createClient = <
   supabaseUrl: string,
   supabaseKey: string,
   options?: SupabaseClientOptions<SchemaName>
-): SupabaseClient<Database, SchemaNameOrClientOptions, SchemaName> => {
-  return new SupabaseClient<Database, SchemaNameOrClientOptions, SchemaName>(
-    supabaseUrl,
-    supabaseKey,
-    options
-  )
+): SupabaseClient<
+  Database,
+  SchemaNameOrClientOptions,
+  SchemaName,
+  ResolveSchema<Database, SchemaName>,
+  ResolveClientOptions<Database, SchemaNameOrClientOptions>
+> => {
+  return new SupabaseClient<
+    Database,
+    SchemaNameOrClientOptions,
+    SchemaName,
+    ResolveSchema<Database, SchemaName>,
+    ResolveClientOptions<Database, SchemaNameOrClientOptions>
+  >(supabaseUrl, supabaseKey, options)
 }
 
 // Check for Node.js <= 18 deprecation

--- a/packages/core/supabase-js/src/lib/types.ts
+++ b/packages/core/supabase-js/src/lib/types.ts
@@ -171,3 +171,30 @@ export type QueryError = PostgrestError
  * ```
  */
 export type DatabaseWithoutInternals<DB> = Omit<DB, '__InternalSupabase'>
+
+/**
+ * @internal
+ * Eagerly resolves the Schema type for a given Database and SchemaName.
+ * Used by createClient to pass concrete Schema types to SupabaseClient,
+ * avoiding cryptic unresolved conditional types in IDE tooltips.
+ */
+export type ResolveSchema<
+  Database,
+  SchemaName extends string & keyof Omit<Database, '__InternalSupabase'>,
+> = Omit<Database, '__InternalSupabase'>[SchemaName] extends GenericSchema
+  ? Omit<Database, '__InternalSupabase'>[SchemaName]
+  : never
+
+/**
+ * @internal
+ * Eagerly resolves the ClientOptions type for a given Database and SchemaNameOrClientOptions.
+ * Used by createClient to pass concrete ClientOptions to SupabaseClient.
+ */
+export type ResolveClientOptions<Database, SchemaNameOrClientOptions> =
+  SchemaNameOrClientOptions extends string & keyof Omit<Database, '__InternalSupabase'>
+    ? Database extends { __InternalSupabase: { PostgrestVersion: string } }
+      ? Database['__InternalSupabase']
+      : { PostgrestVersion: '12' }
+    : SchemaNameOrClientOptions extends { PostgrestVersion: string }
+      ? SchemaNameOrClientOptions
+      : never


### PR DESCRIPTION
## Summary

- `createClient` now explicitly passes all 5 type params to `SupabaseClient`, forcing TypeScript to eagerly evaluate `Schema` and `ClientOptions` at the call site
- Adds `ResolveSchema` and `ResolveClientOptions` helper types to compute concrete types at the function level
- Propagates concrete `Schema` type through to `PostgrestClient` so `from().select('*')` shows clean row types in IDE tooltips instead of unresolved conditionals

## Before / After

- **Before:** hovering `data` showed `GetResult<Omit<Database, "__InternalSupabase">[SchemaNameOrClientOptions extends ...]>`
- **After:** hovering `data` shows the actual expanded row type