### PR TITLE
fix(postgrest): allow Record<string, any> in insert, update, and upsert

### DIFF
--- a/packages/core/postgrest-js/src/types/types.ts
+++ b/packages/core/postgrest-js/src/types/types.ts
@@ -42,9 +42,12 @@ export type Prettify<T> = { [K in keyof T]: T[K] } & {}
 
 // Rejects excess properties that aren't in Base.
 // Works around TypeScript not checking excess properties on generic parameters.
-export type RejectExcessProperties<Base, Row> = Row & {
-  [K in Exclude<keyof Row, keyof Base>]: never
-}
+// If Row has a string index signature (e.g. Record<string, any>), skip the check —
+// string extends keyof Row is true in that case, and applying the check would
+// produce { [x: string]: never } which conflicts with the index signature.
+export type RejectExcessProperties<Base, Row> = string extends keyof Row
+  ? Row
+  : Row & { [K in Exclude<keyof Row, keyof Base>]: never }
 
 // https://github.com/sindresorhus/type-fest
 export type SimplifyDeep<Type, ExcludeType = never> = ConditionalSimplifyDeep<

--- a/packages/core/postgrest-js/test/index.test-d.ts
+++ b/packages/core/postgrest-js/test/index.test-d.ts
@@ -187,6 +187,22 @@ const postgrestWithOptions = new PostgrestClient<DatabaseWithOptions>(REST_URL)
   postgrest.from('users').upsert({ username: 'foo', nonexistent: 'bad' })
 }
 
+// allow loosely-typed Record<string, *> on insert, update, and upsert
+// regression: RejectExcessProperties must not produce { [x: string]: never }
+// when the caller already has a string index signature
+{
+  const data: Record<string, unknown> = { username: 'foo' }
+  postgrest.from('users').insert(data)
+  postgrest.from('users').update(data)
+  postgrest.from('users').upsert(data)
+}
+{
+  const data: Record<string, any> = { username: 'foo' }
+  postgrest.from('users').insert(data)
+  postgrest.from('users').update(data)
+  postgrest.from('users').upsert(data)
+}
+
 // spread resource with single column in select query
 {
   const result = await postgrest.from('messages').select('message, ...users(status)').single()


### PR DESCRIPTION
`RejectExcessProperties` was producing `{ [x: string]: never }` when the caller passed a `Record<string, any>` or `Record<string, unknown>`, because string index signatures cause `Exclude<keyof Row, keyof Base>` to resolve to string. Skip the check when Row already has a string index signature, those callers have opted out of strict typing anyway.                                                                           
                                                                                                                                  
 Adds regression test cases for both `Record<string, any>` and`Record<string, unknown>` to prevent future breakage.    