### PR TITLE
fix(postgrest): add toJSON to PostgrestError for correct JSON serialization

### DIFF
--- a/packages/core/postgrest-js/src/PostgrestError.ts
+++ b/packages/core/postgrest-js/src/PostgrestError.ts
@@ -28,4 +28,14 @@ export default class PostgrestError extends Error {
     this.hint = context.hint
     this.code = context.code
   }
+
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+      details: this.details,
+      hint: this.hint,
+      code: this.code,
+    }
+  }
 }

--- a/packages/core/postgrest-js/test/fetch-errors.test.ts
+++ b/packages/core/postgrest-js/test/fetch-errors.test.ts
@@ -1,4 +1,5 @@
 import { PostgrestClient } from '../src/index'
+import PostgrestError from '../src/PostgrestError'
 import { Database } from './types.override'
 
 describe('Fetch error handling', () => {
@@ -186,5 +187,20 @@ describe('Fetch error handling', () => {
     expect(options.method).toBe('POST')
     expect(JSON.parse(options.body)).toEqual({ obj_arg: { nested: 'value' } })
     expect(options.headers.get('Prefer')).toContain('return=minimal')
+  })
+
+  test('PostgrestError serializes message with JSON.stringify', () => {
+    const err = new PostgrestError({
+      message: 'RLS denied',
+      details: 'some details',
+      hint: 'check policies',
+      code: 'PGRST301',
+    })
+    const serialized = JSON.parse(JSON.stringify(err))
+    expect(serialized.message).toBe('RLS denied')
+    expect(serialized.code).toBe('PGRST301')
+    expect(serialized.details).toBe('some details')
+    expect(serialized.hint).toBe('check policies')
+    expect(serialized.name).toBe('PostgrestError')
   })
 })


### PR DESCRIPTION
`PostgrestError` extends `Error`, so its `message` property is non-enumerable and silently dropped by `JSON.stringify`, causing errors to appear as `{}` in structured logs. This adds a `toJSON()` method to `PostgrestError` so all fields are included when serialized, matching the pattern already used by `StorageApiError` and `AuthImplicitGrantRedirectError`.