### PR TITLE
feat(postgrest): inject permission hints for 42501, PGRST205, PGRST202 errors

### DIFF
--- a/packages/core/postgrest-js/src/PostgrestBuilder.ts
+++ b/packages/core/postgrest-js/src/PostgrestBuilder.ts
@@ -209,6 +209,11 @@ export default abstract class PostgrestBuilder<
           statusText = 'OK'
         }
 
+        if (error && !error.hint) {
+          const hint = this._getPermissionHint(error)
+          if (hint) error = { ...error, hint }
+        }
+
         if (error && this.shouldThrowOnError) {
           throw new PostgrestError(error)
         }
@@ -336,6 +341,79 @@ export default abstract class PostgrestBuilder<
    * ```
    * @returns A PostgrestBuilder instance with the new type
    */
+  private _getPermissionHint(error: { code: string; message: string }): string | null {
+    const isRpc = this.url.pathname.includes('/rpc/')
+
+    const getPrivilege = (): string => {
+      if (isRpc) return 'EXECUTE'
+      switch (this.method) {
+        case 'GET':
+        case 'HEAD':
+          return 'SELECT'
+        case 'POST':
+          return 'INSERT'
+        case 'PATCH':
+          return 'UPDATE'
+        case 'DELETE':
+          return 'DELETE'
+        default:
+          return 'SELECT'
+      }
+    }
+
+    const schema = this.schema ?? 'public'
+
+    // 42501 - PostgreSQL permission denied (supautils fallback or non-supautils environments)
+    if (error.code === '42501') {
+      const match = error.message?.match(
+        /permission denied for (?:table|view|sequence|schema|function) (\S+)/
+      )
+      if (!match) return null
+      const objectName = match[1]
+      const qualified = objectName.includes('.') ? objectName : `${schema}.${objectName}`
+      const privilege = getPrivilege()
+      return (
+        `Missing ${privilege} privilege on '${qualified}'.\n\n` +
+        `Grant it with:\n` +
+        `GRANT ${privilege} ON ${isRpc ? `FUNCTION ${qualified}` : qualified} TO anon, authenticated;\n\n` +
+        `Note: Specify only the roles that need access.`
+      )
+    }
+
+    // PGRST205 - table not found in PostgREST schema cache (could be missing perms)
+    if (error.code === 'PGRST205') {
+      const match = error.message?.match(/Could not find the table ['"]?([^'"]+)['"]?/)
+      if (!match) return null
+      const tableName = match[1]
+      const privilege = getPrivilege()
+      return (
+        `Table '${tableName}' not found. This could mean:\n` +
+        `1. The table doesn't exist, OR\n` +
+        `2. The role lacks permission to see it\n\n` +
+        `If the table exists, grant permission with:\n` +
+        `GRANT ${privilege} ON ${tableName} TO anon, authenticated;\n\n` +
+        `Note: Specify only the roles that need access.`
+      )
+    }
+
+    // PGRST202 - function not found in PostgREST schema cache (could be missing perms)
+    if (error.code === 'PGRST202') {
+      const match = error.message?.match(/Could not find the function (\S+)/)
+      if (!match) return null
+      const funcName = match[1].replace(/\(.*$/, '')
+      return (
+        `Function '${funcName}' not found. This could mean:\n` +
+        `1. The function doesn't exist, OR\n` +
+        `2. The role lacks permission to see it\n\n` +
+        `If the function exists, grant permission with:\n` +
+        `GRANT EXECUTE ON FUNCTION ${funcName} TO anon, authenticated;\n\n` +
+        `Note: Specify only the roles that need access.`
+      )
+    }
+
+    return null
+  }
+
   overrideTypes<
     NewResult,
     Options extends { merge?: boolean } = { merge: true },

