### PR TITLE
fix(auth,supabase): recover from client corruption after tab suspension

### DIFF
--- a/packages/core/auth-js/src/GoTrueClient.ts
+++ b/packages/core/auth-js/src/GoTrueClient.ts
@@ -4540,6 +4540,17 @@ export default class GoTrueClient {
                 error
               )
               await this._removeSession()
+            } else {
+              // The refresh failed with a retryable error (e.g. network still
+              // reconnecting after tab suspension). Emit SIGNED_IN with the
+              // current session so downstream listeners (realtime, functions)
+              // can re-sync with the existing token. The auto-refresh ticker
+              // will retry the actual refresh on its next tick.
+              this._debug(
+                debugName,
+                'refresh failed with a retryable error, notifying subscribers with current session'
+              )
+              await this._notifyAllSubscribers('SIGNED_IN', currentSession)
             }
           }
         }
@@ -5029,6 +5040,14 @@ export default class GoTrueClient {
           // recover the session
           await this._recoverAndRefresh()
         })
+
+        // After lock-based recovery, if the session is still expired
+        // (e.g. network was not yet available when _recoverAndRefresh ran),
+        // trigger an immediate auto-refresh tick so we don't wait up to
+        // AUTO_REFRESH_TICK_DURATION_MS (30s) for the next scheduled tick.
+        if (this.autoRefreshToken) {
+          await this._autoRefreshTokenTick()
+        }
       }
     } else if (document.visibilityState === 'hidden') {
       if (this.autoRefreshToken) {

--- a/packages/core/supabase-js/src/SupabaseClient.ts
+++ b/packages/core/supabase-js/src/SupabaseClient.ts
@@ -355,6 +355,7 @@ export default class SupabaseClient<
 
     if (!settings.accessToken) {
       this._listenForAuthEvents()
+      this._listenForVisibilityChange()
     }
   }
 
@@ -594,6 +595,33 @@ export default class SupabaseClient<
       this._handleTokenChanged(event, 'CLIENT', session?.access_token)
     })
     return data
+  }
+
+  /**
+   * Listens for browser visibility changes (tab resume after suspension).
+   * When the tab becomes visible again, force-syncs a fresh token to
+   * the realtime client. This handles the case where a token refresh
+   * during _recoverAndRefresh fails (e.g. network still reconnecting)
+   * and no TOKEN_REFRESHED event fires, leaving realtime with a stale token.
+   */
+  private _listenForVisibilityChange() {
+    if (typeof globalThis === 'undefined' || typeof document === 'undefined') {
+      return
+    }
+
+    const callback = async () => {
+      if (document.visibilityState === 'visible') {
+        // Tab just became visible — push fresh token to realtime.
+        // _getAccessToken reads from auth.getSession which will trigger
+        // a refresh if the session has expired.
+        const token = await this._getAccessToken()
+        if (token && token !== this.supabaseKey) {
+          this.realtime.setAuth(token)
+        }
+      }
+    }
+
+    document.addEventListener('visibilitychange', callback)
   }
 
   private _handleTokenChanged(

--- a/packages/core/supabase-js/test/unit/SupabaseClient.test.ts
+++ b/packages/core/supabase-js/test/unit/SupabaseClient.test.ts
@@ -378,6 +378,43 @@ describe('SupabaseClient', () => {
         expect(client.realtime.setAuth).toHaveBeenCalledWith(testToken)
         expect((client.realtime as any).accessTokenValue).toBe(testToken)
       })
+
+      test('should sync fresh token to realtime on visibility change (tab resume)', async () => {
+        // Set up a minimal document mock for the visibility change listener
+        const listeners: Record<string, Function[]> = {}
+        const mockDocument = {
+          visibilityState: 'visible',
+          addEventListener: (event: string, cb: Function) => {
+            listeners[event] = listeners[event] || []
+            listeners[event].push(cb)
+          },
+          dispatchEvent: (event: { type: string }) => {
+            ;(listeners[event.type] || []).forEach((cb) => cb())
+          },
+        }
+        ;(globalThis as any).document = mockDocument
+
+        const freshToken = 'fresh-session-token'
+        const client = createClient(URL, KEY)
+
+        client.auth.getSession = jest.fn().mockResolvedValue({
+          data: { session: { access_token: freshToken } },
+        })
+
+        const setAuthSpy = jest.spyOn(client.realtime, 'setAuth').mockResolvedValue()
+
+        // Simulate tab becoming visible (as after suspension)
+        mockDocument.visibilityState = 'visible'
+        mockDocument.dispatchEvent({ type: 'visibilitychange' })
+
+        // Allow async callback to complete
+        await new Promise((r) => setTimeout(r, 50))
+
+        expect(setAuthSpy).toHaveBeenCalledWith(freshToken)
+
+        // Clean up
+        delete (globalThis as any).document
+      })
     })
 
     describe('FetchWithAuth Token Integration', () => {


### PR DESCRIPTION
## Summary

Fixes the Supabase client becoming irrecoverably corrupted after browser tab suspension (2-5+ minutes), which affects PWAs, mobile browsers, and long-lived sessions. After resuming:

- `auth.getSession()` could return `null` despite a valid session in storage
- `functions.invoke()` could hang indefinitely (blocked on lock-gated `getSession`)
- Realtime channels failed silently with stale tokens and no reconnection

**Root cause:** When `_recoverAndRefresh` fails with a retryable error (e.g. network still reconnecting after tab resume), no auth event was emitted, leaving realtime and functions permanently desynchronized. The next auto-refresh tick could be up to 30 seconds away.

### Changes

**auth-js (`GoTrueClient`):**
- Emit `SIGNED_IN` with current session on retryable refresh failure so downstream listeners (realtime, functions) can re-sync immediately instead of silently dropping the error
- Trigger an immediate `_autoRefreshTokenTick()` after visibility change recovery instead of waiting up to `AUTO_REFRESH_TICK_DURATION_MS` (30s) for the next scheduled tick

**supabase-js (`SupabaseClient`):**
- Add `visibilitychange` listener that force-syncs a fresh token to the realtime client when the tab resumes — acts as a safety net for cases where the auth event bridge misses the token update

## Test plan

- [x] New unit test: `should sync fresh token to realtime on visibility change (tab resume)` in SupabaseClient tests
- [x] All existing realtime-js tests pass (325/325, only pre-existing worker test failures on non-browser env)
- [x] All existing supabase-js unit tests pass (88/88)
- [ ] Manual testing: open app with realtime channel, background tab for 3-5 min, resume and verify session + realtime recover

## Related

Closes supabase/supabase#36046

🤖 Generated with [Claude Code](https://claude.com/claude-code)