### PR TITLE
fix(auth): add toJSON to AuthError for correct JSON serialization

### DIFF
--- a/packages/core/auth-js/src/lib/errors.ts
+++ b/packages/core/auth-js/src/lib/errors.ts
@@ -31,6 +31,15 @@ export class AuthError extends Error {
     this.status = status
     this.code = code
   }
+
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+      status: this.status,
+      code: this.code,
+    }
+  }
 }
 
 export function isAuthError(error: unknown): error is AuthError {
@@ -181,9 +190,7 @@ export class AuthImplicitGrantRedirectError extends CustomAuthError {
 
   toJSON() {
     return {
-      name: this.name,
-      message: this.message,
-      status: this.status,
+      ...super.toJSON(),
       details: this.details,
     }
   }
@@ -215,9 +222,7 @@ export class AuthPKCEGrantCodeExchangeError extends CustomAuthError {
 
   toJSON() {
     return {
-      name: this.name,
-      message: this.message,
-      status: this.status,
+      ...super.toJSON(),
       details: this.details,
     }
   }
@@ -300,6 +305,13 @@ export class AuthWeakPasswordError extends CustomAuthError {
     super(message, 'AuthWeakPasswordError', status, 'weak_password')
 
     this.reasons = reasons
+  }
+
+  toJSON() {
+    return {
+      ...super.toJSON(),
+      reasons: this.reasons,
+    }
   }
 }
 

--- a/packages/core/auth-js/test/errors.test.ts
+++ b/packages/core/auth-js/test/errors.test.ts
@@ -39,6 +39,7 @@ describe('AuthError serialization', () => {
     const serialized = JSON.parse(JSON.stringify(err))
     expect(serialized.message).toBe('Auth failed')
     expect(serialized.name).toBe('AuthUnknownError')
+    expect(serialized).not.toHaveProperty('originalError')
   })
 
   test('AuthSessionMissingError serializes message with JSON.stringify', () => {

--- a/packages/core/auth-js/test/errors.test.ts
+++ b/packages/core/auth-js/test/errors.test.ts
@@ -1,0 +1,123 @@
+import 'jest'
+
+import {
+  AuthError,
+  AuthApiError,
+  AuthUnknownError,
+  AuthSessionMissingError,
+  AuthInvalidTokenResponseError,
+  AuthInvalidCredentialsError,
+  AuthImplicitGrantRedirectError,
+  AuthPKCEGrantCodeExchangeError,
+  AuthPKCECodeVerifierMissingError,
+  AuthRetryableFetchError,
+  AuthWeakPasswordError,
+  AuthInvalidJwtError,
+} from '../src/lib/errors'
+
+describe('AuthError serialization', () => {
+  test('AuthError serializes message with JSON.stringify', () => {
+    const err = new AuthError('something went wrong', 500, 'unexpected')
+    const serialized = JSON.parse(JSON.stringify(err))
+    expect(serialized.message).toBe('something went wrong')
+    expect(serialized.name).toBe('AuthError')
+    expect(serialized.status).toBe(500)
+    expect(serialized.code).toBe('unexpected')
+  })
+
+  test('AuthApiError serializes message with JSON.stringify', () => {
+    const err = new AuthApiError('Invalid credentials', 400, 'invalid_credentials')
+    const serialized = JSON.parse(JSON.stringify(err))
+    expect(serialized.message).toBe('Invalid credentials')
+    expect(serialized.name).toBe('AuthApiError')
+    expect(serialized.status).toBe(400)
+    expect(serialized.code).toBe('invalid_credentials')
+  })
+
+  test('AuthUnknownError serializes message with JSON.stringify', () => {
+    const err = new AuthUnknownError('Auth failed', new Error('original'))
+    const serialized = JSON.parse(JSON.stringify(err))
+    expect(serialized.message).toBe('Auth failed')
+    expect(serialized.name).toBe('AuthUnknownError')
+  })
+
+  test('AuthSessionMissingError serializes message with JSON.stringify', () => {
+    const err = new AuthSessionMissingError()
+    const serialized = JSON.parse(JSON.stringify(err))
+    expect(serialized.message).toBe('Auth session missing!')
+    expect(serialized.name).toBe('AuthSessionMissingError')
+    expect(serialized.status).toBe(400)
+  })
+
+  test('AuthInvalidTokenResponseError serializes message with JSON.stringify', () => {
+    const err = new AuthInvalidTokenResponseError()
+    const serialized = JSON.parse(JSON.stringify(err))
+    expect(serialized.message).toBe('Auth session or user missing')
+    expect(serialized.name).toBe('AuthInvalidTokenResponseError')
+    expect(serialized.status).toBe(500)
+  })
+
+  test('AuthInvalidCredentialsError serializes message with JSON.stringify', () => {
+    const err = new AuthInvalidCredentialsError('Email or password is incorrect')
+    const serialized = JSON.parse(JSON.stringify(err))
+    expect(serialized.message).toBe('Email or password is incorrect')
+    expect(serialized.name).toBe('AuthInvalidCredentialsError')
+    expect(serialized.status).toBe(400)
+  })
+
+  test('AuthImplicitGrantRedirectError serializes message and details with JSON.stringify', () => {
+    const details = { error: 'access_denied', code: 'oauth_error' }
+    const err = new AuthImplicitGrantRedirectError('OAuth redirect failed', details)
+    const serialized = JSON.parse(JSON.stringify(err))
+    expect(serialized.message).toBe('OAuth redirect failed')
+    expect(serialized.name).toBe('AuthImplicitGrantRedirectError')
+    expect(serialized.status).toBe(500)
+    expect(serialized.details).toEqual(details)
+  })
+
+  test('AuthPKCEGrantCodeExchangeError serializes message and details with JSON.stringify', () => {
+    const details = { error: 'code_expired', code: 'pkce_error' }
+    const err = new AuthPKCEGrantCodeExchangeError('PKCE exchange failed', details)
+    const serialized = JSON.parse(JSON.stringify(err))
+    expect(serialized.message).toBe('PKCE exchange failed')
+    expect(serialized.name).toBe('AuthPKCEGrantCodeExchangeError')
+    expect(serialized.status).toBe(500)
+    expect(serialized.details).toEqual(details)
+  })
+
+  test('AuthPKCECodeVerifierMissingError serializes message with JSON.stringify', () => {
+    const err = new AuthPKCECodeVerifierMissingError()
+    const serialized = JSON.parse(JSON.stringify(err))
+    expect(serialized.message).toContain('PKCE code verifier not found in storage')
+    expect(serialized.name).toBe('AuthPKCECodeVerifierMissingError')
+    expect(serialized.status).toBe(400)
+    expect(serialized.code).toBe('pkce_code_verifier_not_found')
+  })
+
+  test('AuthRetryableFetchError serializes message with JSON.stringify', () => {
+    const err = new AuthRetryableFetchError('Service unavailable', 503)
+    const serialized = JSON.parse(JSON.stringify(err))
+    expect(serialized.message).toBe('Service unavailable')
+    expect(serialized.name).toBe('AuthRetryableFetchError')
+    expect(serialized.status).toBe(503)
+  })
+
+  test('AuthWeakPasswordError serializes message and reasons with JSON.stringify', () => {
+    const err = new AuthWeakPasswordError('Password too short', 422, ['length', 'characters'])
+    const serialized = JSON.parse(JSON.stringify(err))
+    expect(serialized.message).toBe('Password too short')
+    expect(serialized.name).toBe('AuthWeakPasswordError')
+    expect(serialized.status).toBe(422)
+    expect(serialized.code).toBe('weak_password')
+    expect(serialized.reasons).toEqual(['length', 'characters'])
+  })
+
+  test('AuthInvalidJwtError serializes message with JSON.stringify', () => {
+    const err = new AuthInvalidJwtError('Token expired')
+    const serialized = JSON.parse(JSON.stringify(err))
+    expect(serialized.message).toBe('Token expired')
+    expect(serialized.name).toBe('AuthInvalidJwtError')
+    expect(serialized.status).toBe(400)
+    expect(serialized.code).toBe('invalid_jwt')
+  })
+})


### PR DESCRIPTION
## Summary

`JSON.stringify()` silently drops the `message` field on most auth error classes because `Error.prototype.message` is non-enumerable.

Only 2 out of 13 auth error classes (`AuthImplicitGrantRedirectError` and `AuthPKCEGrantCodeExchangeError`) had `toJSON()` overrides. The rest -- including `AuthApiError`, which is by far the most commonly encountered -- would serialize without `message`:

```js
const err = new AuthApiError('Invalid login credentials', 400, 'invalid_credentials')
JSON.stringify(err)
// Before: {"status":400,"code":"invalid_credentials"}  -- message is gone
// After:  {"name":"AuthApiError","message":"Invalid login credentials","status":400,"code":"invalid_credentials"}
```

This adds `toJSON()` to the `AuthError` base class (returning `name`, `message`, `status`, `code`), so all subclasses inherit it automatically. The two existing overrides now spread `super.toJSON()` instead of duplicating fields. `AuthWeakPasswordError` gets an override to include `reasons`.

Same pattern as the recent fixes for `FunctionsError` (#2226) and `PostgrestError` (#2212).

## Test plan

- [x] Added `errors.test.ts` covering all 12 concrete error classes
- [x] Each test verifies `JSON.stringify()` round-trip preserves `message` and all relevant fields
- [ ] Existing tests pass with no regressions