### PR TITLE
fix(realtime): throw Error objects instead of bare strings

### DIFF
--- a/packages/core/realtime-js/src/RealtimeChannel.ts
+++ b/packages/core/realtime-js/src/RealtimeChannel.ts
@@ -251,7 +251,9 @@ export default class RealtimeChannel {
     this.private = this.params.config.private || false
 
     if (!this.private && this.params.config?.broadcast?.replay) {
-      throw `tried to use replay on public channel '${this.topic}'. It must be a private channel.`
+      throw new Error(
+        `tried to use replay on public channel '${this.topic}'. It must be a private channel.`
+      )
     }
   }
 
@@ -736,7 +738,7 @@ export default class RealtimeChannel {
     opts: { timeout?: number } = {}
   ): Promise<{ success: true } | { success: false; status: number; error: string }> {
     if (payload === undefined || payload === null) {
-      return Promise.reject('Payload is required for httpSend()')
+      return Promise.reject(new Error('Payload is required for httpSend()'))
     }
 
     const headers: Record<string, string> = {

--- a/packages/core/realtime-js/src/phoenix/channelAdapter.ts
+++ b/packages/core/realtime-js/src/phoenix/channelAdapter.ts
@@ -77,7 +77,9 @@ export default class ChannelAdapter {
     try {
       push = this.channel.push(event, payload, timeout)
     } catch (error) {
-      throw `tried to push '${event}' to '${this.channel.topic}' before joining. Use channel.subscribe() before pushing events`
+      throw new Error(
+        `tried to push '${event}' to '${this.channel.topic}' before joining. Use channel.subscribe() before pushing events`
+      )
     }
 
     if (this.channel.pushBuffer.length > MAX_PUSH_BUFFER_SIZE) {

--- a/packages/core/realtime-js/test/RealtimeChannel.messaging.test.ts
+++ b/packages/core/realtime-js/test/RealtimeChannel.messaging.test.ts
@@ -546,7 +546,7 @@ describe('httpSend', () => {
         if (hasToken) await testSetup.client.setAuth()
         const channel = testSetup.client.channel('topic')
 
-        await expect(channel.httpSend('test', undefined as any)).rejects.toBe(
+        await expect(channel.httpSend('test', undefined as any)).rejects.toThrow(
           'Payload is required for httpSend()'
         )
       })
@@ -556,7 +556,7 @@ describe('httpSend', () => {
         if (hasToken) await testSetup.client.setAuth()
         const channel = testSetup.client.channel('topic')
 
-        await expect(channel.httpSend('test', null as any)).rejects.toBe(
+        await expect(channel.httpSend('test', null as any)).rejects.toThrow(
           'Payload is required for httpSend()'
         )
       })


### PR DESCRIPTION
Closes #2255

Three locations in realtime-js throw or reject with bare strings instead of `Error` objects, breaking `instanceof Error` checks and losing stack traces:

- `RealtimeChannel.ts` constructor (replay on public channel)
- `channelAdapter.ts` push() -- catches an `Error` from upstream phoenix and re-throws as a string
- `RealtimeChannel.ts` httpSend() -- rejects with a string while another reject in the same method correctly uses `new Error()`

Wrapped all three in `new Error()` and updated 2 test assertions from `.rejects.toBe()` to `.rejects.toThrow()`.