### PR TITLE
fix(auth): downgrade console.error to console.warn for missing session

### DIFF
--- a/packages/core/auth-js/src/GoTrueClient.ts
+++ b/packages/core/auth-js/src/GoTrueClient.ts
@@ -4007,7 +4007,11 @@ export default class GoTrueClient {
       } catch (err) {
         await this.stateChangeEmitters.get(id)?.callback('INITIAL_SESSION', null)
         this._debug('INITIAL_SESSION', 'callback id', id, 'error', err)
-        console.error(err)
+        if (isAuthSessionMissingError(err)) {
+          console.warn(err)
+        } else {
+          console.error(err)
+        }
       }
     })
   }


### PR DESCRIPTION
In `_emitInitialSession`, a missing or expired session on `onAuthStateChange` listener init was being logged with `console.error`, flooding error monitoring services with false positives. This changes the log level to `console.warn` for `AuthSessionMissingError` (an expected state for logged-out users), while keeping `console.error` for genuinely unexpected errors.

Fixes #1679