### PR TITLE
fix(storage): avoid duplicate content-type headers in vector requests

### DIFF
--- a/packages/core/storage-js/src/lib/common/fetch.ts
+++ b/packages/core/storage-js/src/lib/common/fetch.ts
@@ -95,7 +95,16 @@ const _getRequestParams = (
   }
 
   if (isPlainObject(body)) {
-    params.headers = { 'Content-Type': 'application/json', ...options?.headers }
+    const headers = options?.headers || {}
+    let contentType: string | undefined
+
+    for (const [key, value] of Object.entries(headers)) {
+      if (key.toLowerCase() === 'content-type') {
+        contentType = value
+      }
+    }
+
+    params.headers = setRequestHeader(headers, 'Content-Type', contentType ?? 'application/json')
     params.body = JSON.stringify(body)
   } else {
     params.body = body
@@ -106,6 +115,19 @@ const _getRequestParams = (
   }
 
   return { ...params, ...parameters }
+}
+
+function setRequestHeader(headers: Record<string, string>, name: string, value: string) {
+  const nextHeaders = { ...headers }
+
+  for (const key of Object.keys(nextHeaders)) {
+    if (key.toLowerCase() === name.toLowerCase()) {
+      delete nextHeaders[key]
+    }
+  }
+
+  nextHeaders[name] = value
+  return nextHeaders
 }
 
 /**

--- a/packages/core/storage-js/test/bucket-api.spec.ts
+++ b/packages/core/storage-js/test/bucket-api.spec.ts
@@ -279,7 +279,7 @@ describe('VectorBucketApi JSON headers', () => {
 
     const client = new StorageVectorsClient('https://mock.example.com', {
       fetch: mockFetch as any,
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'content-Type': 'application/json' },
     })
 
     await client.createBucket('test-bucket')

--- a/packages/core/storage-js/test/bucket-api.spec.ts
+++ b/packages/core/storage-js/test/bucket-api.spec.ts
@@ -11,6 +11,7 @@ import {
   assertErrorResponse,
   assertErrorCode,
 } from './helpers'
+import { StorageVectorsClient } from '../src/packages/StorageVectorsClient'
 
 describe('VectorBucketApi Integration Tests', () => {
   let client: ReturnType<typeof createTestClient>
@@ -264,5 +265,31 @@ describe('VectorBucketApi Integration Tests', () => {
       expect(typeof bucketScope.listIndexes).toBe('function')
       expect(typeof bucketScope.index).toBe('function')
     })
+  })
+})
+
+describe('VectorBucketApi JSON headers', () => {
+  it('uses a single content-type header for JSON requests', async () => {
+    const mockFetch = jest.fn().mockResolvedValue(
+      new Response(JSON.stringify({}), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    )
+
+    const client = new StorageVectorsClient('https://mock.example.com', {
+      fetch: mockFetch as any,
+      headers: { 'Content-Type': 'application/json' },
+    })
+
+    await client.createBucket('test-bucket')
+
+    const [, request] = mockFetch.mock.calls[0]
+    const headers = request.headers as Record<string, string>
+
+    expect(Object.keys(headers).filter((key) => key.toLowerCase() === 'content-type')).toHaveLength(
+      1
+    )
+    expect(new Headers(headers).get('content-type')).toBe('application/json')
   })
 })

--- a/packages/core/storage-js/test/common/fetch.test.ts
+++ b/packages/core/storage-js/test/common/fetch.test.ts
@@ -153,6 +153,33 @@ describe('Common Fetch', () => {
         })
       })
 
+      it('should keep a single content-type header for JSON requests', async () => {
+        const requestBody = { data: 'test' }
+        const responseData = { result: 'created' }
+        mockFetch.mockResolvedValue(
+          new MockResponse(JSON.stringify(responseData), {
+            status: 201,
+            statusText: 'Created',
+          })
+        )
+
+        await post(mockFetch, 'http://test.com/api', requestBody, {
+          headers: {
+            Authorization: 'Bearer token',
+            'content-type': 'application/vnd.custom+json',
+          },
+        })
+
+        expect(mockFetch).toHaveBeenCalledWith('http://test.com/api', {
+          method: 'POST',
+          headers: {
+            Authorization: 'Bearer token',
+            'Content-Type': 'application/vnd.custom+json',
+          },
+          body: JSON.stringify(requestBody),
+        })
+      })
+
       it('should handle non-plain object bodies', async () => {
         const formData = new FormData()
         const responseData = { result: 'created' }


### PR DESCRIPTION
## TL;DR

fixes a regression from #2211 where vector json requests could end up with both `Content-Type` and `content-type`

## Problem

that PR lowercased stored headers in `BaseApiClient`

plain object json requests in the shared fetch layer still added `Content-Type`
 without checking for an existing lowercase `content-type`

that could leave both on the same request

## Solution

make the shared fetch layer handle `Content-Type` case insensitively for json requests


## Related

follow up to
- #2211 which closed
-  https://github.com/supabase/supabase-js/issues/2207
