### PR TITLE
fix(postgrest): narrow tstyche testFileMatch to only type test files

### DIFF
--- a/packages/core/postgrest-js/tstyche.config.json
+++ b/packages/core/postgrest-js/tstyche.config.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://tstyche.org/schemas/config.json",
   "tsconfig": "tsconfig.tstyche.json",
-  "testFileMatch": ["./test/**/*.test.ts", "./test/**/*.test-d.ts"],
+  "testFileMatch": ["./test/**/*.test-d.ts"],
   "checkSourceFiles": false,
   "checkSuppressedErrors": true
 }

--- a/packages/core/supabase-js/package.json
+++ b/packages/core/supabase-js/package.json
@@ -57,7 +57,7 @@
     "test:unit": "jest --runInBand --detectOpenHandles test/unit",
     "test:coverage": "jest --runInBand --coverage --testPathIgnorePatterns=\"test/integration|test/deno\"",
     "test:integration": "jest --runInBand --detectOpenHandles test/integration.test.ts",
-    "test:integration:browser": "deno test --allow-all test/integration.browser.test.ts",
+    "test:integration:browser": "deno test --node-modules-dir=none --allow-all test/integration.browser.test.ts",
     "test:edge-functions": "cd test/deno && npm run test:edge-functions",
     "test:deno": "cd test/deno && npm run test",
     "test:watch": "jest --watch --verbose false --silent false",

--- a/packages/core/supabase-js/package.json
+++ b/packages/core/supabase-js/package.json
@@ -57,7 +57,7 @@
     "test:unit": "jest --runInBand --detectOpenHandles test/unit",
     "test:coverage": "jest --runInBand --coverage --testPathIgnorePatterns=\"test/integration|test/deno\"",
     "test:integration": "jest --runInBand --detectOpenHandles test/integration.test.ts",
-    "test:integration:browser": "deno test --node-modules-dir=none --allow-all test/integration.browser.test.ts",
+    "test:integration:browser": "deno test --node-modules-dir=auto --allow-all test/integration.browser.test.ts",
     "test:edge-functions": "cd test/deno && npm run test:edge-functions",
     "test:deno": "cd test/deno && npm run test",
     "test:watch": "jest --watch --verbose false --silent false",

--- a/packages/core/supabase-js/package.json
+++ b/packages/core/supabase-js/package.json
@@ -57,7 +57,7 @@
     "test:unit": "jest --runInBand --detectOpenHandles test/unit",
     "test:coverage": "jest --runInBand --coverage --testPathIgnorePatterns=\"test/integration|test/deno\"",
     "test:integration": "jest --runInBand --detectOpenHandles test/integration.test.ts",
-    "test:integration:browser": "deno test --node-modules-dir=auto --allow-all test/integration.browser.test.ts",
+    "test:integration:browser": "deno test --node-modules-dir=manual --allow-all test/integration.browser.test.ts",
     "test:edge-functions": "cd test/deno && npm run test:edge-functions",
     "test:deno": "cd test/deno && npm run test",
     "test:watch": "jest --watch --verbose false --silent false",

--- a/packages/core/supabase-js/test/integration.browser.test.ts
+++ b/packages/core/supabase-js/test/integration.browser.test.ts
@@ -1,7 +1,7 @@
 import { serve } from 'https://deno.land/std@0.192.0/http/server.ts'
 import { assertEquals } from 'https://deno.land/std@0.224.0/testing/asserts.ts'
 import { describe, it, beforeAll, afterAll } from 'https://deno.land/std@0.224.0/testing/bdd.ts'
-import { Browser, Page, launch } from 'npm:puppeteer@24.9.0'
+import { Browser, Page, launch } from 'npm:puppeteer@24.19.0'
 import { sleep } from 'https://deno.land/x/sleep/mod.ts'
 
 const stderr = 'inherit'
@@ -90,7 +90,11 @@ const content = `<html>
 `
 
 beforeAll(async () => {
-  await new Deno.Command('supabase', { args: ['start'], stderr }).output()
+  try {
+    await new Deno.Command('npx', { args: ['supabase', 'start'], stderr }).output()
+  } catch {
+    // supabase may already be running (e.g. in CI) or not available via PATH
+  }
   await new Deno.Command('npm', { args: ['install'], stderr }).output()
   await new Deno.Command('npm', {
     args: ['run', 'build'],


### PR DESCRIPTION
PR #2183 broke CI in three ways. This fixes all of them.

## Fix 1: tstyche picking up jest test files (postgrest-js)

`tstyche.config.json` had `testFileMatch` set to `["./test/**/*.test.ts", "./test/**/*.test-d.ts"]`, which caused tstyche to pick up regular jest test files in addition to the intended type-level test files (`.test-d.ts`).

This was dormant until the `flatted` 3.3.3 to 3.4.2 bump, which shipped `typescript@^5.9.3` as a devDependency, signaling that TypeScript 5.9 was released and making tstyche's `--target latest` in CI resolve to it. TypeScript 5.9 is stricter about global type resolution, so the jest test files now fail under tstyche because `tsconfig.tstyche.json` has no `@types/jest` or `@types/node`.

The fix removes `./test/**/*.test.ts` from `testFileMatch`. Jest tests are not tstyche type tests and should never have been included.

## Fix 2: Deno browser test failing to find puppeteer (supabase-js)

The CI workflow uses `deno-version: 2.x`, which always installs the latest Deno 2.x release. A new Deno 2.x version (2.7.8) shipped around the same time as the flatted bump and changed how it resolves npm packages: it no longer traverses up to the workspace root to find hoisted packages, and instead requires a local `node_modules/`.

The fix uses `--node-modules-dir=manual`, which tells Deno to read existing `node_modules/` directories (traversing up to the workspace root where puppeteer lives) without creating or modifying anything. This avoids the `node_modules/.deno/` pollution that `--node-modules-dir=auto` caused, which was breaking Nx's project graph builder.

The puppeteer import in the test is also updated from `24.9.0` to `24.19.0` to match the version installed in the workspace, so the Chrome version pre-installed by the workflow matches what the test expects.

## Fix 3: supabase binary not found in the browser test beforeAll (supabase-js)

`new Deno.Command('supabase', ...)` in the test's `beforeAll` fails because Deno does not add `node_modules/.bin` to PATH when spawning subprocesses. The call is redundant in CI since supabase is already started by the setup step, but is useful for local development.

The fix wraps it in a try/catch using `npx supabase` so it works locally and fails silently in CI where supabase is already running.