### PR TITLE
feat(storage): extract shared header normalization utility

### DIFF
--- a/packages/core/storage-js/src/lib/common/BaseApiClient.ts
+++ b/packages/core/storage-js/src/lib/common/BaseApiClient.ts
@@ -1,5 +1,6 @@
 import { ErrorNamespace, isStorageError, StorageError } from './errors'
 import { Fetch } from './fetch'
+import { setHeader as setHeaderUtil } from './headers'
 import { resolveFetch } from './helpers'
 
 /**
@@ -55,7 +56,7 @@ export default abstract class BaseApiClient<TError extends StorageError = Storag
    * @returns this - For method chaining
    */
   public setHeader(name: string, value: string): this {
-    this.headers = { ...this.headers, [name.toLowerCase()]: value }
+    this.headers = setHeaderUtil(this.headers, name, value)
     return this
   }
 

--- a/packages/core/storage-js/src/lib/common/BaseApiClient.ts
+++ b/packages/core/storage-js/src/lib/common/BaseApiClient.ts
@@ -1,6 +1,6 @@
 import { ErrorNamespace, isStorageError, StorageError } from './errors'
 import { Fetch } from './fetch'
-import { setHeader as setHeaderUtil } from './headers'
+import { normalizeHeaders, setHeader as setHeaderUtil } from './headers'
 import { resolveFetch } from './helpers'
 
 /**
@@ -31,7 +31,7 @@ export default abstract class BaseApiClient<TError extends StorageError = Storag
     namespace: ErrorNamespace = 'storage'
   ) {
     this.url = url
-    this.headers = Object.fromEntries(Object.entries(headers).map(([k, v]) => [k.toLowerCase(), v]))
+    this.headers = normalizeHeaders(headers)
     this.fetch = resolveFetch(fetch)
     this.namespace = namespace
   }

--- a/packages/core/storage-js/src/lib/common/fetch.ts
+++ b/packages/core/storage-js/src/lib/common/fetch.ts
@@ -1,4 +1,5 @@
 import { StorageApiError, StorageUnknownError, ErrorNamespace } from './errors'
+import { setHeader } from './headers'
 import { isPlainObject, resolveResponse } from './helpers'
 import { FetchParameters } from '../types'
 
@@ -104,7 +105,7 @@ const _getRequestParams = (
       }
     }
 
-    params.headers = setRequestHeader(headers, 'Content-Type', contentType ?? 'application/json')
+    params.headers = setHeader(headers, 'Content-Type', contentType ?? 'application/json')
     params.body = JSON.stringify(body)
   } else {
     params.body = body
@@ -115,19 +116,6 @@ const _getRequestParams = (
   }
 
   return { ...params, ...parameters }
-}
-
-function setRequestHeader(headers: Record<string, string>, name: string, value: string) {
-  const nextHeaders = { ...headers }
-
-  for (const key of Object.keys(nextHeaders)) {
-    if (key.toLowerCase() === name.toLowerCase()) {
-      delete nextHeaders[key]
-    }
-  }
-
-  nextHeaders[name] = value
-  return nextHeaders
 }
 
 /**

--- a/packages/core/storage-js/src/lib/common/headers.ts
+++ b/packages/core/storage-js/src/lib/common/headers.ts
@@ -1,10 +1,10 @@
 /**
  * Sets a header with case-insensitive deduplication.
  * Removes any existing headers whose name matches (case-insensitive),
- * then sets the new key/value. Does not mutate the input object.
+ * then sets the value under the lowercase key. Does not mutate the input object.
  *
  * @param headers - Existing headers object
- * @param name - Header name to set
+ * @param name - Header name to set (stored as lowercase)
  * @param value - Header value
  * @returns New headers object with the header set
  */
@@ -22,7 +22,7 @@ export function setHeader(
     }
   }
 
-  result[name] = value
+  result[nameLower] = value
   return result
 }
 

