### PR TITLE
feat(supabase): export PostgrestFilterBuilder and StorageApiError from supabase-js

### DIFF
--- a/packages/core/supabase-js/src/index.ts
+++ b/packages/core/supabase-js/src/index.ts
@@ -7,8 +7,13 @@ export type {
   PostgrestResponse,
   PostgrestSingleResponse,
   PostgrestMaybeSingleResponse,
+  PostgrestBuilder,
+  PostgrestFilterBuilder,
+  PostgrestTransformBuilder,
+  PostgrestQueryBuilder,
 } from '@supabase/postgrest-js'
 export { PostgrestError } from '@supabase/postgrest-js'
+export { StorageApiError } from '@supabase/storage-js'
 export type { FunctionInvokeOptions } from '@supabase/functions-js'
 export {
   FunctionsHttpError,


### PR DESCRIPTION
Re-exports `PostgrestFilterBuilder`, `PostgrestTransformBuilder`, `PostgrestQueryBuilder`, and `PostgrestBuilder` as types from `@supabase/supabase-js`, alongside `StorageApiError` as a value export. Previously these were only available by importing directly from `@supabase/postgrest-js` or `@supabase/storage-js`, making it awkward to type higher-order helper functions that wrap queries.