### PR TITLE
ci(repo): install npm v11 instead of latest with corepack

### DIFF
--- a/.github/workflows/deprecate-version.yml
+++ b/.github/workflows/deprecate-version.yml
@@ -67,7 +67,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Update npm
-        run: npm install -g npm@latest
+        run: corepack enable npm && corepack prepare npm@11 --activate
 
       - name: Deprecate package versions
         env:

--- a/.github/workflows/fix-lockfile.yml
+++ b/.github/workflows/fix-lockfile.yml
@@ -22,10 +22,9 @@ jobs:
         with:
           node-version: 22
 
-      - name: Upgrade to latest
-        run: npm install -g npm@latest
-
       # This is needed to match the npm version used when publishing
+      - name: Update npm
+        run: corepack enable npm && corepack prepare npm@11 --activate
       - name: Regenerate lockfile
         run: npm install --package-lock-only --ignore-scripts
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -84,9 +84,8 @@ jobs:
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
 
-      # Ensure npm 11.5.1 or later is installed for trusted publishing support
       - name: Update npm
-        run: npm install -g npm@latest
+        run: corepack enable npm && corepack prepare npm@11 --activate
 
       - name: Install dependencies
         run: npm ci
@@ -257,7 +256,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Update npm
-        run: npm install -g npm@latest
+        run: corepack enable npm && corepack prepare npm@11 --activate
 
       - name: Install dependencies
         run: npm ci
@@ -378,9 +377,8 @@ jobs:
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
 
-      # Ensure npm 11.5.1 or later is installed for trusted publishing support
       - name: Update npm
-        run: npm install -g npm@latest
+        run: corepack enable npm && corepack prepare npm@11 --activate
       - name: Install dependencies
         run: npm ci
       - name: Configure git


### PR DESCRIPTION
Replaces `npm install -g npm@latest` with `corepack enable npm && corepack prepare npm@11 --activate` across all workflows. The npm bundled with Node 22.22.2 (10.9.7) has a bug where it cannot run any global install command, and trusted publishing requires npm >=11.5.1. Corepack is built into Node.js and sidesteps the bootstrapping issue cleanly.