### PR TITLE
test(postgrest): verify hints get passed down

### DIFF
--- a/packages/core/postgrest-js/test/permission-hints.test.ts
+++ b/packages/core/postgrest-js/test/permission-hints.test.ts
@@ -1,0 +1,61 @@
+import { PostgrestClient } from '../src/index'
+import { Database } from './types.override'
+
+// Simulates the JSON body PostgREST returns when supautils injects a hint
+// for a 42501 (permission denied) error at the PostgreSQL executor level.
+// See: https://github.com/supabase/supautils (enhanced hints feature)
+const SUPAUTILS_42501_BODY = {
+  code: '42501',
+  message: 'permission denied for table users',
+  details: null,
+  hint: 'GRANT SELECT ON public.users TO anon;',
+}
+
+function mockFetch(body: object, status: number) {
+  return jest.fn().mockResolvedValue({
+    ok: false,
+    status,
+    statusText: 'Forbidden',
+    headers: new Headers(),
+    text: async () => JSON.stringify(body),
+  })
+}
+
+describe('postgres hint passthrough', () => {
+  test('hint from supautils is passed through to error', async () => {
+    const postgrest = new PostgrestClient<Database>('https://example.com', {
+      fetch: mockFetch(SUPAUTILS_42501_BODY, 403) as any,
+    })
+
+    const { error } = await postgrest.from('users').select()
+
+    expect(error).toMatchInlineSnapshot(`
+      {
+        "code": "42501",
+        "details": null,
+        "hint": "GRANT SELECT ON public.users TO anon;",
+        "message": "permission denied for table users",
+      }
+    `)
+  })
+
+  test('hint is included on thrown PostgrestError', async () => {
+    const postgrest = new PostgrestClient<Database>('https://example.com', {
+      fetch: mockFetch(SUPAUTILS_42501_BODY, 403) as any,
+    })
+
+    await expect(postgrest.from('users').select().throwOnError()).rejects.toMatchObject({
+      hint: 'GRANT SELECT ON public.users TO anon;',
+    })
+  })
+
+  test('null hint is passed through unchanged (supautils not active for this role)', async () => {
+    const postgrest = new PostgrestClient<Database>('https://example.com', {
+      fetch: mockFetch({ ...SUPAUTILS_42501_BODY, hint: null }, 403) as any,
+    })
+
+    const { error } = await postgrest.from('users').select()
+
+    expect(error?.hint).toBeNull()
+  })
+})

--- a/packages/core/postgrest-js/test/permission-hints.test.ts
+++ b/packages/core/postgrest-js/test/permission-hints.test.ts
@@ -2,13 +2,15 @@ import { PostgrestClient } from '../src/index'
 import { Database } from './types.override'
 
 // Simulates the JSON body PostgREST returns when supautils injects a hint
-// for a 42501 (permission denied) error at the PostgreSQL executor level.
+// for a 42501 (permission denied) error at the Postgres executor level.
+// The hint string here matches what's observed end-to-end against a project
+// running supautils >= 3.2.0.
 // See: https://github.com/supabase/supautils (enhanced hints feature)
 const SUPAUTILS_42501_BODY = {
   code: '42501',
   message: 'permission denied for table users',
   details: null,
-  hint: 'GRANT SELECT ON public.users TO anon;',
+  hint: 'Grant the required privileges to the current role with: GRANT SELECT ON public.users TO anon;',
 }
 
 function mockFetch(body: object, status: number) {
@@ -33,7 +35,7 @@ describe('postgres hint passthrough', () => {
       {
         "code": "42501",
         "details": null,
-        "hint": "GRANT SELECT ON public.users TO anon;",
+        "hint": "Grant the required privileges to the current role with: GRANT SELECT ON public.users TO anon;",
         "message": "permission denied for table users",
       }
     `)
@@ -45,7 +47,7 @@ describe('postgres hint passthrough', () => {
     })
 
     await expect(postgrest.from('users').select().throwOnError()).rejects.toMatchObject({
-      hint: 'GRANT SELECT ON public.users TO anon;',
+      hint: 'Grant the required privileges to the current role with: GRANT SELECT ON public.users TO anon;',
     })
   })
 


### PR DESCRIPTION
Adds a mock-based contract test that locks in postgrest-js' passthrough of the `hint` field on `PostgrestError`. The mock body matches what supautils >= 3.2.0 actually emits end-to-end (verified against a real Supabase project), so the test also serves as living documentation of the supautils 42501 response format.

Three cases covered: `{ data, error }` passthrough, `.throwOnError()` rejection carrying the same `hint`, and the `hint: null` case for when supautils isn't active for the role.