### PR TITLE
fix(realtime): revert `vsn` type to `string`

### DIFF
--- a/packages/core/realtime-js/src/RealtimeClient.ts
+++ b/packages/core/realtime-js/src/RealtimeClient.ts
@@ -15,14 +15,7 @@ import { httpEndpointURL } from './lib/transformers'
 import RealtimeChannel from './RealtimeChannel'
 import type { RealtimeChannelOptions } from './RealtimeChannel'
 import SocketAdapter from './phoenix/socketAdapter'
-import type {
-  Message,
-  SocketOptions,
-  HeartbeatCallback,
-  Encode,
-  Decode,
-  Vsn,
-} from './phoenix/types'
+import type { Message, SocketOptions, HeartbeatCallback, Encode, Decode } from './phoenix/types'
 
 type Fetch = typeof fetch
 
@@ -65,7 +58,7 @@ export type RealtimeClientOptions = {
   timeout?: number
   heartbeatIntervalMs?: number
   heartbeatCallback?: (status: HeartbeatStatus, latency?: number) => void
-  vsn?: Vsn
+  vsn?: string
   logger?: (kind: string, msg: string, data?: any) => void
   encode?: Encode<void>
   decode?: Decode<void>
@@ -672,7 +665,7 @@ export default class RealtimeClient {
     result.timeout = options?.timeout ?? DEFAULT_TIMEOUT
     result.heartbeatIntervalMs =
       options?.heartbeatIntervalMs ?? CONNECTION_TIMEOUTS.HEARTBEAT_INTERVAL
-    result.vsn = options?.vsn ?? DEFAULT_VSN
+
     // @ts-ignore - mismatch between phoenix and supabase
     result.transport = options?.transport ?? WebSocketFactory.getWebSocketConstructor()
     result.params = options?.params
@@ -687,7 +680,9 @@ export default class RealtimeClient {
     let defaultEncode: Encode<void>
     let defaultDecode: Decode<void>
 
-    switch (result.vsn) {
+    const vsn = options?.vsn ?? DEFAULT_VSN
+
+    switch (vsn) {
       case VSN_1_0_0:
         defaultEncode = (payload, callback) => {
           return callback(JSON.stringify(payload))
@@ -704,6 +699,7 @@ export default class RealtimeClient {
         throw new Error(`Unsupported serializer version: ${result.vsn}`)
     }
 
+    result.vsn = vsn
     result.encode = options?.encode ?? defaultEncode
     result.decode = options?.decode ?? defaultDecode
 


### PR DESCRIPTION
<!-- Your PR title should follow the conventional commit format:
<type>(<scope>): <description> -->

## 🔍 Description

This PR loosens typing in `RealtimeClientOptions`.

### What changed?

Revert `vsn` type back to `string`. Checks it's value later on, [the same way previous implementation did](https://github.com/supabase/supabase-js/blob/b835e3c870f3767980776cc25fd16df72fa416be/packages/core/realtime-js/src/RealtimeClient.ts#L993-L1013).

### Why was this change needed?
Fixes failing [CI in supabase/supabase](https://github.com/supabase/supabase/pull/43828)

## 🔄 Breaking changes

Changes `RealtimeClientOptions.vsn` type to `string | undefined`

## 📋 Checklist

<!-- Ensure all items are checked before submitting -->

- [x] I have read the [Contributing Guidelines](https://github.com/supabase/supabase-js/blob/master/CONTRIBUTING.md)
- [x] My PR title follows the [conventional commit format](https://www.conventionalcommits.org/): `<type>(<scope>): <description>`
- [x] I have run `npx nx format` to ensure consistent code formatting
- ~[ ] I have added tests for new functionality (if applicable)~
- ~[ ] I have updated documentation (if applicable)~
