### PR TITLE
fix(postgrest): fix maybeSingle for all request methods by removing Accept header override

### DIFF
--- a/packages/core/postgrest-js/src/PostgrestBuilder.ts
+++ b/packages/core/postgrest-js/src/PostgrestBuilder.ts
@@ -176,9 +176,8 @@ export default abstract class PostgrestBuilder<
           count = parseInt(contentRange[1])
         }
 
-        // Temporary partial fix for https://github.com/supabase/postgrest-js/issues/361
-        // Issue persists e.g. for `.insert([...]).select().maybeSingle()`
-        if (this.isMaybeSingle && this.method === 'GET' && Array.isArray(data)) {
+        // Fix for https://github.com/supabase/postgrest-js/issues/361 — applies to all methods.
+        if (this.isMaybeSingle && Array.isArray(data)) {
           if (data.length > 1) {
             error = {
               // https://github.com/PostgREST/postgrest/blob/a867d79c42419af16c18c3fb019eba8df992626f/src/PostgREST/Error.hs#L553
@@ -220,12 +219,6 @@ export default abstract class PostgrestBuilder<
               message: body,
             }
           }
-        }
-
-        if (error && this.isMaybeSingle && error?.details?.includes('0 rows')) {
-          error = null
-          status = 200
-          statusText = 'OK'
         }
 
         if (error && this.shouldThrowOnError) {

--- a/packages/core/postgrest-js/src/PostgrestTransformBuilder.ts
+++ b/packages/core/postgrest-js/src/PostgrestTransformBuilder.ts
@@ -685,13 +685,8 @@ export default class PostgrestTransformBuilder<
   maybeSingle<
     ResultOne = Result extends (infer ResultOne)[] ? ResultOne : never,
   >(): PostgrestBuilder<ClientOptions, ResultOne | null> {
-    // Temporary partial fix for https://github.com/supabase/postgrest-js/issues/361
-    // Issue persists e.g. for `.insert([...]).select().maybeSingle()`
-    if (this.method === 'GET') {
-      this.headers.set('Accept', 'application/json')
-    } else {
-      this.headers.set('Accept', 'application/vnd.pgrst.object+json')
-    }
+    // No Accept header override — we fetch as a list and enforce cardinality client-side.
+    // Fixes https://github.com/supabase/postgrest-js/issues/361 for all request methods.
     this.isMaybeSingle = true
     return this as unknown as PostgrestBuilder<ClientOptions, ResultOne | null>
   }

--- a/packages/core/postgrest-js/test/basic.test.ts
+++ b/packages/core/postgrest-js/test/basic.test.ts
@@ -2157,29 +2157,8 @@ test('handles empty body with 404 status', async () => {
   `)
 })
 
-test('maybeSingle handles zero rows error', async () => {
-  const customFetch = jest.fn().mockImplementation(() =>
-    Promise.resolve({
-      ok: false,
-      status: 406,
-      statusText: 'Not Acceptable',
-      text: () =>
-        Promise.resolve(
-          JSON.stringify({
-            code: 'PGRST116',
-            details: '0 rows',
-            hint: null,
-            message: 'JSON object requested, multiple (or no) rows returned',
-          })
-        ),
-    })
-  )
-
-  const postgrestWithCustomFetch = new PostgrestClient<Database>(REST_URL, {
-    fetch: customFetch,
-  })
-
-  const res = await postgrestWithCustomFetch.from('users').select().maybeSingle()
+test('maybeSingle returns null for zero rows (GET)', async () => {
+  const res = await postgrest.from('users').select().eq('username', 'does_not_exist').maybeSingle()
 
   expect(res).toMatchInlineSnapshot(`
     {

--- a/packages/core/postgrest-js/test/transforms.test.ts
+++ b/packages/core/postgrest-js/test/transforms.test.ts
@@ -228,9 +228,9 @@ test('maybeSingle', async () => {
       "data": null,
       "error": {
         "code": "PGRST116",
-        "details": "The result contains 2 rows",
+        "details": "Results contain 2 rows, application/vnd.pgrst.object+json requires 1 row",
         "hint": null,
-        "message": "Cannot coerce the result to a single JSON object",
+        "message": "JSON object requested, multiple (or no) rows returned",
       },
       "status": 406,
       "statusText": "Not Acceptable",
@@ -286,7 +286,9 @@ test('csv', async () => {
     kiwicopple,,"[25,35)",OFFLINE,"'bat' 'cat'"
     awailas,,"[25,35)",ONLINE,"'bat' 'rat'"
     jsonuser,"{""foo"": {""bar"": {""nested"": ""value""}, ""baz"": ""string value""}}","[20,30)",ONLINE,"'json' 'test'"
-    dragarcia,,"[20,30)",ONLINE,"'fat' 'rat'"",
+    dragarcia,,"[20,30)",ONLINE,"'fat' 'rat'"
+    a,,,ONLINE,
+    b,,,ONLINE,",
       "error": null,
       "status": 200,
       "statusText": "OK",


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                
                                                            
- Removes the `Accept: application/vnd.pgrst.object+json` header override from `maybeSingle()` so PostgREST never sends a 406 for 0-row results                                                                                            
- Drops the `method === 'GET'` guard so client-side array cardinality enforcement applies to all methods (including `.insert().select().maybeSingle()`)
- Removes the "0 rows" string-matching fallback, which is no longer needed                                                                                                                                                             
                                                                                                                                                                                                                                         
Related https://github.com/supabase/postgrest-js/issues/361   

And thanks to https://github.com/supabase/supabase-py/pull/1424