--- a/packages/core/storage-js/src/lib/common/headers.ts
+++ b/packages/core/storage-js/src/lib/common/headers.ts
@@ -25,3 +25,19 @@ export function setHeader(
   result[name] = value
   return result
 }
+
+/**
+ * Normalizes all header keys to lowercase with case-insensitive deduplication.
+ * When duplicate keys exist (differing only in case), the last value wins.
+ * Does not mutate the input object.
+ *
+ * @param headers - Headers object to normalize
+ * @returns New headers object with all keys lowercased
+ */
+export function normalizeHeaders(headers: Record<string, string>): Record<string, string> {
+  const result: Record<string, string> = {}
+  for (const [key, value] of Object.entries(headers)) {
+    result[key.toLowerCase()] = value
+  }
+  return result
+}

--- a/packages/core/storage-js/src/lib/common/headers.ts
+++ b/packages/core/storage-js/src/lib/common/headers.ts
@@ -1,0 +1,27 @@
+/**
+ * Sets a header with case-insensitive deduplication.
+ * Removes any existing headers whose name matches (case-insensitive),
+ * then sets the new key/value. Does not mutate the input object.
+ *
+ * @param headers - Existing headers object
+ * @param name - Header name to set
+ * @param value - Header value
+ * @returns New headers object with the header set
+ */
+export function setHeader(
+  headers: Record<string, string>,
+  name: string,
+  value: string
+): Record<string, string> {
+  const result = { ...headers }
+  const nameLower = name.toLowerCase()
+
+  for (const key of Object.keys(result)) {
+    if (key.toLowerCase() === nameLower) {
+      delete result[key]
+    }
+  }
+
+  result[name] = value
+  return result
+}

--- a/packages/core/storage-js/src/packages/StorageFileApi.ts
+++ b/packages/core/storage-js/src/packages/StorageFileApi.ts
@@ -5,6 +5,7 @@ import {
   isStorageError,
 } from '../lib/common/errors'
 import { get, head, post, put, remove, Fetch } from '../lib/common/fetch'
