### PR TITLE
fix(auth): replace navigatorLock with processLock as default browser lock

### DIFF
--- a/packages/core/auth-js/example/react/src/App.tsx
+++ b/packages/core/auth-js/example/react/src/App.tsx
@@ -13,6 +13,10 @@ const auth = new AuthClient({
   },
 })
 
+if (import.meta.env.DEV) {
+  ;(window as any).__auth__ = auth
+}
+
 function App() {
   const [session, setSession] = useState<Session | null>(null)
   const [email, setEmail] = useState(localStorage.getItem('email') ?? '')

--- a/packages/core/auth-js/example/react/tests/lock-behavior.spec.ts
+++ b/packages/core/auth-js/example/react/tests/lock-behavior.spec.ts
@@ -1,0 +1,123 @@
+import { test, expect } from '@playwright/test'
+
+const STORAGE_KEY = 'supabase.auth.token'
+const DEADLOCK_TIMEOUT_MS = 5000
+
+/** Expire the stored session so the next getSession() triggers a token refresh. */
+async function expireStoredSession(page: any) {
+  await page.evaluate((key: string) => {
+    const raw = localStorage.getItem(key)
+    if (!raw) return
+    const session = JSON.parse(raw)
+    session.expires_at = Math.floor(Date.now() / 1000) - 10
+    localStorage.setItem(key, JSON.stringify(session))
+  }, STORAGE_KEY)
+}
+
+test.describe('Lock behavior', () => {
+  test('concurrent getSession calls all resolve without deadlock', async ({ page }) => {
+    const email = `concurrent-${Date.now()}@test.com`
+
+    await page.goto('/')
+    await page.fill('#email', email)
+    await page.fill('#password', 'TestPassword123!')
+    await page.click('button:has-text("Sign Up")')
+    await expect(page.locator('button:has-text("Sign out")')).toBeVisible({ timeout: 10000 })
+
+    // Fire 10 concurrent getSession calls — each races against a hard deadline.
+    // With navigatorLock this would deadlock; with processLock all should resolve.
+    const results: { error: string | null }[] = await page.evaluate(
+      async ({ timeoutMs }: { timeoutMs: number }) => {
+        const auth = (window as any).__auth__
+        return Promise.all(
+          Array.from({ length: 10 }, () =>
+            Promise.race([
+              auth.getSession().then((r: any) => ({ error: r.error?.message ?? null })),
+              new Promise<never>((_, reject) =>
+                setTimeout(() => reject(new Error('deadlock: getSession did not resolve')), timeoutMs)
+              ),
+            ])
+          )
+        )
+      },
+      { timeoutMs: DEADLOCK_TIMEOUT_MS }
+    )
+
+    expect(results).toHaveLength(10)
+    for (const r of results) {
+      expect(r.error).toBeNull()
+    }
+  })
+
+  test('two tabs refreshing concurrently both remain authenticated', async ({ browser }) => {
+    const context = await browser.newContext()
+    const page1 = await context.newPage()
+    const page2 = await context.newPage()
+
+    try {
+      // Sign in on tab 1
+      await page1.goto('/')
+      await page1.fill('#email', `multitab-${Date.now()}@test.com`)
+      await page1.fill('#password', 'TestPassword123!')
+      await page1.click('button:has-text("Sign Up")')
+      await expect(page1.locator('button:has-text("Sign out")')).toBeVisible({ timeout: 10000 })
+
+      // Tab 2 navigates — picks up the session from shared localStorage
+      await page2.goto('/')
+      await expect(page2.locator('button:has-text("Sign out")')).toBeVisible({ timeout: 5000 })
+
+      // Expire the token so both tabs will hit /token?grant_type=refresh_token
+      await expireStoredSession(page1)
+
+      // Both tabs call getSession simultaneously — triggers a concurrent refresh
+      const [r1, r2] = await Promise.all([
+        page1.evaluate(async ({ timeoutMs }: { timeoutMs: number }) => {
+          return Promise.race([
+            (window as any).__auth__
+              .getSession()
+              .then((r: any) => ({ session: !!r.data?.session, error: r.error?.message ?? null })),
+            new Promise<never>((_, reject) =>
+              setTimeout(() => reject(new Error('deadlock: tab 1 getSession did not resolve')), timeoutMs)
+            ),
+          ])
+        }, { timeoutMs: DEADLOCK_TIMEOUT_MS }),
+        page2.evaluate(async ({ timeoutMs }: { timeoutMs: number }) => {
+          return Promise.race([
+            (window as any).__auth__
+              .getSession()
+              .then((r: any) => ({ session: !!r.data?.session, error: r.error?.message ?? null })),
+            new Promise<never>((_, reject) =>
+              setTimeout(() => reject(new Error('deadlock: tab 2 getSession did not resolve')), timeoutMs)
+            ),
+          ])
+        }, { timeoutMs: DEADLOCK_TIMEOUT_MS }),
+      ])
+
+      expect(r1.error).toBeNull()
+      expect(r2.error).toBeNull()
+      expect(r1.session).toBe(true)
+      expect(r2.session).toBe(true)
+    } finally {
+      await context.close()
+    }
+  })
+
+  test('signOut during token refresh results in signed-out state', async ({ page }) => {
+    await page.goto('/')
+    await page.fill('#email', `signout-race-${Date.now()}@test.com`)
+    await page.fill('#password', 'TestPassword123!')
+    await page.click('button:has-text("Sign Up")')
+    await expect(page.locator('button:has-text("Sign out")')).toBeVisible({ timeout: 10000 })
+
+    // Expire the token so getSession() triggers a refresh, then fire both concurrently
+    await expireStoredSession(page)
+
+    await page.evaluate(async () => {
+      const auth = (window as any).__auth__
+      // getSession will attempt a refresh; signOut should win and clear the session
+      await Promise.allSettled([auth.getSession(), auth.signOut()])
+    })
+
+    await expect(page.locator('pre')).toContainText('None', { timeout: 5000 })
+  })
+})

--- a/packages/core/auth-js/src/GoTrueClient.ts
+++ b/packages/core/auth-js/src/GoTrueClient.ts
@@ -53,7 +53,7 @@ import {
   validateExp,
 } from './lib/helpers'
 import { memoryLocalStorageAdapter } from './lib/local-storage'
-import { LockAcquireTimeoutError, navigatorLock, processLock } from './lib/locks'
+import { LockAcquireTimeoutError, processLock } from './lib/locks'
 import { polyfillGlobalThis } from './lib/polyfills'
 import { version } from './lib/version'
 
@@ -2536,7 +2536,7 @@ export default class GoTrueClient {
    * - If the session's access token is expired or is about to expire, this method will use the refresh token to refresh the session.
    * - When using in a browser, or you've called `startAutoRefresh()` in your environment (React Native, etc.) this function always returns a valid access token without refreshing the session itself, as this is done in the background. This function returns very fast.
    * - **IMPORTANT SECURITY NOTICE:** If using an insecure storage medium, such as cookies or request headers, the user object returned by this function **must not be trusted**. Always verify the JWT using `getClaims()` or your own JWT verification library to securely establish the user's identity and access. You can also use `getUser()` to fetch the user object directly from the Auth server for this purpose.
-   * - When using in a browser, this function is synchronized across all tabs using the [LockManager](https://developer.mozilla.org/en-US/docs/Web/API/LockManager) API. In other environments make sure you've defined a proper `lock` property, if necessary, to make sure there are no race conditions while the session is being refreshed.
+   * - This function is synchronized within the current process using an in-process lock. Cross-tab refresh races are handled server-side by GoTrue's refresh token reuse detection. You can opt in to cross-tab serialization via the Web Locks API by passing `lock: navigatorLock` (deprecated) in the client options.
    *
    * @example Get the session data
    * ```js

--- a/packages/core/auth-js/src/GoTrueClient.ts
+++ b/packages/core/auth-js/src/GoTrueClient.ts
@@ -53,7 +53,7 @@ import {
   validateExp,
 } from './lib/helpers'
 import { memoryLocalStorageAdapter } from './lib/local-storage'
-import { LockAcquireTimeoutError, navigatorLock } from './lib/locks'
+import { LockAcquireTimeoutError, navigatorLock, processLock } from './lib/locks'
 import { polyfillGlobalThis } from './lib/polyfills'
 import { version } from './lib/version'
 
@@ -336,8 +336,8 @@ export default class GoTrueClient {
 
     if (settings.lock) {
       this.lock = settings.lock
-    } else if (this.persistSession && isBrowser() && globalThis?.navigator?.locks) {
-      this.lock = navigatorLock
+    } else if (this.persistSession && isBrowser()) {
+      this.lock = processLock
     } else {
       this.lock = lockNoOp
     }

--- a/packages/core/auth-js/src/lib/locks.ts
+++ b/packages/core/auth-js/src/lib/locks.ts
@@ -42,12 +42,11 @@ export abstract class LockAcquireTimeoutError extends Error {
 /**
  * Error thrown when the browser Navigator Lock API fails to acquire a lock.
  *
- * @example
- * ```ts
- * import { NavigatorLockAcquireTimeoutError } from '@supabase/auth-js'
+ * @deprecated Only thrown by the deprecated {@link navigatorLock}. Scheduled
+ * for removal in the next major version. Use {@link ProcessLockAcquireTimeoutError}
+ * or catch {@link LockAcquireTimeoutError} instead.
  *
- * throw new NavigatorLockAcquireTimeoutError('Lock timed out')
- * ```
+ * TODO(v3): remove along with navigatorLock.
  */
 export class NavigatorLockAcquireTimeoutError extends LockAcquireTimeoutError {}
 /**
@@ -68,6 +67,14 @@ export class ProcessLockAcquireTimeoutError extends LockAcquireTimeoutError {}
  * last one to release support. If the API is not available, this function will
  * throw. Make sure you check availablility before configuring {@link
  * GoTrueClient}.
+ *
+ * @deprecated `navigatorLock` is no longer the default browser lock and is kept
+ * only for opt-in use. It is scheduled for removal in the next major version.
+ * The default `processLock` handles within-tab serialization, and cross-tab
+ * refresh races are handled server-side by GoTrue's refresh token reuse
+ * detection. To opt in: `createClient(url, key, { auth: { lock: navigatorLock } })`
+ *
+ * TODO(v3): remove navigatorLock export and all steal-based recovery logic.
  *
  * You can turn on debugging by setting the `supabase.gotrue-js.locks.debug`
  * local storage item to `true`.
@@ -305,7 +312,8 @@ const PROCESS_LOCKS: { [name: string]: Promise<any> } = {}
  * Useful for environments like React Native or other non-browser
  * single-process (i.e. no concept of "tabs") environments.
  *
- * Use {@link #navigatorLock} in browser environments.
+ * This is the default lock for all environments. Use {@link navigatorLock} only
+ * if you need opt-in cross-tab serialization via the Web Locks API.
  *
  * @param name Name of the lock to be acquired.
  * @param acquireTimeout If negative, no timeout. If 0 an error is thrown if

--- a/packages/core/auth-js/src/lib/types.ts
+++ b/packages/core/auth-js/src/lib/types.ts
@@ -121,9 +121,14 @@ export type GoTrueClientOptions = {
   debug?: boolean | ((message: string, ...args: any[]) => void)
   /**
    * Provide your own locking mechanism based on the environment. By default,
-   * `navigatorLock` (Web Locks API) is used in browser environments when
-   * `persistSession` is true. Falls back to an in-process lock for non-browser
-   * environments (e.g. React Native).
+   * `processLock` (an in-process queue) is used in browser environments when
+   * `persistSession` is true. Falls back to a no-op for non-browser environments.
+   *
+   * To opt back in to the Web Locks API for cross-tab serialization:
+   * ```ts
+   * import { navigatorLock } from '@supabase/auth-js'
+   * createClient(url, key, { auth: { lock: navigatorLock } })
+   * ```
    *
    * @experimental
    */
@@ -139,19 +144,18 @@ export type GoTrueClientOptions = {
    */
   throwOnError?: boolean
   /**
-   * The maximum time in milliseconds to wait for acquiring a cross-tab synchronization lock.
+   * The maximum time in milliseconds to wait for acquiring a lock.
    *
-   * When multiple browser tabs or windows use the auth client simultaneously, they coordinate
-   * via the Web Locks API to prevent race conditions during session refresh and other operations.
-   * This timeout controls how long to wait before attempting lock recovery.
+   * This is most impactful when using a custom `lock` implementation such as the
+   * opt-in `navigatorLock`. When using the default `processLock`, this controls
+   * how long to wait for the in-process queue to drain.
    *
-   * - **Positive value**: Wait up to this many milliseconds. If the lock is still held, attempt
-   *   automatic recovery by stealing it (the previous holder is evicted, its callback continues
-   *   to completion without exclusive access). This recovers from orphaned locks caused by
-   *   React Strict Mode double-mount, storage API hangs, or aborted operations.
+   * - **Positive value**: Wait up to this many milliseconds before giving up.
+   *   When using `navigatorLock`, a timeout triggers automatic recovery by stealing
+   *   the orphaned lock.
    * - **Zero (0)**: Fail immediately if the lock is unavailable; throws `LockAcquireTimeoutError`
    *   (check `error.isAcquireTimeout === true`).
-   * - **Negative value**: Wait indefinitely — can cause permanent deadlocks if the lock is orphaned.
+   * - **Negative value**: Wait indefinitely.
    *
    * @default 5000
    *
@@ -159,7 +163,7 @@ export type GoTrueClientOptions = {
    * ```ts
    * const client = createClient(url, key, {
    *   auth: {
-   *     lockAcquireTimeout: 5000, // 5 seconds, then steal orphaned lock
+   *     lockAcquireTimeout: 5000,
    *   },
    * })
    * ```

--- a/packages/core/auth-js/src/lib/types.ts
+++ b/packages/core/auth-js/src/lib/types.ts
@@ -124,13 +124,16 @@ export type GoTrueClientOptions = {
    * `processLock` (an in-process queue) is used in browser environments when
    * `persistSession` is true. Falls back to a no-op for non-browser environments.
    *
-   * To opt back in to the Web Locks API for cross-tab serialization:
+   * Cross-tab token refresh races are handled server-side: GoTrue allows
+   * concurrent refreshes of the same token (via reuse detection) so both tabs
+   * receive valid tokens without any client-side coordination.
+   *
+   * To opt back in to the Web Locks API for explicit cross-tab serialization
+   * (deprecated, scheduled for removal in the next major version):
    * ```ts
    * import { navigatorLock } from '@supabase/auth-js'
    * createClient(url, key, { auth: { lock: navigatorLock } })
    * ```
-   *
-   * @experimental
    */
   lock?: LockFunc
   /**

--- a/packages/core/auth-js/test/GoTrueClient.browser.test.ts
+++ b/packages/core/auth-js/test/GoTrueClient.browser.test.ts
@@ -9,6 +9,7 @@ import {
   getClientWithSpecificStorageKey,
   pkceClient,
 } from './lib/clients'
+import { navigatorLock, processLock } from '../src/lib/locks'
 import { mockUserCredentials } from './lib/utils'
 import {
   supportsLocalStorage,
@@ -651,26 +652,38 @@ describe('GoTrueClient BroadcastChannel', () => {
 })
 
 describe('Browser locks functionality', () => {
-  it('should use navigator locks when available', () => {
-    // Mock navigator.locks
-    const mockLock = { name: 'test-lock' }
+  it('should use processLock even when navigator.locks is available', () => {
+    // Mock navigator.locks to confirm it is no longer selected as the default
     const mockRequest = jest
       .fn()
-      .mockImplementation((_, __, callback) => Promise.resolve(callback(mockLock)))
+      .mockImplementation((_, __, callback) => Promise.resolve(callback({ name: 'test-lock' })))
 
     Object.defineProperty(navigator, 'locks', {
       value: { request: mockRequest },
       writable: true,
     })
 
-    // Test navigator locks usage in GoTrueClient
     const client = getClientWithSpecificStorage({
       getItem: jest.fn(),
       setItem: jest.fn(),
       removeItem: jest.fn(),
     })
 
-    expect(client).toBeDefined()
+    expect((client as any).lock).toBe(processLock)
+  })
+
+  it('should use navigatorLock when explicitly configured via lock option', () => {
+    const client = new (require('../src/GoTrueClient').default)({
+      url: 'http://localhost:9999',
+      headers: { apikey: 'test-key' },
+      storageKey: 'test-lock-opt-in',
+      autoRefreshToken: false,
+      persistSession: true,
+      storage: { getItem: jest.fn(), setItem: jest.fn(), removeItem: jest.fn() },
+      lock: navigatorLock,
+    })
+
+    expect((client as any).lock).toBe(navigatorLock)
   })
 
   it('should handle _acquireLock with empty pendingInLock', async () => {
@@ -678,17 +691,6 @@ describe('Browser locks functionality', () => {
       getItem: jest.fn(),
       setItem: jest.fn(),
       removeItem: jest.fn(),
-    })
-
-    // Mock navigator.locks
-    const mockLock = { name: 'test-lock' }
-    const mockRequest = jest
-      .fn()
-      .mockImplementation((_, __, callback) => Promise.resolve(callback(mockLock)))
-
-    Object.defineProperty(navigator, 'locks', {
-      value: { request: mockRequest },
-      writable: true,
     })
 
     // Initialize client to trigger lock acquisition


### PR DESCRIPTION
## Description

### What changed?

Replaced `navigatorLock` (Web Locks API) with `processLock` (in-process promise queue) as the default browser lock in `GoTrueClient`. Previously, any browser with `navigator.locks` support would use the Web Locks API for cross-tab auth coordination. Now all environments use `processLock` by default, which serializes operations within a single tab/process without touching the Web Locks API.

`navigatorLock` remains exported and available as an explicit opt-in:

```ts
import { navigatorLock } from '@supabase/auth-js'

createClient(url, key, { auth: { lock: navigatorLock } })
```

### Why was this change needed?

`navigator.locks` causes permanent authentication deadlocks in production when a lock is acquired but never released. Once a lock is orphaned, every subsequent auth call in that tab hangs indefinitely until the user closes the browser. Known triggers:

- React Strict Mode double-mount/unmount interrupting a lock request mid-flight (affects all Next.js 13+ apps in dev mode by default)
- HMR tearing down components while a lock is held
- `localStorage.setItem()` hanging due to quota exceeded or browser extension interference
- Android Chrome not releasing locks from previous sessions

The steal-based recovery added in #2106 and #2178 addressed the symptom but introduced new failure modes (double-write windows, cascade when stolen). This PR addresses the root cause by removing the Web Locks API from the default path entirely.

Cross-tab concurrent refresh races are now handled server-side by GoTrue's refresh token reuse detection. When two tabs refresh simultaneously, the server allows both via the `likelyNotSavedByClient` (`counterDifference == 1`) and `likelyConcurrentRefreshes` (within reuse interval) logic, returning valid tokens to both tabs without any client-side coordination. `refresh_token_already_used` is only returned for genuinely stale tokens outside the reuse window, at which point the session is already server-side revoked and the existing sign-out behavior is correct.

`processLock` still provides within-tab serialization, which is needed to prevent races between operations in the same tab (e.g. `signOut` racing with an in-flight auto-refresh).

Relates to: #2111, #936, #1594, #2013

## Screenshots/Examples

N/A

## Breaking changes

- [x] This PR contains no breaking changes

The default lock behavior changes, but no public API is removed or modified. `navigatorLock` remains exported. `processLock` was already exported. The `lock` and `lockAcquireTimeout` options continue to work as before.

## Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/supabase/supabase-js/blob/master/CONTRIBUTING.md)
- [x] My PR title follows the [conventional commit format](https://www.conventionalcommits.org/): `<type>(<scope>): <description>`
- [x] I have run `npx nx format` to ensure consistent code formatting
- [x] I have added tests for new functionality (if applicable)
- [x] I have updated documentation (if applicable)

## Additional notes

The server-side behavior this relies on (`likelyNotSavedByClient` counter logic) is confirmed in `supabase/auth` `internal/tokens/service.go`. The reuse detection has been in production since the v2 refresh token algorithm rollout (Oct 2025).

## Try it out

You can try out this PR on `2.103.1-beta.0`