### PR TITLE
 fix(storage): set correct content-type for uploads

### DIFF
--- a/packages/core/storage-js/src/lib/common/BaseApiClient.ts
+++ b/packages/core/storage-js/src/lib/common/BaseApiClient.ts
@@ -30,7 +30,7 @@ export default abstract class BaseApiClient<TError extends StorageError = Storag
     namespace: ErrorNamespace = 'storage'
   ) {
     this.url = url
-    this.headers = headers
+    this.headers = Object.fromEntries(Object.entries(headers).map(([k, v]) => [k.toLowerCase(), v]))
     this.fetch = resolveFetch(fetch)
     this.namespace = namespace
   }
@@ -55,7 +55,7 @@ export default abstract class BaseApiClient<TError extends StorageError = Storag
    * @returns this - For method chaining
    */
   public setHeader(name: string, value: string): this {
-    this.headers = { ...this.headers, [name]: value }
+    this.headers = { ...this.headers, [name.toLowerCase()]: value }
     return this
   }
 

--- a/packages/core/storage-js/src/packages/StorageFileApi.ts
+++ b/packages/core/storage-js/src/packages/StorageFileApi.ts
@@ -112,7 +112,7 @@ export default class StorageFileApi extends BaseApiClient<StorageError> {
       } else {
         body = fileBody
         headers['cache-control'] = `max-age=${options.cacheControl}`
-        headers = this.setRequestHeader(headers, 'Content-Type', options.contentType as string)
+        headers['content-type'] = options.contentType as string
 
         if (metadata) {
           headers['x-metadata'] = this.toBase64(this.encodeMetadata(metadata))
@@ -266,7 +266,7 @@ export default class StorageFileApi extends BaseApiClient<StorageError> {
     return this.handleOperation(async () => {
       let body
       const options = { ...DEFAULT_FILE_OPTIONS, ...fileOptions }
-      let headers: Record<string, string> = {
+      const headers: Record<string, string> = {
         ...this.headers,
         ...{ 'x-upsert': String(options.upsert as boolean) },
       }
@@ -281,26 +281,13 @@ export default class StorageFileApi extends BaseApiClient<StorageError> {
       } else {
         body = fileBody
         headers['cache-control'] = `max-age=${options.cacheControl}`
-        headers = this.setRequestHeader(headers, 'Content-Type', options.contentType as string)
+        headers['content-type'] = options.contentType as string
       }
 
       const data = await put(this.fetch, url.toString(), body as object, { headers })
 
       return { path: cleanPath, fullPath: data.Key }
     })
-  }
-
-  private setRequestHeader(headers: Record<string, string>, name: string, value: string) {
-    const nextHeaders = { ...headers }
-
-    for (const key of Object.keys(nextHeaders)) {
-      if (key.toLowerCase() === name.toLowerCase()) {
-        delete nextHeaders[key]
-      }
-    }
-
-    nextHeaders[name] = value
-    return nextHeaders
   }
 
   /**

--- a/packages/core/storage-js/test/storageFileApi.test.ts
+++ b/packages/core/storage-js/test/storageFileApi.test.ts
@@ -1009,9 +1009,29 @@ describe('StorageFileApi Edge Cases', () => {
       expect(mockPost).toHaveBeenCalled()
       const [, , , { headers }] = mockPost.mock.calls[0]
 
-      expect(headers['Content-Type']).toBe('image/png')
-      expect(headers['content-type']).toBeUndefined()
-      expect(new Headers(headers).get('Content-Type')).toBe('image/png')
+      expect(headers['content-type']).toBe('image/png')
+      expect(headers['Content-Type']).toBeUndefined()
+      expect(new Headers(headers).get('content-type')).toBe('image/png')
+    })
+
+    test('uploadToSignedUrl prefers file content type over existing content type header', async () => {
+      const clientWithContentType = new StorageClient('http://localhost:8000/storage/v1', {
+        apikey: 'test-token',
+        'Content-Type': 'application/json',
+      })
+
+      await clientWithContentType
+        .from('test-bucket')
+        .uploadToSignedUrl('test-path', 'test-token', 'test content', {
+          contentType: 'image/png',
+        })
+
+      expect(mockPut).toHaveBeenCalled()
+      const [, , , { headers }] = mockPut.mock.calls[0]
+
+      expect(headers['content-type']).toBe('image/png')
+      expect(headers['Content-Type']).toBeUndefined()
+      expect(new Headers(headers).get('content-type')).toBe('image/png')
     })
   })
 })


### PR DESCRIPTION
Moved from https://github.com/supabase/supabase-js/pull/2209

## Description

### What changed?

- In `BaseApiClient`, all header keys are now normalized to lowercase at initialization time, and `setHeader` also lowercases the key before storing
- Added 2 unit tests to `storageFileApi.test.ts` verifying that `upload` and `uploadToSignedUrl` correctly use the file-specific `contentType` over any globally configured `Content-Type` header

### Why was this change needed?

When users configure a global `Content-Type` header on the Supabase client (e.g. `'Content-Type': 'application/json'`), storage upload requests ended up with two conflicting header entries because the global header key and the upload-specific key had different casing. Since JavaScript object keys are case-sensitive, `Content-Type` and `content-type` were treated as distinct keys and both were sent in the request.

Lowercasing all header keys at storage time ensures that when the upload sets `content-type: image/png`, it overwrites the global `Content-Type: application/json` entry rather than sitting alongside it.

Closes #2207

## Screenshots/Examples

Before (broken):
```ts
const supabase = createClient(url, key, {
  global: { headers: { 'Content-Type': 'application/json' } }
})

// Would send both Content-Type: application/json AND content-type: image/png
await supabase.storage.from('bucket').upload('path', file, { contentType: 'image/png' })
```

After (fixed): the upload correctly sends only `content-type: image/png`.

## Breaking changes

- [ ] This PR contains no breaking changes

## Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/supabase/supabase-js/blob/master/CONTRIBUTING.md)
- [x] My PR title follows the [conventional commit format](https://www.conventionalcommits.org/): `<type>(<scope>): <description>`
- [x] I have run `npx nx format` to ensure consistent code formatting
- [x] I have added tests for new functionality (if applicable)
- [ ] I have updated documentation (if applicable)

## Additional notes

The fix applies case normalization at the storage client layer (`BaseApiClient`), so any header key variant (`Content-Type`, `content-type`, `CONTENT-TYPE`) is stored uniformly as lowercase. This is consistent with how HTTP headers are defined to be case-insensitive.