### PR TITLE
ci(release): restore canary releases

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -265,6 +265,7 @@
     "projects": ["packages/core/*"],
     "projectsRelationship": "fixed",
     "releaseTagPatternCheckAllBranchesWhen": true,
+    "releaseTagPatternStrictPreid": true,
     "version": {
       "conventionalCommits": true
     },


### PR DESCRIPTION
Fix canary releases, so that it checks latest preid tag, when tagging.