### PR TITLE
fix(functions): add RateLimitError in `Deno.errors` namespace

### DIFF
--- a/packages/core/functions-js/src/edge-runtime.d.ts
+++ b/packages/core/functions-js/src/edge-runtime.d.ts
@@ -194,5 +194,15 @@ declare namespace Deno {
   export namespace errors {
     class WorkerRequestCancelled extends Error {}
     class WorkerAlreadyRetired extends Error {}
+
+    /** Thrown when an outbound HTTP request is blocked by the rate limiter. */
+    class RateLimitError extends Error {
+      /**
+       * Number of milliseconds until the rate-limit window resets.
+       * `null` if the reset time could not be determined.
+       */
+      retryAfterMs: number | null;
+      constructor(message: string, retryAfterMs?: number);
+    }
   }
 }


### PR DESCRIPTION
This PR adds a custom error type for rate-limiting introduced in https://github.com/supabase/edge-runtime/pull/670.