### PR TITLE
ix(postgrest): filter out undefined values in match method

### DIFF
--- a/packages/core/postgrest-js/src/PostgrestFilterBuilder.ts
+++ b/packages/core/postgrest-js/src/PostgrestFilterBuilder.ts
@@ -604,9 +604,13 @@ export default class PostgrestFilterBuilder<
    * to their filter values
    */
   match(query: Record<string, unknown>): this {
-    Object.entries(query).forEach(([column, value]) => {
-      this.url.searchParams.append(column, `eq.${value}`)
-    })
+    Object.entries(query) 
+      // columns with `undefined` value needs to be filtered out, otherwise it'll 
+      // show up as `?column=eq.undefined` 
+      .filter(([_, value]) => value !== undefined)
+      .forEach(([column, value]) => {
+        this.url.searchParams.append(column, `eq.${value}`)
+      })
     return this
   }
 


### PR DESCRIPTION
## 🔍 Description

### What changed?

Filter out `undefined` values from the query

### Why was this change needed?

Closes #2167

## 🔄 Breaking changes

- [x] This PR contains no breaking changes

## 📋 Checklist

<!-- Ensure all items are checked before submitting -->

- [x] I have read the [Contributing Guidelines](https://github.com/supabase/supabase-js/blob/master/CONTRIBUTING.md)
- [x] My PR title follows the [conventional commit format](https://www.conventionalcommits.org/): `<type>(<scope>): <description>`
- [x] I have run `npx nx format` to ensure consistent code formatting
- [ ] I have added tests for new functionality (if applicable)
- [N/A] I have updated documentation (if applicable)

Edit from @mandarini:

**Note on behavior change**

Previously, passing `undefined` values in the `match()` query object would result in the literal string `eq.undefined` being appended as a query parameter (e.g., `?column=eq.undefined`). This was never valid PostgREST syntax and would produce errors or unexpected results.

With this change, `undefined` values are silently filtered out, matching the existing behavior in `PostgrestClient.rpc()`. While technically a behavior change, the previous behavior was broken and no one should be relying on e`q.undefined` being sent as a filter. So I am categorizing this as a fix.