--- a/packages/core/postgrest-js/test/permission-hints.test.ts
+++ b/packages/core/postgrest-js/test/permission-hints.test.ts
@@ -1,0 +1,274 @@
+import { PostgrestClient } from '../src/index'
+import { Database } from './types.override'
+
+function mockFetchWithError(body: object, status = 403) {
+  return jest.fn().mockResolvedValue({
+    ok: false,
+    status,
+    statusText: status === 403 ? 'Forbidden' : 'Not Found',
+    headers: new Headers(),
+    text: async () => JSON.stringify(body),
+  })
+}
+
+describe('Permission error hints', () => {
+  describe('42501 - permission denied', () => {
+    test('GET request injects GRANT SELECT hint', async () => {
+      const postgrest = new PostgrestClient<Database>('https://example.com', {
+        fetch: mockFetchWithError({
+          code: '42501',
+          message: 'permission denied for table test',
+          details: null,
+          hint: null,
+        }) as any,
+      })
+
+      const res = await postgrest.from('test' as any).select()
+
+      expect(res.error).toBeTruthy()
+      expect(res.error!.hint).toContain('GRANT SELECT')
+      expect(res.error!.hint).toContain('public.test')
+      expect(res.error!.hint).toContain('anon, authenticated')
+    })
+
+    test('POST request injects GRANT INSERT hint', async () => {
+      const postgrest = new PostgrestClient<Database>('https://example.com', {
+        fetch: mockFetchWithError({
+          code: '42501',
+          message: 'permission denied for table test',
+          details: null,
+          hint: null,
+        }) as any,
+      })
+
+      const res = await postgrest.from('test' as any).insert({ id: 1 } as any)
+
+      expect(res.error).toBeTruthy()
+      expect(res.error!.hint).toContain('GRANT INSERT')
+    })
+
+    test('PATCH request injects GRANT UPDATE hint', async () => {
+      const postgrest = new PostgrestClient<Database>('https://example.com', {
+        fetch: mockFetchWithError({
+          code: '42501',
+          message: 'permission denied for table test',
+          details: null,
+          hint: null,
+        }) as any,
+      })
+
+      const res = await postgrest.from('test' as any).update({ id: 1 } as any)
+
+      expect(res.error).toBeTruthy()
+      expect(res.error!.hint).toContain('GRANT UPDATE')
+    })
+
+    test('DELETE request injects GRANT DELETE hint', async () => {
+      const postgrest = new PostgrestClient<Database>('https://example.com', {
+        fetch: mockFetchWithError({
+          code: '42501',
+          message: 'permission denied for table test',
+          details: null,
+          hint: null,
+        }) as any,
+      })
+
+      const res = await postgrest.from('test' as any).delete()
+
+      expect(res.error).toBeTruthy()
+      expect(res.error!.hint).toContain('GRANT DELETE')
+    })
+
+    test('does not override existing hint', async () => {
+      const postgrest = new PostgrestClient<Database>('https://example.com', {
+        fetch: mockFetchWithError({
+          code: '42501',
+          message: 'permission denied for table test',
+          details: null,
+          hint: 'some existing hint',
+        }) as any,
+      })
+
+      const res = await postgrest.from('test' as any).select()
+
+      expect(res.error).toBeTruthy()
+      expect(res.error!.hint).toBe('some existing hint')
+    })
+
+    test('returns null hint when message does not match regex', async () => {
+      const postgrest = new PostgrestClient<Database>('https://example.com', {
+        fetch: mockFetchWithError({
+          code: '42501',
+          message: 'permission denied',
+          details: null,
+          hint: null,
+        }) as any,
+      })
+
+      const res = await postgrest.from('test' as any).select()
+
+      expect(res.error).toBeTruthy()
+      expect(res.error!.hint).toBeNull()
+    })
+
+    test('RPC path uses EXECUTE privilege', async () => {
+      const postgrest = new PostgrestClient<Database>('https://example.com', {
+        fetch: mockFetchWithError({
+          code: '42501',
+          message: 'permission denied for function my_func',
+          details: null,
+          hint: null,
+        }) as any,
+      })
+
+      const res = await postgrest.rpc('my_func' as any)
+
+      expect(res.error).toBeTruthy()
+      expect(res.error!.hint).toContain('GRANT EXECUTE')
+    })
+
+    test('custom schema is used in qualified name', async () => {
+      const postgrest = new PostgrestClient<Database>('https://example.com', {
+        schema: 'myschema' as any,
+        fetch: mockFetchWithError({
+          code: '42501',
+          message: 'permission denied for table test',
+          details: null,
+          hint: null,
+        }) as any,
+      })
+
+      const res = await postgrest.from('test' as any).select()
+
+      expect(res.error).toBeTruthy()
+      expect(res.error!.hint).toContain('myschema.test')
+    })
+
+    test('throwOnError throws PostgrestError with enhanced hint', async () => {
+      const postgrest = new PostgrestClient<Database>('https://example.com', {
+        fetch: mockFetchWithError({
+          code: '42501',
+          message: 'permission denied for table test',
+          details: null,
+          hint: null,
+        }) as any,
+      })
+
+      await expect(
+        postgrest
+          .from('test' as any)
+          .select()
+          .throwOnError()
+      ).rejects.toMatchObject({
+        hint: expect.stringContaining('GRANT SELECT'),
+      })
+    })
+  })
+
+  describe('PGRST205 - table not found in schema cache', () => {
+    test('GET request injects hint with two possibilities and GRANT SELECT', async () => {
+      const postgrest = new PostgrestClient<Database>('https://example.com', {
+        fetch: mockFetchWithError(
+          {
+            code: 'PGRST205',
+            message: "Could not find the table 'secret_table' in the schema cache",
+            details: null,
+            hint: null,
+          },
+          404
+        ) as any,
+      })
+
+      const res = await postgrest.from('secret_table' as any).select()
+
+      expect(res.error).toBeTruthy()
+      expect(res.error!.hint).toContain("Table 'secret_table' not found")
+      expect(res.error!.hint).toContain("table doesn't exist")
+      expect(res.error!.hint).toContain('lacks permission')
+      expect(res.error!.hint).toContain('GRANT SELECT')
+    })
+
+    test('does not override existing hint', async () => {
+      const postgrest = new PostgrestClient<Database>('https://example.com', {
+        fetch: mockFetchWithError(
+          {
+            code: 'PGRST205',
+            message: "Could not find the table 'secret_table' in the schema cache",
+            details: null,
+            hint: 'existing hint',
+          },
+          404
+        ) as any,
+      })
+
+      const res = await postgrest.from('secret_table' as any).select()
+
+      expect(res.error).toBeTruthy()
+      expect(res.error!.hint).toBe('existing hint')
+    })
+  })
+
+  describe('PGRST202 - function not found in schema cache', () => {
+    test('injects hint with two possibilities and GRANT EXECUTE', async () => {
+      const postgrest = new PostgrestClient<Database>('https://example.com', {
+        fetch: mockFetchWithError(
+          {
+            code: 'PGRST202',
+            message: 'Could not find the function public.secret_func(id) in the schema cache',
+            details: null,
+            hint: null,
+          },
+          404
+        ) as any,
+      })
+
+      const res = await postgrest.rpc('secret_func' as any)
+
+      expect(res.error).toBeTruthy()
+      expect(res.error!.hint).toContain("Function 'public.secret_func' not found")
+      expect(res.error!.hint).toContain("function doesn't exist")
+      expect(res.error!.hint).toContain('lacks permission')
+      expect(res.error!.hint).toContain('GRANT EXECUTE')
+    })
+
+    test('does not override existing hint', async () => {
+      const postgrest = new PostgrestClient<Database>('https://example.com', {
+        fetch: mockFetchWithError(
+          {
+            code: 'PGRST202',
+            message: 'Could not find the function public.secret_func in the schema cache',
+            details: null,
+            hint: 'existing hint',
+          },
+          404
+        ) as any,
+      })
+
+      const res = await postgrest.rpc('secret_func' as any)
+
+      expect(res.error).toBeTruthy()
+      expect(res.error!.hint).toBe('existing hint')
+    })
+  })
+
+  describe('unrelated error codes', () => {
+    test('PGRST116 hint stays null', async () => {
+      const postgrest = new PostgrestClient<Database>('https://example.com', {
+        fetch: mockFetchWithError(
+          {
+            code: 'PGRST116',
+            message: 'JSON object requested, multiple (or no) rows returned',
+            details: 'Results contain 2 rows',
+            hint: null,
+          },
+          406
+        ) as any,
+      })
+
+      const res = await postgrest.from('test' as any).select()
+
+      expect(res.error).toBeTruthy()
+      expect(res.error!.hint).toBeNull()
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Part of the `#project-default-secure` initiative. As default `GRANT` permissions are revoked from `anon`/`authenticated` roles, developers will start hitting `permission denied` errors with `"hint": null`, leaving them with no guidance on how to fix it.

This PR adds a client-side fallback that injects a helpful hint when `hint` is `null` in the error response:

- **`42501` (PostgreSQL permission denied)** — infers the required SQL privilege from the HTTP method (`GET`→`SELECT`, `POST`→`INSERT`, `PATCH`→`UPDATE`, `DELETE`→`DELETE`, RPC→`EXECUTE`) and generates a `GRANT` statement with the schema-qualified object name.
- **`PGRST205`** (table not found in schema cache) — explains both possible causes (table doesn't exist OR role lacks permission) and suggests the appropriate `GRANT`.
- **`PGRST202`** (function not found in schema cache) — same pattern for functions.

**Core invariant:** hints from PostgREST or supautils are never overridden, injection only happens when `error.hint` is `null`.

## Relationship to [supautils](https://github.com/supabase/supautils/pull/178) updates

`supautils-3.2.0` (postgres branch `supautils-3.2.0`) adds `hint_roles = 'anon, authenticated, service_role'`, which will inject DB-level hints for `42501` on Supabase-managed instances. When that lands, supautils populates `hint` and our guard (`!error.hint`) skips client-side injection entirely, no conflict.

Our `42501` fallback continues to serve:

- Self-hosted / local dev environments without supautils
- The rollout gap before `supautils-3.2.0` deploys everywhere
- PG18 views (known limitation where supautils hints don't fire)

`PGRST205` and `PGRST202` are PostgREST-level errors supautils never covers, so those hints are always client-side.

## Changes

- `packages/core/postgrest-js/src/PostgrestBuilder.ts` — hint injection logic + `_getPermissionHint` private method
- `packages/core/postgrest-js/test/permission-hints.test.ts` — 14 new unit tests