### PR TITLE
chore(ci): remove embeddings-generator from dogfooding

### DIFF
--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -56,7 +56,7 @@ jobs:
           app-id: ${{ secrets.DOGFOOD_APP_ID }}
           private-key: ${{ secrets.DOGFOOD_APP_PRIVATE_KEY }}
           owner: supabase
-          repositories: supabase,multiplayer.dev,platform,tests,realtime,ssr,helper-scripts,embeddings-generator,dbdev
+          repositories: supabase,multiplayer.dev,platform,tests,realtime,ssr,helper-scripts,dbdev
 
       - name: Check if actor is member of admin or sdk team
         id: team-check
@@ -135,11 +135,6 @@ jobs:
               },
               {
                 repo: 'helper-scripts',
-                workflow: 'update-supabase-js.yml',
-                inputs: { version, source },
-              },
-              {
-                repo: 'embeddings-generator',
                 workflow: 'update-supabase-js.yml',
                 inputs: { version, source },
               },


### PR DESCRIPTION
Remove `embeddings-generator` project from dogfooding workflow. The team asked for it, because the project is dormant.