### PR TITLE
fix(misc): add explicit return types to toJSON methods for JSR compat

### DIFF
--- a/packages/core/auth-js/src/lib/errors.ts
+++ b/packages/core/auth-js/src/lib/errors.ts
@@ -32,7 +32,12 @@ export class AuthError extends Error {
     this.code = code
   }
 
-  toJSON() {
+  toJSON(): {
+    name: string
+    message: string
+    status: number | undefined
+    code: ErrorCode | (string & {}) | undefined
+  } {
     return {
       name: this.name,
       message: this.message,
@@ -188,7 +193,13 @@ export class AuthImplicitGrantRedirectError extends CustomAuthError {
     this.details = details
   }
 
-  toJSON() {
+  toJSON(): {
+    name: string
+    message: string
+    status: number | undefined
+    code: ErrorCode | (string & {}) | undefined
+    details: { error: string; code: string } | null
+  } {
     return {
       ...super.toJSON(),
       details: this.details,
@@ -220,7 +231,13 @@ export class AuthPKCEGrantCodeExchangeError extends CustomAuthError {
     this.details = details
   }
 
-  toJSON() {
+  toJSON(): {
+    name: string
+    message: string
+    status: number | undefined
+    code: ErrorCode | (string & {}) | undefined
+    details: { error: string; code: string } | null
+  } {
     return {
       ...super.toJSON(),
       details: this.details,
@@ -307,7 +324,13 @@ export class AuthWeakPasswordError extends CustomAuthError {
     this.reasons = reasons
   }
 
-  toJSON() {
+  toJSON(): {
+    name: string
+    message: string
+    status: number | undefined
+    code: ErrorCode | (string & {}) | undefined
+    reasons: WeakPasswordReasons[]
+  } {
     return {
       ...super.toJSON(),
       reasons: this.reasons,

--- a/packages/core/functions-js/src/types.ts
+++ b/packages/core/functions-js/src/types.ts
@@ -35,7 +35,7 @@ export class FunctionsError extends Error {
     this.context = context
   }
 
-  toJSON() {
+  toJSON(): { name: string; message: string; context: any } {
     return {
       name: this.name,
       message: this.message,

--- a/packages/core/postgrest-js/src/PostgrestError.ts
+++ b/packages/core/postgrest-js/src/PostgrestError.ts
@@ -29,7 +29,7 @@ export default class PostgrestError extends Error {
     this.code = context.code
   }
 
-  toJSON() {
+  toJSON(): { name: string; message: string; details: string; hint: string; code: string } {
     return {
       name: this.name,
       message: this.message,

--- a/packages/core/storage-js/src/lib/common/errors.ts
+++ b/packages/core/storage-js/src/lib/common/errors.ts
@@ -27,7 +27,12 @@ export class StorageError extends Error {
     this.statusCode = statusCode
   }
 
-  toJSON() {
+  toJSON(): {
+    name: string
+    message: string
+    status: number | undefined
+    statusCode: string | undefined
+  } {
     return {
       name: this.name,
       message: this.message,
@@ -66,7 +71,12 @@ export class StorageApiError extends StorageError {
     this.statusCode = statusCode
   }
 
-  toJSON() {
+  toJSON(): {
+    name: string
+    message: string
+    status: number | undefined
+    statusCode: string | undefined
+  } {
     return {
       ...super.toJSON(),
     }


### PR DESCRIPTION
Adds explicit return types to all `toJSON()` methods across error classes in auth-js, functions-js, postgrest-js, and storage-js. The functions-js JSR canary publish was failing because JSR's slow-type checker requires explicit return types on public API methods. Applied the same fix to all packages for consistency, even though only functions-js and supabase-js are currently published to JSR.