### PR TITLE
fix(storage): add toJSON to StorageError for correct JSON serialization

### DIFF
--- a/packages/core/storage-js/src/lib/common/errors.ts
+++ b/packages/core/storage-js/src/lib/common/errors.ts
@@ -26,6 +26,15 @@ export class StorageError extends Error {
     this.status = status
     this.statusCode = statusCode
   }
+
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+      status: this.status,
+      statusCode: this.statusCode,
+    }
+  }
 }
 
 /**
@@ -59,10 +68,7 @@ export class StorageApiError extends StorageError {
 
   toJSON() {
     return {
-      name: this.name,
-      message: this.message,
-      status: this.status,
-      statusCode: this.statusCode,
+      ...super.toJSON(),
     }
   }
 }

--- a/packages/core/storage-js/test/common/errors.test.ts
+++ b/packages/core/storage-js/test/common/errors.test.ts
@@ -206,6 +206,74 @@ describe('Common Errors', () => {
     })
   })
 
+  describe('JSON serialization', () => {
+    it('should serialize StorageError with JSON.stringify', () => {
+      const error = new StorageError('Upload failed', 'storage', 500, 'InternalError')
+      const serialized = JSON.parse(JSON.stringify(error))
+      expect(serialized.message).toBe('Upload failed')
+      expect(serialized.name).toBe('StorageError')
+      expect(serialized.status).toBe(500)
+      expect(serialized.statusCode).toBe('InternalError')
+    })
+
+    it('should serialize StorageError without optional fields', () => {
+      const error = new StorageError('Something went wrong')
+      const serialized = JSON.parse(JSON.stringify(error))
+      expect(serialized.message).toBe('Something went wrong')
+      expect(serialized.name).toBe('StorageError')
+    })
+
+    it('should serialize StorageApiError with JSON.stringify', () => {
+      const error = new StorageApiError('Not found', 404, 'NotFound')
+      const serialized = JSON.parse(JSON.stringify(error))
+      expect(serialized.message).toBe('Not found')
+      expect(serialized.name).toBe('StorageApiError')
+      expect(serialized.status).toBe(404)
+      expect(serialized.statusCode).toBe('NotFound')
+    })
+
+    it('should serialize StorageUnknownError with JSON.stringify', () => {
+      const error = new StorageUnknownError('Unknown failure', new Error('original'))
+      const serialized = JSON.parse(JSON.stringify(error))
+      expect(serialized.message).toBe('Unknown failure')
+      expect(serialized.name).toBe('StorageUnknownError')
+      expect(serialized).not.toHaveProperty('originalError')
+    })
+
+    it('should serialize vectors namespace errors with JSON.stringify', () => {
+      const baseError = new StorageError('test', 'vectors')
+      const serialized = JSON.parse(JSON.stringify(baseError))
+      expect(serialized.name).toBe('StorageVectorsError')
+      expect(serialized.message).toBe('test')
+
+      const apiError = new StorageApiError('API error', 500, 'InternalError', 'vectors')
+      const apiSerialized = JSON.parse(JSON.stringify(apiError))
+      expect(apiSerialized.name).toBe('StorageVectorsApiError')
+      expect(apiSerialized.status).toBe(500)
+      expect(apiSerialized.statusCode).toBe('InternalError')
+
+      const unknownError = new StorageUnknownError('Unknown', new Error(), 'vectors')
+      const unknownSerialized = JSON.parse(JSON.stringify(unknownError))
+      expect(unknownSerialized.name).toBe('StorageVectorsUnknownError')
+      expect(unknownSerialized).not.toHaveProperty('originalError')
+    })
+
+    it('should serialize backward compatibility classes with JSON.stringify', () => {
+      const error = new StorageVectorsApiError('Conflict', 409, 'S3VectorConflictException')
+      const serialized = JSON.parse(JSON.stringify(error))
+      expect(serialized.message).toBe('Conflict')
+      expect(serialized.name).toBe('StorageVectorsApiError')
+      expect(serialized.status).toBe(409)
+      expect(serialized.statusCode).toBe('S3VectorConflictException')
+
+      const unknownError = new StorageVectorsUnknownError('Unknown', { circular: true })
+      const unknownSerialized = JSON.parse(JSON.stringify(unknownError))
+      expect(unknownSerialized.message).toBe('Unknown')
+      expect(unknownSerialized.name).toBe('StorageVectorsUnknownError')
+      expect(unknownSerialized).not.toHaveProperty('originalError')
+    })
+  })
+
   describe('StorageVectorsErrorCode', () => {
     it('should have all expected error codes', () => {
       expect(StorageVectorsErrorCode.InternalError).toBe('InternalError')


### PR DESCRIPTION
Closes #2247

`JSON.stringify()` on `StorageError` or `StorageUnknownError` returns `{}` because `Error` properties aren't enumerable. `StorageApiError` already had a `toJSON()` override, but the base class and `StorageUnknownError` didn't.

This adds `toJSON()` to the `StorageError` base class so all subclasses serialize correctly. `StorageApiError.toJSON()` is refactored to use `...super.toJSON()` instead of duplicating field access.

`StorageUnknownError` inherits the base `toJSON()` and intentionally excludes `originalError` from serialized output since the underlying error is typed `unknown` and could be circular or non-serializable.

Same pattern as `FunctionsError` (#2226), `PostgrestError` (#2212), and `AuthError` (#2238).

Tests cover `JSON.stringify` serialization for all error classes including vectors namespace and backward-compat classes.