### PR TITLE
ci(release): fix canary versioning to respect commit type (feat→preminor, fix→prepatch

### DIFF
--- a/scripts/release-canary.ts
+++ b/scripts/release-canary.ts
@@ -1,5 +1,6 @@
 import { releaseVersion, releaseChangelog, releasePublish } from 'nx/release'
 import { execSync } from 'child_process'
+import { getLastStableTag } from './utils'
 ;(async () => {
   const { workspaceVersion: canaryCheckWorkspaceVersion } = await releaseVersion({
     verbose: true,
@@ -16,11 +17,24 @@ import { execSync } from 'child_process'
     process.exit(0)
   }
 
+  // Derive the correct pre* specifier from conventional commits rather than
+  // always using 'prerelease' (which always bumps patch regardless of commit type).
+  const lastStableTag = getLastStableTag()
+  const stableBase = lastStableTag.replace(/^v/, '') // e.g. "2.100.0"
+  const [curMajor, curMinor] = stableBase.split('.').map(Number)
+  const dryBase = canaryCheckWorkspaceVersion.replace(/^v/, '').replace(/-.*$/, '')
+  const [newMajor, newMinor] = dryBase.split('.').map(Number)
+
+  let specifier: 'prepatch' | 'preminor' | 'premajor'
+  if (newMajor > curMajor) specifier = 'premajor'
+  else if (newMinor > curMinor) specifier = 'preminor'
+  else specifier = 'prepatch'
+
   const { workspaceVersion, projectsVersionData } = await releaseVersion({
     verbose: true,
     gitCommit: false,
     stageChanges: false,
-    specifier: 'prerelease',
+    specifier,
     preid: 'canary',
   })
 

--- a/scripts/utils.ts
+++ b/scripts/utils.ts
@@ -1,0 +1,22 @@
+import { execSync } from 'child_process'
+
+export function getLastStableTag(): string {
+  try {
+    return execSync(
+      `git tag --list --sort=-version:refname | grep -E '^v?[0-9]+\\.[0-9]+\\.[0-9]+$' | head -n1`
+    )
+      .toString()
+      .trim()
+  } catch {
+    return ''
+  }
+}
+
+export function getArg(name: string): string | undefined {
+  // supports --name=value and --name value
+  const idx = process.argv.findIndex((a) => a === `--${name}` || a.startsWith(`--${name}=`))
+  if (idx === -1) return undefined
+  const token = process.argv[idx]
+  if (token.includes('=')) return token.split('=')[1]
+  return process.argv[idx + 1]
+}


### PR DESCRIPTION
The canary release script was always using `specifier: 'prerelease'` when calling `nx releaseVersion`, which bumps only the patch segment regardless of whether the triggering commits were `feat:` (minor) or `fix:` (patch). This meant a `feat:` commit on master would publish e.g. `2.100.1-canary.0` instead of the correct `2.101.0-canary.0`.

This fix performs a dry-run first to let Nx determine the intended semver bump, then compares the result against the last stable git tag to derive the correct pre-release specifier (`prepatch`, `preminor`, or `premajor`) before running the real release.