### PR TITLE
fix(storage): remove client-side signed URL render endpoint normalization

### DIFF
--- a/packages/core/storage-js/src/packages/StorageFileApi.ts
+++ b/packages/core/storage-js/src/packages/StorageFileApi.ts
@@ -667,18 +667,10 @@ export default class StorageFileApi extends BaseApiClient<StorageError> {
       if (options?.cacheNonce != null) query.set('cacheNonce', String(options.cacheNonce))
       const queryString = query.toString()
 
-      // When transforms are requested the signed URL must use the render endpoint.
-      // Some storage-api versions return /object/sign/ even for transform requests,
-      // so we normalise the path on the client side.
-      const returnedPath =
-        hasTransform && data.signedURL.includes('/object/sign/')
-          ? data.signedURL.replace('/object/sign/', '/render/image/sign/')
-          : data.signedURL
-
-      // `returnedPath` contains a `token` query parameter, so append extra params with `&` only
-      // when we actually have something to add.
+      // `data.signedURL` contains a `token` query parameter, so append extra params with `&`
+      // only when we actually have something to add.
       const signedUrl = encodeURI(
-        `${this.url}${returnedPath}${queryString ? `&${queryString}` : ''}`
+        `${this.url}${data.signedURL}${queryString ? `&${queryString}` : ''}`
       )
 
       return { signedUrl }

--- a/packages/core/storage-js/test/storageFileApi.test.ts
+++ b/packages/core/storage-js/test/storageFileApi.test.ts
@@ -119,10 +119,11 @@ describe('Object API', () => {
       })
 
       expect(res.error).toBeNull()
-      expect(res.data?.signedUrl).toContain(`${URL}/render/image/sign/${bucketName}/${uploadPath}`)
+      expect(res.data?.signedUrl).toContain(`/${bucketName}/${uploadPath}`)
+      expect(res.data?.signedUrl).toContain('token=')
     })
 
-    test('sign url with empty transform object does not use render endpoint', async () => {
+    test('sign url with empty transform object uses object endpoint', async () => {
       await storage.from(bucketName).upload(uploadPath, file)
       const res = await storage.from(bucketName).createSignedUrl(uploadPath, 2000, {
         transform: {},
@@ -130,7 +131,6 @@ describe('Object API', () => {
 
       expect(res.error).toBeNull()
       expect(res.data?.signedUrl).toContain(`${URL}/object/sign/${bucketName}/${uploadPath}`)
-      expect(res.data?.signedUrl).not.toContain('/render/image/sign/')
     })
 
     test('sign url with custom filename for download', async () => {


### PR DESCRIPTION
## Description

### What changed?

Removed the client-side normalization in `StorageFileApi.createSignedUrl` that rewrote signed URLs from `/object/sign/` to `/render/image/sign/` when transform options were present.

The client now uses the signed URL returned by the storage server as-is, without any path rewriting.

Updated tests to no longer assert a specific endpoint prefix for transform signed URLs, since the server is responsible for returning the correct path.

### Why was this change needed?

The normalization was added in #2143 as a workaround for older storage-api versions that returned `/object/sign/` even when transforms were requested. The storage server has returned the correct `/render/image/sign/` path for transform-enabled tenants since late 2022 (supabase/storage-api@05824a7).

When transforms are disabled on a tenant, the server intentionally returns `/object/sign/`. Rewriting that path to `/render/image/sign/` on the client was incorrect -- the JWT token in that case contains no transformation data, so the render endpoint cannot apply transforms anyway.

This normalization only existed in the JS SDK. Other Supabase SDKs (Dart, Kotlin, Swift, Python) do not perform this rewrite and rely on the server to return the correct path.

## Breaking changes

- [x] This PR contains no breaking changes

## Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/supabase/supabase-js/blob/master/CONTRIBUTING.md)
- [x] My PR title follows the [conventional commit format](https://www.conventionalcommits.org/): `<type>(<scope>): <description>`
- [x] I have run `npx nx format` to ensure consistent code formatting
- [x] I have added tests for new functionality (if applicable)
- [ ] I have updated documentation (if applicable)

## Additional notes

The `hasTransform` check is retained because it is still used to decide whether to include the `transform` object in the POST body sent to the server. Only the post-response URL rewriting was removed.