### PR TITLE
fix(auth): include Cloudflare error codes in NETWORK_ERROR_CODES

### DIFF
--- a/packages/core/auth-js/src/lib/fetch.ts
+++ b/packages/core/auth-js/src/lib/fetch.ts
@@ -35,7 +35,10 @@ export type RequestMethodType = 'GET' | 'POST' | 'PUT' | 'DELETE'
 const _getErrorMessage = (err: any): string =>
   err.msg || err.message || err.error_description || err.error || JSON.stringify(err)
 
-const NETWORK_ERROR_CODES = [502, 503, 504]
+// 502, 503, 504: Standard server/gateway errors
+// 520-524, 530: Cloudflare-specific error codes (web server down, connection timed out, etc.)
+// These are infrastructure errors and should not cause session invalidation.
+const NETWORK_ERROR_CODES = [502, 503, 504, 520, 521, 522, 523, 524, 530]
 
 export async function handleError(error: unknown) {
   if (!looksLikeFetchResponse(error)) {


### PR DESCRIPTION
## Description

When Supabase is deployed behind Cloudflare and the server goes down, Cloudflare responds with HTTP `5xx` error codes that are **not** standard HTTP codes:

- `520` — Unknown error
- `521` — Web server is down
- `522` — Connection timed out
- `523` — Origin is unreachable
- `524` — A timeout occurred
- `530` — Cloudflare 1xxx error

Previously, `NETWORK_ERROR_CODES` only included `[502, 503, 504]`. When Cloudflare returned a `521` (or similar), `handleError` would fall through to parse the response body as an auth API error — which would fail (since the Cloudflare HTML error page isn't valid JSON), and in some cases cause the auth client to **wipe the user's session token** as if it were an auth failure.

### What changed?

- `packages/core/auth-js/src/lib/fetch.ts`: Extended `NETWORK_ERROR_CODES` to include Cloudflare-specific error codes (`520`, `521`, `522`, `523`, `524`, `530`). These are now correctly classified as retryable infrastructure errors (`AuthRetryableFetchError`) instead of auth API errors.

### Checklist

- [x] PR title follows the conventional commit format
- [x] Changes are limited to a single logical unit
- [x] Code is self-documenting with inline comments explaining the Cloudflare codes

Fixes #1684