### PR TITLE
fix(postgrest)!: wrap error in PostgrestError instance on processResponse

### DIFF
--- a/packages/core/postgrest-js/jest.config.ts
+++ b/packages/core/postgrest-js/jest.config.ts
@@ -19,6 +19,6 @@ const config: Config.InitialOptions = {
       tsconfig: 'tsconfig.test.json',
     },
   },
-    snapshotSerializers: ['<rootDir>/test/postgrestErrorSerializer.js'],
+  snapshotSerializers: ['<rootDir>/test/postgrestErrorSerializer.js'],
 }
 export default config

--- a/packages/core/postgrest-js/jest.config.ts
+++ b/packages/core/postgrest-js/jest.config.ts
@@ -19,5 +19,6 @@ const config: Config.InitialOptions = {
       tsconfig: 'tsconfig.test.json',
     },
   },
+    snapshotSerializers: ['<rootDir>/test/postgrestErrorSerializer.js'],
 }
 export default config

--- a/packages/core/postgrest-js/src/PostgrestBuilder.ts
+++ b/packages/core/postgrest-js/src/PostgrestBuilder.ts
@@ -533,7 +533,7 @@ export default abstract class PostgrestBuilder<
 
     return {
       success: error === null,
-      error,
+      error: error ? new PostgrestError(error) : null,
       data,
       count,
       status,

--- a/packages/core/postgrest-js/src/PostgrestBuilder.ts
+++ b/packages/core/postgrest-js/src/PostgrestBuilder.ts
@@ -446,7 +446,7 @@ export default abstract class PostgrestBuilder<
    */
   private async processResponse(res: Response): Promise<{
     success: boolean
-    error: any
+    error: PostgrestError | null
     data: any
     count: number | null
     status: number

--- a/packages/core/postgrest-js/src/PostgrestError.ts
+++ b/packages/core/postgrest-js/src/PostgrestError.ts
@@ -23,6 +23,7 @@ export default class PostgrestError extends Error {
    */
   constructor(context: { message: string; details: string; hint: string; code: string }) {
     super(context.message)
+        Object.defineProperty(this, 'message', { value: context.message, enumerable: true, writable: true, configurable: true })
     this.name = 'PostgrestError'
     this.details = context.details
     this.hint = context.hint

--- a/packages/core/postgrest-js/src/PostgrestError.ts
+++ b/packages/core/postgrest-js/src/PostgrestError.ts
@@ -23,7 +23,12 @@ export default class PostgrestError extends Error {
    */
   constructor(context: { message: string; details: string; hint: string; code: string }) {
     super(context.message)
-        Object.defineProperty(this, 'message', { value: context.message, enumerable: true, writable: true, configurable: true })
+    Object.defineProperty(this, 'message', {
+      value: context.message,
+      enumerable: true,
+      writable: true,
+      configurable: true,
+    })
     this.name = 'PostgrestError'
     this.details = context.details
     this.hint = context.hint

--- a/packages/core/postgrest-js/test/basic.test.ts
+++ b/packages/core/postgrest-js/test/basic.test.ts
@@ -937,13 +937,13 @@ test('throwOnError throws errors instead of returning them', async () => {
     // @ts-expect-error Argument of type '"missing_table"' is not assignable to parameter
     await postgrest.from('missing_table').select().throwOnError()
   } catch (error) {
-expect(error).toBeInstanceOf(PostgrestError)
-      expect(error).toMatchObject({
-        code: 'PGRST205',
-        details: null,
-        hint: null,
-        message: "Could not find the table 'public.missing_table' in the schema cache",
-      })
+    expect(error).toBeInstanceOf(PostgrestError)
+    expect(error).toMatchObject({
+      code: 'PGRST205',
+      details: null,
+      hint: null,
+      message: "Could not find the table 'public.missing_table' in the schema cache",
+    })
     isErrorCaught = true
   }
 

--- a/packages/core/postgrest-js/test/basic.test.ts
+++ b/packages/core/postgrest-js/test/basic.test.ts
@@ -1,4 +1,4 @@
-import { PostgrestClient } from '../src/index'
+import { PostgrestClient, PostgrestError } from '../src/index'
 import { CustomUserDataType, Database } from './types.override'
 
 const REST_URL = 'http://localhost:54321/rest/v1'

--- a/packages/core/postgrest-js/test/basic.test.ts
+++ b/packages/core/postgrest-js/test/basic.test.ts
@@ -937,15 +937,13 @@ test('throwOnError throws errors instead of returning them', async () => {
     // @ts-expect-error Argument of type '"missing_table"' is not assignable to parameter
     await postgrest.from('missing_table').select().throwOnError()
   } catch (error) {
-    expect(error).toMatchInlineSnapshot(`      `
-      Object {
-        "code": "PGRST205",
-        "details": null,
-        "hint": null,
-        "message": "Could not find the table 'public.missing_table' in the schema cache",
-      }
-    `
-    )
+expect(error).toBeInstanceOf(PostgrestError)
+      expect(error).toMatchObject({
+        code: 'PGRST205',
+        details: null,
+        hint: null,
+        message: "Could not find the table 'public.missing_table' in the schema cache",
+      })
     isErrorCaught = true
   }
 

--- a/packages/core/postgrest-js/test/basic.test.ts
+++ b/packages/core/postgrest-js/test/basic.test.ts
@@ -937,8 +937,14 @@ test('throwOnError throws errors instead of returning them', async () => {
     // @ts-expect-error Argument of type '"missing_table"' is not assignable to parameter
     await postgrest.from('missing_table').select().throwOnError()
   } catch (error) {
-    expect(error).toMatchInlineSnapshot(
-      `[PostgrestError: Could not find the table 'public.missing_table' in the schema cache]`
+    expect(error).toMatchInlineSnapshot(`      `
+      Object {
+        "code": "PGRST205",
+        "details": null,
+        "hint": null,
+        "message": "Could not find the table 'public.missing_table' in the schema cache",
+      }
+    `
     )
     isErrorCaught = true
   }

--- a/packages/core/postgrest-js/test/postgrestErrorSerializer.js
+++ b/packages/core/postgrest-js/test/postgrestErrorSerializer.js
@@ -1,0 +1,23 @@
+/**
+ * Custom Jest snapshot serializer for PostgrestError instances.
+ * Serializes PostgrestError as a plain object so existing inline snapshots
+ * remain compatible after the instanceof fix in PostgrestBuilder.
+ */
+module.exports = {
+  test(val) {
+    return (
+      val !== null &&
+      typeof val === 'object' &&
+      val.constructor &&
+      val.constructor.name === 'PostgrestError'
+    )
+  },
+  print(val, serialize) {
+    return serialize({
+      code: val.code,
+      details: val.details,
+      hint: val.hint,
+      message: val.message,
+    })
+  },
+}


### PR DESCRIPTION
## Problem

The `error` field returned by `processResponse` in `PostgrestBuilder` is a plain object literal, not an instance of `PostgrestError`. `error instanceof PostgrestError` always returns `false`, breaking error type-narrowing for consumers.

Related issue: https://github.com/supabase/supabase-js/issues/1643

## Fix

Wrap the non-null `error` in `new PostgrestError(error)` in the final return of `processResponse`, matching the existing `throw new PostgrestError(error)` on the `shouldThrowOnError` path.

```ts
// Before
error,

// After
error: error ? new PostgrestError(error) : null,
```

Consumers can now reliably narrow:

```ts
const { error } = await supabase.from('table').select()
if (error instanceof PostgrestError) {
  console.log(error.code, error.message)
}
```

## Breaking change (v3)

The runtime shape of `error` changes from plain `Object` to a `PostgrestError`/`Error` instance:

- `error instanceof Error` flips `false` → `true`.
- `JSON.stringify(error)` routes through `toJSON()` and emits a new `name: "PostgrestError"` field.
- `Object.keys(error)` now includes `name` (and `message`, see below).
- The error now carries a `stack`.

Consumers forwarding errors to logs / UIs / wire formats may see the new shape.

## Other changes

- **`PostgrestError` constructor**: explicitly marks `message` as enumerable. `Error`'s super constructor leaves it non-enumerable, which would otherwise hide it from spread, `pretty-format`, and `JSON.stringify` paths that don't go through `toJSON()`. Now consistent with `code` / `details` / `hint`.
- **Jest snapshot serializer** (`test/postgrestErrorSerializer.js`): renders `PostgrestError` instances as `{ code, details, hint, message }` so existing inline snapshots stay valid after the prototype flip. Only matches `PostgrestError` instances — no effect on other values.
