### PR TITLE
fix(postgrest): reject excess properties in insert, update, and upsert

### DIFF
--- a/packages/core/postgrest-js/src/PostgrestQueryBuilder.ts
+++ b/packages/core/postgrest-js/src/PostgrestQueryBuilder.ts
@@ -7,6 +7,7 @@ import {
   GenericTable,
   GenericView,
 } from './types/common/common'
+import { RejectExcessProperties } from './types/types'
 
 export default class PostgrestQueryBuilder<
   ClientOptions extends ClientServerOptions,
@@ -929,7 +930,10 @@ export default class PostgrestQueryBuilder<
 
   // TODO(v3): Make `defaultToNull` consistent for both single & bulk inserts.
   insert<Row extends Relation extends { Insert: unknown } ? Relation['Insert'] : never>(
-    values: Row,
+    values: RejectExcessProperties<
+      Relation extends { Insert: unknown } ? Relation['Insert'] : never,
+      Row
+    >,
     options?: {
       count?: 'exact' | 'planned' | 'estimated'
     }
@@ -943,7 +947,10 @@ export default class PostgrestQueryBuilder<
     'POST'
   >
   insert<Row extends Relation extends { Insert: unknown } ? Relation['Insert'] : never>(
-    values: Row[],
+    values: RejectExcessProperties<
+      Relation extends { Insert: unknown } ? Relation['Insert'] : never,
+      Row
+    >[],
     options?: {
       count?: 'exact' | 'planned' | 'estimated'
       defaultToNull?: boolean
@@ -1069,7 +1076,15 @@ export default class PostgrestQueryBuilder<
    * ```
    */
   insert<Row extends Relation extends { Insert: unknown } ? Relation['Insert'] : never>(
-    values: Row | Row[],
+    values:
+      | RejectExcessProperties<
+          Relation extends { Insert: unknown } ? Relation['Insert'] : never,
+          Row
+        >
+      | RejectExcessProperties<
+          Relation extends { Insert: unknown } ? Relation['Insert'] : never,
+          Row
+        >[],
     {
       count,
       defaultToNull = true,
@@ -1118,7 +1133,10 @@ export default class PostgrestQueryBuilder<
 
   // TODO(v3): Make `defaultToNull` consistent for both single & bulk upserts.
   upsert<Row extends Relation extends { Insert: unknown } ? Relation['Insert'] : never>(
-    values: Row,
+    values: RejectExcessProperties<
+      Relation extends { Insert: unknown } ? Relation['Insert'] : never,
+      Row
+    >,
     options?: {
       onConflict?: string
       ignoreDuplicates?: boolean
@@ -1134,7 +1152,10 @@ export default class PostgrestQueryBuilder<
     'POST'
   >
   upsert<Row extends Relation extends { Insert: unknown } ? Relation['Insert'] : never>(
-    values: Row[],
+    values: RejectExcessProperties<
+      Relation extends { Insert: unknown } ? Relation['Insert'] : never,
+      Row
+    >[],
     options?: {
       onConflict?: string
       ignoreDuplicates?: boolean
@@ -1360,7 +1381,15 @@ export default class PostgrestQueryBuilder<
    */
 
   upsert<Row extends Relation extends { Insert: unknown } ? Relation['Insert'] : never>(
-    values: Row | Row[],
+    values:
+      | RejectExcessProperties<
+          Relation extends { Insert: unknown } ? Relation['Insert'] : never,
+          Row
+        >
+      | RejectExcessProperties<
+          Relation extends { Insert: unknown } ? Relation['Insert'] : never,
+          Row
+        >[],
     {
       onConflict,
       ignoreDuplicates = false,
@@ -1554,7 +1583,10 @@ export default class PostgrestQueryBuilder<
    * ```
    */
   update<Row extends Relation extends { Update: unknown } ? Relation['Update'] : never>(
-    values: Row,
+    values: RejectExcessProperties<
+      Relation extends { Update: unknown } ? Relation['Update'] : never,
+      Row
+    >,
     {
       count,
     }: {

--- a/packages/core/postgrest-js/src/types/types.ts
+++ b/packages/core/postgrest-js/src/types/types.ts
@@ -38,6 +38,12 @@ export type DatabaseWithOptions<Database, Options extends ClientServerOptions> =
 // https://twitter.com/mattpocockuk/status/1622730173446557697
 export type Prettify<T> = { [K in keyof T]: T[K] } & {}
 
+// Rejects excess properties that aren't in Base.
+// Works around TypeScript not checking excess properties on generic parameters.
+export type RejectExcessProperties<Base, Row> = Row & {
+  [K in Exclude<keyof Row, keyof Base>]: never
+}
+
 // https://github.com/sindresorhus/type-fest
 export type SimplifyDeep<Type, ExcludeType = never> = ConditionalSimplifyDeep<
   Type,

--- a/packages/core/postgrest-js/test/index.test-d.ts
+++ b/packages/core/postgrest-js/test/index.test-d.ts
@@ -173,6 +173,20 @@ const postgrestWithOptions = new PostgrestClient<DatabaseWithOptions>(REST_URL)
   postgrest.from('updatable_view').update({ non_updatable_column: 0 })
 }
 
+// reject excess properties on insert, update, and upsert (#1636)
+{
+  // @ts-expect-error No overload matches this call.
+  postgrest.from('users').insert({ username: 'foo', nonexistent: 'bad' })
+}
+{
+  // @ts-expect-error Type 'string' is not assignable to type 'never'.
+  postgrest.from('users').update({ username: 'foo', nonexistent: 'bad' })
+}
+{
+  // @ts-expect-error No overload matches this call.
+  postgrest.from('users').upsert({ username: 'foo', nonexistent: 'bad' })
+}
+
 // spread resource with single column in select query
 {
   const result = await postgrest.from('messages').select('message, ...users(status)').single()


### PR DESCRIPTION
Fixes #1636

Passing extra properties to `.insert()`, `.update()`, and `.upsert()` compiles without error but fails at runtime with a Postgres error. This happens because the generic `<Row extends Base>(values: Row)` pattern bypasses TypeScript's excess property checking.

```typescript
// Compiles fine, fails at runtime
await supabase.from('users').update({ name: 'test', nonexistent_column: 'bad' })
```

This adds a `RejectExcessProperties` utility type that maps unknown keys to `never`, catching them at compile time:

```typescript
type RejectExcessProperties<Base, Row> = Row & {
  [K in Exclude<keyof Row, keyof Base>]: never
}
```

After this fix, the example above produces a TypeScript error: `Type 'string' is not assignable to type 'never'`.

**Changes:**
- `packages/core/postgrest-js/src/types/types.ts` -- add `RejectExcessProperties` utility type
- `packages/core/postgrest-js/src/PostgrestQueryBuilder.ts` -- apply to `values` parameter in all `insert`, `update`, and `upsert` overloads
- `packages/core/postgrest-js/test/index.test-d.ts` -- type tests for excess property rejection

All 25 existing test files pass, including type tests.