### PR TITLE
feat(realtime): add `copyBindings` functionality

### DIFF
--- a/packages/core/realtime-js/src/RealtimeChannel.ts
+++ b/packages/core/realtime-js/src/RealtimeChannel.ts
@@ -1055,7 +1055,7 @@ export default class RealtimeChannel {
 
   copyBindings(other: RealtimeChannel) {
     if (this.joinedOnce) {
-        throw new Error("cannot copy bindings into joined channel")
+      throw new Error('cannot copy bindings into joined channel')
     }
     for (const kind in other.bindings) {
       for (const binding of other.bindings[kind]) {

--- a/packages/core/realtime-js/test/RealtimeChannel.messaging.test.ts
+++ b/packages/core/realtime-js/test/RealtimeChannel.messaging.test.ts
@@ -1,7 +1,12 @@
 import assert from 'assert'
 import { describe, test, beforeEach, afterEach, vi, expect } from 'vitest'
 import type RealtimeChannel from '../src/RealtimeChannel'
-import { DEFAULT_API_KEY, setupRealtimeTest, waitForChannelSubscribed, type TestSetup } from './helpers/setup'
+import {
+  DEFAULT_API_KEY,
+  setupRealtimeTest,
+  waitForChannelSubscribed,
+  type TestSetup,
+} from './helpers/setup'
 import { VSN_2_0_0 } from '../src/lib/constants'
 let testSetup: TestSetup
 
@@ -148,14 +153,14 @@ describe('on', () => {
   })
 })
 
-describe("copyBindings", () => {
-  let firstChannel: RealtimeChannel;
-  let secondChannel: RealtimeChannel;
+describe('copyBindings', () => {
+  let firstChannel: RealtimeChannel
+  let secondChannel: RealtimeChannel
 
   beforeEach(() => {
     testSetup = setupRealtimeTest()
-    firstChannel = testSetup.client.channel("test")
-    secondChannel = testSetup.client.channel("test-copy")
+    firstChannel = testSetup.client.channel('test')
+    secondChannel = testSetup.client.channel('test-copy')
   })
 
   afterEach(() => {
@@ -164,10 +169,12 @@ describe("copyBindings", () => {
     testSetup.cleanup()
   })
 
-  test("throws if channel is subscribed", () => {
+  test('throws if channel is subscribed', () => {
     secondChannel.subscribe()
     waitForChannelSubscribed(secondChannel)
-    expect(() => secondChannel.copyBindings(firstChannel)).toThrow(/cannot copy bindings into joined channel/)
+    expect(() => secondChannel.copyBindings(firstChannel)).toThrow(
+      /cannot copy bindings into joined channel/
+    )
   })
 
   test('copies broadcast bindings', () => {
@@ -224,7 +231,7 @@ describe("copyBindings", () => {
   })
 
   test('copies bindings from unsubscribed channel to new channel with same topic', async () => {
-    secondChannel.unsubscribe();
+    secondChannel.unsubscribe()
 
     const callback = vi.fn()
     firstChannel.on('broadcast', { event: 'test' }, callback)
@@ -233,7 +240,7 @@ describe("copyBindings", () => {
     await waitForChannelSubscribed(firstChannel)
     await firstChannel.unsubscribe()
 
-    secondChannel = testSetup.client.channel("test")
+    secondChannel = testSetup.client.channel('test')
     secondChannel.copyBindings(firstChannel)
 
     secondChannel.subscribe()


### PR DESCRIPTION
<!-- Your PR title should follow the conventional commit format:
<type>(<scope>): <description> -->

## 🔍 Description

This PR adds function that allows copying bindings from one channel to the other.

### Why was this change needed?

Since `resubscibe` wasn't working (and isn't possible with phoenix) this allows end-users to reuse bindigs between old and newly created channels.

## 🔄 Breaking changes

- [x] This PR contains no breaking changes

## 📋 Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/supabase/supabase-js/blob/master/CONTRIBUTING.md)
- [x] My PR title follows the [conventional commit format](https://www.conventionalcommits.org/): `<type>(<scope>): <description>`
- [x] I have run `npx nx format` to ensure consistent code formatting
- [x] I have added tests for new functionality (if applicable)
- [ ] I have updated documentation (if applicable)