### PR TITLE
fix(postgrest): add type safety for eq() and neq() column names

### DIFF
--- a/packages/core/postgrest-js/src/PostgrestFilterBuilder.ts
+++ b/packages/core/postgrest-js/src/PostgrestFilterBuilder.ts
@@ -93,13 +93,6 @@ export default class PostgrestFilterBuilder<
   Relationships,
   Method
 > {
-  eq<ColumnName extends string & keyof Row>(
-    column: ColumnName,
-    value: ResolveFilterValue<Schema, Row, ColumnName> extends infer Resolved
-      ? NonNullable<Resolved>
-      : never
-  ): this
-  eq(column: string, value: unknown): this
   /**
    * Match only rows where `column` is equal to `value`.
    *
@@ -145,18 +138,24 @@ export default class PostgrestFilterBuilder<
    * }
    * ```
    */
-  eq(column: string, value: unknown): this {
-    this.url.searchParams.append(column, `eq.${value}`)
+  eq<ColumnName extends string>(
+    column: ColumnName extends keyof Row
+      ? ColumnName
+      : ColumnName extends `${string}.${string}` | `${string}->${string}`
+        ? ColumnName
+        : string extends ColumnName
+          ? string
+          : keyof Row,
+    value: ResolveFilterValue<Schema, Row, ColumnName> extends never
+      ? NonNullable<unknown>
+      : ResolveFilterValue<Schema, Row, ColumnName> extends infer ResolvedFilterValue
+        ? NonNullable<ResolvedFilterValue>
+        : never
+  ): this {
+    this.url.searchParams.append(column as string, `eq.${value}`)
     return this
   }
 
-  neq<ColumnName extends string & keyof Row>(
-    column: ColumnName,
-    value: ResolveFilterValue<Schema, Row, ColumnName> extends infer Resolved
-      ? Resolved
-      : never
-  ): this
-  neq(column: string, value: unknown): this
   /**
    * Match only rows where `column` is not equal to `value`.
    *
@@ -204,8 +203,21 @@ export default class PostgrestFilterBuilder<
    * }
    * ```
    */
-  neq(column: string, value: unknown): this {
-    this.url.searchParams.append(column, `neq.${value}`)
+  neq<ColumnName extends string>(
+    column: ColumnName extends keyof Row
+      ? ColumnName
+      : ColumnName extends `${string}.${string}` | `${string}->${string}`
+        ? ColumnName
+        : string extends ColumnName
+          ? string
+          : keyof Row,
+    value: ResolveFilterValue<Schema, Row, ColumnName> extends never
+      ? unknown
+      : ResolveFilterValue<Schema, Row, ColumnName> extends infer Resolved
+        ? Resolved
+        : never
+  ): this {
+    this.url.searchParams.append(column as string, `neq.${value}`)
     return this
   }
 

--- a/packages/core/postgrest-js/test/index.test-d.ts
+++ b/packages/core/postgrest-js/test/index.test-d.ts
@@ -19,6 +19,19 @@ const postgrestWithOptions = new PostgrestClient<DatabaseWithOptions>(REST_URL)
   postgrest.from('nonexistent_view')
 }
 
+// `.eq()` and `.neq()` reject invalid column name literals
+{
+  // @ts-expect-error Argument of type '"INVALID"' is not assignable to parameter
+  postgrest.from('users').select().eq('INVALID', 'test')
+  // @ts-expect-error Argument of type '"INVALID"' is not assignable to parameter
+  postgrest.from('users').select().neq('INVALID', 'test')
+
+  // Dynamic string variables should still work (falls through to string branch)
+  const col: string = 'username'
+  postgrest.from('users').select().eq(col, 'foo')
+  postgrest.from('users').select().neq(col, 'foo')
+}
+
 // `null` can't be used with `.eq()`
 {
   postgrest.from('users').select().eq('username', 'foo')

--- a/packages/core/postgrest-js/test/relationships-error-handling.test.ts
+++ b/packages/core/postgrest-js/test/relationships-error-handling.test.ts
@@ -212,7 +212,7 @@ test('aggregate on missing column with alias', async () => {
   const res = await postgrest
     .from('users')
     .select('alias:missing_column.count()')
-    .eq('id', 2)
+    .eq('username', 'supabot')
     .limit(1)
     .single()
   expect(res).toMatchInlineSnapshot(`


### PR DESCRIPTION
Fixes supabase/supabase#43381, Adds type safety to eq() and neq() for column names.
                                                                                                                                                                                                                                         
Builds on the original approach from @aayushbaluni, but uses a conditional type on the column parameter instead of overloads. The overload pattern doesn't actually reject invalid literals, they silently fall through to the `eq(column: string, value: unknown)` fallback. The conditional type approach closes that hole.                                                                                                                                           
                                                                       
  How it works:                                                                                                                                                                                                                          
                                                                       
  | Call | Result |
  |------|--------|
  | `.eq('username', 'foo')` |  typed value |
  | `.eq('INVALID', 'x')` | TS error not a valid column |
  | `.eq('users.status', 'ONLINE')` | relationship filter |                                                                                                                                                                           
  | `.eq('bar->version', 31)` | JSON path filter |
  | `const col: string; .eq(col, x)` | dynamic variable passes through |                                                                                                                                                               
                                                                       
Also fixes a latent type error in `relationships-error-handling.test.ts` where `.eq('id', 2)` was called on the users table (which has no id column). This was previously masked by the fallback overload.   