### PR TITLE
fix(storage): correct signedUrl type to allow null in createSignedUrls

### DIFF
--- a/packages/core/storage-js/src/packages/StorageFileApi.ts
+++ b/packages/core/storage-js/src/packages/StorageFileApi.ts
@@ -728,7 +728,7 @@ export default class StorageFileApi extends BaseApiClient<StorageError> {
     options?: { download?: string | boolean; cacheNonce?: string }
   ): Promise<
     | {
-        data: { error: string | null; path: string | null; signedUrl: string }[]
+        data: { error: string | null; path: string | null; signedUrl: string | null }[]
         error: null
       }
     | {

--- a/packages/core/storage-js/test/storageFileApi.test.ts
+++ b/packages/core/storage-js/test/storageFileApi.test.ts
@@ -830,7 +830,7 @@ describe('Object API', () => {
       expect(res.data).toHaveLength(1)
       expect(res.data[0].error).toBeNull()
 
-      const parsedUrl = global.URL.parse(res.data[0].signedUrl)
+      const parsedUrl = global.URL.parse(res.data[0].signedUrl!)
       assert(parsedUrl)
       assert(parsedUrl.searchParams.has('cacheNonce', cacheNonce))
       assert(parsedUrl.searchParams.has('token'))
@@ -848,7 +848,7 @@ describe('Object API', () => {
       expect(res.data).toHaveLength(1)
       expect(res.data[0].error).toBeNull()
 
-      const parsedUrl = global.URL.parse(res.data[0].signedUrl)
+      const parsedUrl = global.URL.parse(res.data[0].signedUrl!)
       assert(parsedUrl)
       assert(parsedUrl.searchParams.has('cacheNonce', cacheNonce))
       assert(parsedUrl.searchParams.has('token'))


### PR DESCRIPTION
The `createSignedUrls` return type declared `signedUrl` as `string`, but when a requested path does not exist the Storage server returns `signedURL: null` for that item and the client maps it to `null` in the ternary. This corrects the type to `string | null` so consumers can handle the partial-failure case without a type assertion. The mismatch was not caught by the compiler because the internal `post()` helper returns `Promise<any>`.