### PR TITLE
fix(storage): apply empty transform check to download and getPublicUrl

### DIFF
--- a/packages/core/storage-js/src/packages/StorageFileApi.ts
+++ b/packages/core/storage-js/src/packages/StorageFileApi.ts
@@ -817,7 +817,10 @@ export default class StorageFileApi extends BaseApiClient<StorageError> {
     options?: Options,
     parameters?: FetchParameters
   ): BlobDownloadBuilder {
-    const wantsTransformation = typeof options?.transform !== 'undefined'
+    const wantsTransformation =
+      typeof options?.transform === 'object' &&
+      options.transform !== null &&
+      Object.keys(options.transform).length > 0
     const renderPath = wantsTransformation ? 'render/image/authenticated' : 'object'
     const transformationQuery = this.transformOptsToQueryString(options?.transform || {})
     const queryString = transformationQuery ? `?${transformationQuery}` : ''
@@ -1006,7 +1009,10 @@ export default class StorageFileApi extends BaseApiClient<StorageError> {
       _queryString.push(downloadQueryParam)
     }
 
-    const wantsTransformation = typeof options?.transform !== 'undefined'
+    const wantsTransformation =
+      typeof options?.transform === 'object' &&
+      options.transform !== null &&
+      Object.keys(options.transform).length > 0
     const renderPath = wantsTransformation ? 'render/image' : 'object'
     const transformationQuery = this.transformOptsToQueryString(options?.transform || {})
 

--- a/packages/core/storage-js/test/storageFileApi.test.ts
+++ b/packages/core/storage-js/test/storageFileApi.test.ts
@@ -652,9 +652,11 @@ describe('Object API', () => {
     })
 
     it('download with empty transform object does not use render endpoint', async () => {
-      await storage.from(bucketName).upload(uploadPath, file)
+      const txtFile = await fsp.readFile(uploadFilePath('file.txt'))
+      const txtPath = `testpath/file-${Date.now()}.txt`
+      await storage.from(bucketName).upload(txtPath, txtFile)
 
-      const res = await storage.from(bucketName).download(uploadPath, {
+      const res = await storage.from(bucketName).download(txtPath, {
         transform: {},
       })
 

--- a/packages/core/storage-js/test/storageFileApi.test.ts
+++ b/packages/core/storage-js/test/storageFileApi.test.ts
@@ -624,6 +624,14 @@ describe('Object API', () => {
       )
     })
 
+    it('gets public url with empty transform object does not use render endpoint', () => {
+      const res = storage.from(bucketName).getPublicUrl(uploadPath, {
+        transform: {},
+      })
+      expect(res.data.publicUrl).toContain(`${URL}/object/public/${bucketName}/${uploadPath}`)
+      expect(res.data.publicUrl).not.toContain('/render/image/')
+    })
+
     it('will download an authenticated transformed file', async () => {
       const privateBucketName = 'my-private-bucket'
       await findOrCreateBucket(privateBucketName)
@@ -641,6 +649,17 @@ describe('Object API', () => {
       expect(res.error).toBeNull()
       expect(res.data?.size).toBeGreaterThan(0)
       expect(res.data?.type).toEqual('image/jpeg')
+    })
+
+    it('download with empty transform object does not use render endpoint', async () => {
+      await storage.from(bucketName).upload(uploadPath, file)
+
+      const res = await storage.from(bucketName).download(uploadPath, {
+        transform: {},
+      })
+
+      expect(res.error).toBeNull()
+      expect(res.data?.size).toBeGreaterThan(0)
     })
   })
 


### PR DESCRIPTION
Fixes #2218

PR #2162 fixed `createSignedUrl()` to reject empty transform objects, but `download()` and `getPublicUrl()` still use the old `typeof options?.transform !== 'undefined'` check. Since `typeof {} !== 'undefined'` is `true`, passing an empty transform object routes requests through `/render/image/` instead of `/object/`, causing 422 errors for non-image files.

This applies the same `Object.keys` check from `createSignedUrl` to both methods.