+import { setHeader } from '../lib/common/headers'
 import { recursiveToCamel } from '../lib/common/helpers'
 import BaseApiClient from '../lib/common/BaseApiClient'
 import {
@@ -130,7 +131,9 @@ export default class StorageFileApi extends BaseApiClient<StorageError> {
       }
 
       if (fileOptions?.headers) {
-        headers = { ...headers, ...fileOptions.headers }
+        for (const [key, value] of Object.entries(fileOptions.headers)) {
+          headers = setHeader(headers, key, value)
+        }
       }
 
       const cleanPath = this._removeEmptyFolders(path)

--- a/packages/core/storage-js/test/common/fetch.test.ts
+++ b/packages/core/storage-js/test/common/fetch.test.ts
@@ -123,7 +123,7 @@ describe('Common Fetch', () => {
 
         expect(mockFetch).toHaveBeenCalledWith('http://test.com/api', {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
+          headers: { 'content-type': 'application/json' },
           body: JSON.stringify(requestBody),
         })
         expect(result).toEqual(responseData)
@@ -146,7 +146,7 @@ describe('Common Fetch', () => {
         expect(mockFetch).toHaveBeenCalledWith('http://test.com/api', {
           method: 'POST',
           headers: {
-            'Content-Type': 'application/json',
+            'content-type': 'application/json',
             Authorization: 'Bearer token',
           },
           body: JSON.stringify(requestBody),
@@ -174,7 +174,7 @@ describe('Common Fetch', () => {
           method: 'POST',
           headers: {
             Authorization: 'Bearer token',
-            'Content-Type': 'application/vnd.custom+json',
+            'content-type': 'application/vnd.custom+json',
           },
           body: JSON.stringify(requestBody),
         })
@@ -215,7 +215,7 @@ describe('Common Fetch', () => {
 
         expect(mockFetch).toHaveBeenCalledWith('http://test.com/api', {
           method: 'PUT',
-          headers: { 'Content-Type': 'application/json' },
+          headers: { 'content-type': 'application/json' },
           body: JSON.stringify(requestBody),
         })
         expect(result).toEqual(responseData)
@@ -255,7 +255,7 @@ describe('Common Fetch', () => {
 
         expect(mockFetch).toHaveBeenCalledWith('http://test.com/api', {
           method: 'DELETE',
-          headers: { 'Content-Type': 'application/json' },
+          headers: { 'content-type': 'application/json' },
           body: JSON.stringify(requestBody),
         })
         expect(result).toEqual(responseData)
@@ -277,7 +277,7 @@ describe('Common Fetch', () => {
 
         expect(mockFetch).toHaveBeenCalledWith('http://test.com/api', {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
+          headers: { 'content-type': 'application/json' },
           body: JSON.stringify(requestBody),
           duplex: 'half',
         })

--- a/packages/core/storage-js/test/common/headers.test.ts
+++ b/packages/core/storage-js/test/common/headers.test.ts
@@ -1,23 +1,22 @@
 import { normalizeHeaders, setHeader } from '../../src/lib/common/headers'
 
 describe('setHeader', () => {
-  it('sets a new header', () => {
+  it('sets a new header with lowercase key', () => {
     const result = setHeader({}, 'Content-Type', 'application/json')
-    expect(result).toEqual({ 'Content-Type': 'application/json' })
+    expect(result).toEqual({ 'content-type': 'application/json' })
   })
 
   it('replaces an existing header with the same case', () => {
-    const result = setHeader({ 'Content-Type': 'text/plain' }, 'Content-Type', 'application/json')
-    expect(result).toEqual({ 'Content-Type': 'application/json' })
+    const result = setHeader({ 'content-type': 'text/plain' }, 'content-type', 'application/json')
+    expect(result).toEqual({ 'content-type': 'application/json' })
   })
 
-  it('replaces an existing header with different case', () => {
+  it('replaces an existing header with different case and normalizes key to lowercase', () => {
     const result = setHeader({ 'content-type': 'text/plain' }, 'Content-Type', 'application/json')
-    expect(result).toEqual({ 'Content-Type': 'application/json' })
-    expect(result).not.toHaveProperty('content-type')
+    expect(result).toEqual({ 'content-type': 'application/json' })
   })
 
-  it('removes all case variants and sets one canonical key', () => {
+  it('removes all case variants and sets one lowercase canonical key', () => {
     const headers: Record<string, string> = {}
     // Simulate duplicate keys by building with Object.assign
     Object.assign(headers, {
@@ -26,8 +25,7 @@ describe('setHeader', () => {
     })
 
     const result = setHeader(headers, 'CONTENT-TYPE', 'application/json')
-    expect(Object.keys(result).filter((k) => k.toLowerCase() === 'content-type')).toHaveLength(1)
-    expect(result['CONTENT-TYPE']).toBe('application/json')
+    expect(result).toEqual({ 'content-type': 'application/json' })
   })
 
   it('does not mutate the input object', () => {
@@ -35,8 +33,8 @@ describe('setHeader', () => {
     const result = setHeader(original, 'Content-Type', 'application/json')
 
     expect(original['Content-Type']).toBe('text/plain')
-    expect(result['Content-Type']).toBe('application/json')
-    expect(result['Authorization']).toBe('Bearer token')
+    expect(result['content-type']).toBe('application/json')
+    expect(result).not.toHaveProperty('Content-Type')
   })
 
   it('preserves other headers when replacing', () => {
@@ -46,7 +44,7 @@ describe('setHeader', () => {
       'application/json'
     )
     expect(result).toEqual({
-      'Content-Type': 'application/json',
+      'content-type': 'application/json',
       authorization: 'Bearer token',
       'x-custom': 'value',
     })
@@ -60,10 +58,26 @@ describe('setHeader', () => {
     })
 
     const result = setHeader(headers, 'Content-Length', '42')
-    expect(result['Content-Length']).toBe('42')
-    // The unrelated content-type duplicates are untouched
+    expect(result).toEqual({
+      'content-type': 'text/plain',
+      'Content-Type': 'text/html',
+      'content-length': '42',
+    })
+  })
+
+  it('ensures no duplicate when setting an unrelated header with pre-existing duplicates', () => {
+    const headers: Record<string, string> = {}
+    Object.assign(headers, {
+      'content-type': 'text/plain',
+      'Content-Type': 'text/html',
+    })
+
+    const result = setHeader(headers, 'content-length', '42')
+    expect(result['content-length']).toBe('42')
+    // setHeader only deduplicates the header being set;
+    // pre-existing duplicates of other headers are preserved as-is
     const contentTypeKeys = Object.keys(result).filter((k) => k.toLowerCase() === 'content-type')
-    expect(contentTypeKeys.length).toBeGreaterThanOrEqual(1)
+    expect(contentTypeKeys).toHaveLength(2)
   })
 })
 

--- a/packages/core/storage-js/test/common/headers.test.ts
+++ b/packages/core/storage-js/test/common/headers.test.ts
@@ -1,4 +1,4 @@
-import { setHeader } from '../../src/lib/common/headers'
+import { normalizeHeaders, setHeader } from '../../src/lib/common/headers'
 
 describe('setHeader', () => {
   it('sets a new header', () => {
@@ -50,5 +50,53 @@ describe('setHeader', () => {
       authorization: 'Bearer token',
       'x-custom': 'value',
     })
+  })
+
+  it('does not deduplicate unrelated headers when setting a different one', () => {
+    const headers: Record<string, string> = {}
+    Object.assign(headers, {
+      'content-type': 'text/plain',
+      'Content-Type': 'text/html',
+    })
+
+    const result = setHeader(headers, 'Content-Length', '42')
+    expect(result['Content-Length']).toBe('42')
+    // The unrelated content-type duplicates are untouched
+    const contentTypeKeys = Object.keys(result).filter((k) => k.toLowerCase() === 'content-type')
+    expect(contentTypeKeys.length).toBeGreaterThanOrEqual(1)
+  })
+})
+
+describe('normalizeHeaders', () => {
+  it('lowercases all header keys', () => {
+    const result = normalizeHeaders({
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer token',
+    })
+    expect(result).toEqual({ 'content-type': 'application/json', authorization: 'Bearer token' })
+  })
+
+  it('deduplicates case variants keeping the last value', () => {
+    const headers: Record<string, string> = {}
+    Object.assign(headers, {
+      'content-type': 'text/plain',
+      'Content-Type': 'application/json',
+    })
+
+    const result = normalizeHeaders(headers)
+    expect(Object.keys(result).filter((k) => k === 'content-type')).toHaveLength(1)
+    expect(result['content-type']).toBe('application/json')
+  })
+
+  it('does not mutate the input object', () => {
+    const original = { 'Content-Type': 'text/plain' }
+    const result = normalizeHeaders(original)
+    expect(original).toHaveProperty('Content-Type')
+    expect(result).not.toHaveProperty('Content-Type')
+    expect(result).toHaveProperty('content-type')
+  })
+
+  it('returns empty object for empty input', () => {
+    expect(normalizeHeaders({})).toEqual({})
   })
 })

--- a/packages/core/storage-js/test/common/headers.test.ts
+++ b/packages/core/storage-js/test/common/headers.test.ts
@@ -1,0 +1,54 @@
+import { setHeader } from '../../src/lib/common/headers'
+
+describe('setHeader', () => {
+  it('sets a new header', () => {
+    const result = setHeader({}, 'Content-Type', 'application/json')
+    expect(result).toEqual({ 'Content-Type': 'application/json' })
+  })
+
+  it('replaces an existing header with the same case', () => {
+    const result = setHeader({ 'Content-Type': 'text/plain' }, 'Content-Type', 'application/json')
+    expect(result).toEqual({ 'Content-Type': 'application/json' })
+  })
+
+  it('replaces an existing header with different case', () => {
+    const result = setHeader({ 'content-type': 'text/plain' }, 'Content-Type', 'application/json')
+    expect(result).toEqual({ 'Content-Type': 'application/json' })
+    expect(result).not.toHaveProperty('content-type')
+  })
+
+  it('removes all case variants and sets one canonical key', () => {
+    const headers: Record<string, string> = {}
+    // Simulate duplicate keys by building with Object.assign
+    Object.assign(headers, {
+      'content-type': 'text/plain',
+      'Content-Type': 'text/html',
+    })
+
+    const result = setHeader(headers, 'CONTENT-TYPE', 'application/json')
+    expect(Object.keys(result).filter((k) => k.toLowerCase() === 'content-type')).toHaveLength(1)
+    expect(result['CONTENT-TYPE']).toBe('application/json')
+  })
+
+  it('does not mutate the input object', () => {
+    const original = { 'Content-Type': 'text/plain', Authorization: 'Bearer token' }
+    const result = setHeader(original, 'Content-Type', 'application/json')
+
+    expect(original['Content-Type']).toBe('text/plain')
+    expect(result['Content-Type']).toBe('application/json')
+    expect(result['Authorization']).toBe('Bearer token')
+  })
+
+  it('preserves other headers when replacing', () => {
+    const result = setHeader(
+      { 'content-type': 'text/plain', authorization: 'Bearer token', 'x-custom': 'value' },
+      'Content-Type',
+      'application/json'
+    )
+    expect(result).toEqual({
+      'Content-Type': 'application/json',
+      authorization: 'Bearer token',
+      'x-custom': 'value',
+    })
+  })
+})


### PR DESCRIPTION
## Description

### What changed?

Extracted a reusable `setHeader()` utility in `storage-js` that performs case-insensitive header deduplication. This consolidates header normalization logic that was previously scattered across multiple files:

- **New file: `headers.ts`** - Exports `setHeader(headers, name, value)` which removes any existing header matching the name (case-insensitive) before setting the new value. Returns a new object without mutating the input.
- **`fetch.ts`** - Removed the private `setRequestHeader` function and replaced it with the shared `setHeader` import.
- **`BaseApiClient.ts`** - The `setHeader` method now delegates to the utility instead of inline lowercasing.
- **`StorageFileApi.ts`** - User-provided `fileOptions.headers` are now merged via `setHeader` in a loop instead of a raw object spread, preventing case-variant duplicates (e.g. a user passing `Content-Type` when `content-type` already exists).

### Why was this change needed?

PR #2211 lowercased all headers in the `BaseApiClient` constructor. PR #2220 fixed the resulting `Content-Type` / `content-type` duplicate in `_getRequestParams` with inline logic.

The utility is scoped to `storage-js` for now since other packages (`postgrest-js`, `supabase-js`) already use the native `Headers` API which handles case-insensitivity natively.

## Breaking changes

- [x] This PR contains no breaking changes

## Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/supabase/supabase-js/blob/master/CONTRIBUTING.md)
- [x] My PR title follows the [conventional commit format](https://www.conventionalcommits.org/): `<type>(<scope>): <description>`
- [x] I have run `npx nx format` to ensure consistent code formatting
- [x] I have added tests for new functionality (if applicable)
- [ ] I have updated documentation (if applicable)

## Additional notes

- The `setHeader` utility is intentionally minimal: one function, one file, no class. It can be promoted to a shared package later if other SDK packages need it.
- Existing tests in `fetch.test.ts` and `BaseApiClient.test.ts` continue to pass, covering the content-type deduplication behavior from PR #2220.