### PR TITLE
fix(postgrest): serialize bigint values in rpc() request body

### DIFF
--- a/packages/core/postgrest-js/src/PostgrestBuilder.ts
+++ b/packages/core/postgrest-js/src/PostgrestBuilder.ts
@@ -248,7 +248,7 @@ export default abstract class PostgrestBuilder<
           res = await _fetch(this.url.toString(), {
             method: this.method,
             headers: requestHeaders,
-            body: JSON.stringify(this.body),
+            body: JSON.stringify(this.body, (_, v) => typeof v === 'bigint' ? v.toString() : v),
             signal: this.signal,
           })
         } catch (fetchError: any) {


### PR DESCRIPTION
## Description

### What changed?

Added a `bigint` serialization replacer to `JSON.stringify` in `PostgrestBuilder.ts`. When the request body is serialized, any `bigint` value is now converted to its string representation instead of throwing a `TypeError`.

**One-line change:**
```diff
- body: JSON.stringify(this.body),
+ body: JSON.stringify(this.body, (_, v) => typeof v === 'bigint' ? v.toString() : v),
```

### Why was this change needed?

JavaScript's `JSON.stringify` does not natively support `bigint` values and throws:
```
TypeError: Do not know how to serialize a BigInt
```

This means any user calling `rpc()` with a `bigint` argument (e.g., for `int8` / `bigint` Postgres columns) had to manually call `.toString()` on every bigint value:
```ts
// Before (broken):
await supabase.rpc('my_func', { amount: 9007199254740993n }) // throws TypeError

// Workaround users needed:
await supabase.rpc('my_func', { amount: 9007199254740993n.toString() })

// After (works transparently):
await supabase.rpc('my_func', { amount: 9007199254740993n }) // works!
```

This approach is consistent with how many serialization libraries handle `bigint` and avoids a breaking change — `bigint` → string conversion matches what PostgREST expects for `int8` parameters anyway.

Closes #2117