### PR TITLE
docs(repo): show createClient as primary example in all client constructors

### DIFF
--- a/packages/core/auth-js/src/GoTrueAdminApi.ts
+++ b/packages/core/auth-js/src/GoTrueAdminApi.ts
@@ -57,7 +57,15 @@ export default class GoTrueAdminApi {
   /**
    * Creates an admin API client that can be used to manage users and OAuth clients.
    *
-   * @example
+   * @example Using supabase-js (recommended)
+   * ```ts
+   * import { createClient } from '@supabase/supabase-js'
+   *
+   * const supabase = createClient('https://xyzcompany.supabase.co', 'secret-or-service-role-key')
+   * const { data, error } = await supabase.auth.admin.listUsers()
+   * ```
+   *
+   * @example Standalone import for bundle-sensitive environments
    * ```ts
    * import { GoTrueAdminApi } from '@supabase/auth-js'
    *

--- a/packages/core/auth-js/src/GoTrueClient.ts
+++ b/packages/core/auth-js/src/GoTrueClient.ts
@@ -285,7 +285,15 @@ export default class GoTrueClient {
   /**
    * Create a new client for use in the browser.
    *
-   * @example
+   * @example Using supabase-js (recommended)
+   * ```ts
+   * import { createClient } from '@supabase/supabase-js'
+   *
+   * const supabase = createClient('https://xyzcompany.supabase.co', 'public-anon-key')
+   * const { data, error } = await supabase.auth.getUser()
+   * ```
+   *
+   * @example Standalone import for bundle-sensitive environments
    * ```ts
    * import { GoTrueClient } from '@supabase/auth-js'
    *

--- a/packages/core/auth-js/src/GoTrueClient.ts
+++ b/packages/core/auth-js/src/GoTrueClient.ts
@@ -289,7 +289,7 @@ export default class GoTrueClient {
    * ```ts
    * import { createClient } from '@supabase/supabase-js'
    *
-   * const supabase = createClient('https://xyzcompany.supabase.co', 'public-anon-key')
+   * const supabase = createClient('https://xyzcompany.supabase.co', 'publishable-or-anon-key')
    * const { data, error } = await supabase.auth.getUser()
    * ```
    *
@@ -299,7 +299,7 @@ export default class GoTrueClient {
    *
    * const auth = new GoTrueClient({
    *   url: 'https://xyzcompany.supabase.co/auth/v1',
-   *   headers: { apikey: 'public-anon-key' },
+   *   headers: { apikey: 'publishable-or-anon-key' },
    *   storageKey: 'supabase-auth',
    * })
    * ```

--- a/packages/core/functions-js/src/FunctionsClient.ts
+++ b/packages/core/functions-js/src/FunctionsClient.ts
@@ -25,7 +25,7 @@ export class FunctionsClient {
    * ```ts
    * import { createClient } from '@supabase/supabase-js'
    *
-   * const supabase = createClient('https://xyzcompany.supabase.co', 'public-anon-key')
+   * const supabase = createClient('https://xyzcompany.supabase.co', 'publishable-or-anon-key')
    * const { data, error } = await supabase.functions.invoke('hello-world')
    * ```
    *
@@ -36,7 +36,7 @@ export class FunctionsClient {
    * import { FunctionsClient, FunctionRegion } from '@supabase/functions-js'
    *
    * const functions = new FunctionsClient('https://xyzcompany.supabase.co/functions/v1', {
-   *   headers: { apikey: 'public-anon-key' },
+   *   headers: { apikey: 'publishable-or-anon-key' },
    *   region: FunctionRegion.UsEast1,
    * })
    * ```

--- a/packages/core/functions-js/src/FunctionsClient.ts
+++ b/packages/core/functions-js/src/FunctionsClient.ts
@@ -21,19 +21,17 @@ export class FunctionsClient {
   /**
    * Creates a new Functions client bound to an Edge Functions URL.
    *
-   * @example
+   * @example Using supabase-js (recommended)
    * ```ts
-   * import { FunctionsClient, FunctionRegion } from '@supabase/functions-js'
+   * import { createClient } from '@supabase/supabase-js'
    *
-   * const functions = new FunctionsClient('https://xyzcompany.supabase.co/functions/v1', {
-   *   headers: { apikey: 'public-anon-key' },
-   *   region: FunctionRegion.UsEast1,
-   * })
+   * const supabase = createClient('https://xyzcompany.supabase.co', 'public-anon-key')
+   * const { data, error } = await supabase.functions.invoke('hello-world')
    * ```
    *
    * @category Functions
    *
-   * @example Creating a Functions client
+   * @example Standalone import for bundle-sensitive environments
    * ```ts
    * import { FunctionsClient, FunctionRegion } from '@supabase/functions-js'
    *

--- a/packages/core/postgrest-js/src/PostgrestBuilder.ts
+++ b/packages/core/postgrest-js/src/PostgrestBuilder.ts
@@ -92,19 +92,17 @@ export default abstract class PostgrestBuilder<
   /**
    * Creates a builder configured for a specific PostgREST request.
    *
-   * @example
+   * @example Using supabase-js (recommended)
    * ```ts
-   * import { PostgrestQueryBuilder } from '@supabase/postgrest-js'
+   * import { createClient } from '@supabase/supabase-js'
    *
-   * const builder = new PostgrestQueryBuilder(
-   *   new URL('https://xyzcompany.supabase.co/rest/v1/users'),
-   *   { headers: new Headers({ apikey: 'publishable-or-anon-key' }) }
-   * )
+   * const supabase = createClient('https://xyzcompany.supabase.co', 'publishable-or-anon-key')
+   * const { data, error } = await supabase.from('users').select('*')
    * ```
    *
    * @category Database
    *
-   * @example Creating a Postgrest query builder
+   * @example Standalone import for bundle-sensitive environments
    * ```ts
    * import { PostgrestQueryBuilder } from '@supabase/postgrest-js'
    *

--- a/packages/core/postgrest-js/src/PostgrestBuilder.ts
+++ b/packages/core/postgrest-js/src/PostgrestBuilder.ts
@@ -98,7 +98,7 @@ export default abstract class PostgrestBuilder<
    *
    * const builder = new PostgrestQueryBuilder(
    *   new URL('https://xyzcompany.supabase.co/rest/v1/users'),
-   *   { headers: new Headers({ apikey: 'public-anon-key' }) }
+   *   { headers: new Headers({ apikey: 'publishable-or-anon-key' }) }
    * )
    * ```
    *
@@ -110,7 +110,7 @@ export default abstract class PostgrestBuilder<
    *
    * const builder = new PostgrestQueryBuilder(
    *   new URL('https://xyzcompany.supabase.co/rest/v1/users'),
-   *   { headers: new Headers({ apikey: 'public-anon-key' }) }
+   *   { headers: new Headers({ apikey: 'publishable-or-anon-key' }) }
    * )
    * ```
    */

--- a/packages/core/postgrest-js/src/PostgrestClient.ts
+++ b/packages/core/postgrest-js/src/PostgrestClient.ts
@@ -62,7 +62,7 @@ export default class PostgrestClient<
    * ```ts
    * import { createClient } from '@supabase/supabase-js'
    *
-   * const supabase = createClient('https://xyzcompany.supabase.co', 'public-anon-key')
+   * const supabase = createClient('https://xyzcompany.supabase.co', 'publishable-or-anon-key')
    * const { data, error } = await supabase.from('profiles').select('*')
    * ```
    *
@@ -77,7 +77,7 @@ export default class PostgrestClient<
    * import { PostgrestClient } from '@supabase/postgrest-js'
    *
    * const postgrest = new PostgrestClient('https://xyzcompany.supabase.co/rest/v1', {
-   *   headers: { apikey: 'public-anon-key' },
+   *   headers: { apikey: 'publishable-or-anon-key' },
    *   schema: 'public',
    *   timeout: 30000, // 30 second timeout
    * })

--- a/packages/core/postgrest-js/src/PostgrestClient.ts
+++ b/packages/core/postgrest-js/src/PostgrestClient.ts
@@ -58,15 +58,12 @@ export default class PostgrestClient<
    *   When enabled, idempotent requests (GET, HEAD, OPTIONS) that fail with network
    *   errors or HTTP 503/520 responses will be automatically retried up to 3 times
    *   with exponential backoff (1s, 2s, 4s). Defaults to `true`.
-   * @example
+   * @example Using supabase-js (recommended)
    * ```ts
-   * import { PostgrestClient } from '@supabase/postgrest-js'
+   * import { createClient } from '@supabase/supabase-js'
    *
-   * const postgrest = new PostgrestClient('https://xyzcompany.supabase.co/rest/v1', {
-   *   headers: { apikey: 'public-anon-key' },
-   *   schema: 'public',
-   *   timeout: 30000, // 30 second timeout
-   * })
+   * const supabase = createClient('https://xyzcompany.supabase.co', 'public-anon-key')
+   * const { data, error } = await supabase.from('profiles').select('*')
    * ```
    *
    * @category Database
@@ -75,17 +72,7 @@ export default class PostgrestClient<
    * - A `timeout` option (in milliseconds) can be set to automatically abort requests that take too long.
    * - A `urlLengthLimit` option (default: 8000) can be set to control when URL length warnings are included in error messages for aborted requests.
    *
-   * @example Creating a Postgrest client
-   * ```ts
-   * import { PostgrestClient } from '@supabase/postgrest-js'
-   *
-   * const postgrest = new PostgrestClient('https://xyzcompany.supabase.co/rest/v1', {
-   *   headers: { apikey: 'public-anon-key' },
-   *   schema: 'public',
-   * })
-   * ```
-   *
-   * @example With timeout
+   * @example Standalone import for bundle-sensitive environments
    * ```ts
    * import { PostgrestClient } from '@supabase/postgrest-js'
    *
@@ -93,7 +80,6 @@ export default class PostgrestClient<
    *   headers: { apikey: 'public-anon-key' },
    *   schema: 'public',
    *   timeout: 30000, // 30 second timeout
-   *   retry: false, // Disable automatic retries
    * })
    * ```
    */

--- a/packages/core/postgrest-js/src/PostgrestQueryBuilder.ts
+++ b/packages/core/postgrest-js/src/PostgrestQueryBuilder.ts
@@ -44,7 +44,15 @@ export default class PostgrestQueryBuilder<
    * @param options.urlLengthLimit - Maximum URL length before warning
    * @param options.retry - Enable automatic retries for transient errors (default: true)
    *
-   * @example Creating a Postgrest query builder
+   * @example Using supabase-js (recommended)
+   * ```ts
+   * import { createClient } from '@supabase/supabase-js'
+   *
+   * const supabase = createClient('https://xyzcompany.supabase.co', 'publishable-or-anon-key')
+   * const { data, error } = await supabase.from('users').select('*')
+   * ```
+   *
+   * @example Standalone import for bundle-sensitive environments
    * ```ts
    * import { PostgrestQueryBuilder } from '@supabase/postgrest-js'
    *

--- a/packages/core/postgrest-js/src/PostgrestQueryBuilder.ts
+++ b/packages/core/postgrest-js/src/PostgrestQueryBuilder.ts
@@ -50,7 +50,7 @@ export default class PostgrestQueryBuilder<
    *
    * const query = new PostgrestQueryBuilder(
    *   new URL('https://xyzcompany.supabase.co/rest/v1/users'),
-   *   { headers: { apikey: 'public-anon-key' }, retry: true }
+   *   { headers: { apikey: 'publishable-or-anon-key' }, retry: true }
    * )
    * ```
    */

--- a/packages/core/realtime-js/src/RealtimeChannel.ts
+++ b/packages/core/realtime-js/src/RealtimeChannel.ts
@@ -212,7 +212,18 @@ export default class RealtimeChannel {
    *
    * @category Realtime
    *
-   * @example Example for a public channel
+   * @example Using supabase-js (recommended)
+   * ```ts
+   * import { createClient } from '@supabase/supabase-js'
+   *
+   * const supabase = createClient('https://xyzcompany.supabase.co', 'publishable-or-anon-key')
+   * const channel = supabase.channel('room1')
+   * channel
+   *   .on('broadcast', { event: 'cursor-pos' }, (payload) => console.log(payload))
+   *   .subscribe()
+   * ```
+   *
+   * @example Standalone import for bundle-sensitive environments
    * ```ts
    * import RealtimeClient from '@supabase/realtime-js'
    *

--- a/packages/core/realtime-js/src/RealtimeChannel.ts
+++ b/packages/core/realtime-js/src/RealtimeChannel.ts
@@ -217,7 +217,7 @@ export default class RealtimeChannel {
    * import RealtimeClient from '@supabase/realtime-js'
    *
    * const client = new RealtimeClient('https://xyzcompany.supabase.co/realtime/v1', {
-   *   params: { apikey: 'public-anon-key' },
+   *   params: { apikey: 'publishable-or-anon-key' },
    * })
    * const channel = new RealtimeChannel('realtime:public:messages', { config: {} }, client)
    * ```

--- a/packages/core/realtime-js/src/RealtimeClient.ts
+++ b/packages/core/realtime-js/src/RealtimeClient.ts
@@ -200,7 +200,18 @@ export default class RealtimeClient {
    *
    * @category Realtime
    *
-   * @example Example for a public channel
+   * @example Using supabase-js (recommended)
+   * ```ts
+   * import { createClient } from '@supabase/supabase-js'
+   *
+   * const supabase = createClient('https://xyzcompany.supabase.co', 'public-anon-key')
+   * const channel = supabase.channel('room1')
+   * channel
+   *   .on('broadcast', { event: 'cursor-pos' }, (payload) => console.log(payload))
+   *   .subscribe()
+   * ```
+   *
+   * @example Standalone import for bundle-sensitive environments
    * ```ts
    * import RealtimeClient from '@supabase/realtime-js'
    *

--- a/packages/core/realtime-js/src/RealtimeClient.ts
+++ b/packages/core/realtime-js/src/RealtimeClient.ts
@@ -204,7 +204,7 @@ export default class RealtimeClient {
    * ```ts
    * import { createClient } from '@supabase/supabase-js'
    *
-   * const supabase = createClient('https://xyzcompany.supabase.co', 'public-anon-key')
+   * const supabase = createClient('https://xyzcompany.supabase.co', 'publishable-or-anon-key')
    * const channel = supabase.channel('room1')
    * channel
    *   .on('broadcast', { event: 'cursor-pos' }, (payload) => console.log(payload))
@@ -216,7 +216,7 @@ export default class RealtimeClient {
    * import RealtimeClient from '@supabase/realtime-js'
    *
    * const client = new RealtimeClient('https://xyzcompany.supabase.co/realtime/v1', {
-   *   params: { apikey: 'public-anon-key' },
+   *   params: { apikey: 'publishable-or-anon-key' },
    * })
    * client.connect()
    * ```

--- a/packages/core/storage-js/src/StorageClient.ts
+++ b/packages/core/storage-js/src/StorageClient.ts
@@ -13,7 +13,15 @@ export class StorageClient extends StorageBucketApi {
    * Creates a client for Storage buckets, files, analytics, and vectors.
    *
    * @category File Buckets
-   * @example Creating a Storage client
+   * @example Using supabase-js (recommended)
+   * ```ts
+   * import { createClient } from '@supabase/supabase-js'
+   *
+   * const supabase = createClient('https://xyzcompany.supabase.co', 'public-anon-key')
+   * const avatars = supabase.storage.from('avatars')
+   * ```
+   *
+   * @example Standalone import for bundle-sensitive environments
    * ```ts
    * import { StorageClient } from '@supabase/storage-js'
    *

--- a/packages/core/storage-js/src/StorageClient.ts
+++ b/packages/core/storage-js/src/StorageClient.ts
@@ -17,7 +17,7 @@ export class StorageClient extends StorageBucketApi {
    * ```ts
    * import { createClient } from '@supabase/supabase-js'
    *
-   * const supabase = createClient('https://xyzcompany.supabase.co', 'public-anon-key')
+   * const supabase = createClient('https://xyzcompany.supabase.co', 'publishable-or-anon-key')
    * const avatars = supabase.storage.from('avatars')
    * ```
    *
@@ -26,7 +26,7 @@ export class StorageClient extends StorageBucketApi {
    * import { StorageClient } from '@supabase/storage-js'
    *
    * const storage = new StorageClient('https://xyzcompany.supabase.co/storage/v1', {
-   *   apikey: 'public-anon-key',
+   *   apikey: 'publishable-or-anon-key',
    * })
    * const avatars = storage.from('avatars')
    * ```

--- a/packages/core/storage-js/src/packages/StorageAnalyticsClient.ts
+++ b/packages/core/storage-js/src/packages/StorageAnalyticsClient.ts
@@ -35,7 +35,7 @@ export default class StorageAnalyticsClient extends BaseApiClient<StorageError> 
    * ```typescript
    * import { createClient } from '@supabase/supabase-js'
    *
-   * const supabase = createClient('https://xyzcompany.supabase.co', 'public-anon-key')
+   * const supabase = createClient('https://xyzcompany.supabase.co', 'publishable-or-anon-key')
    * const { data, error } = await supabase.storage.analytics.listBuckets()
    * ```
    *

--- a/packages/core/storage-js/src/packages/StorageAnalyticsClient.ts
+++ b/packages/core/storage-js/src/packages/StorageAnalyticsClient.ts
@@ -31,8 +31,18 @@ export default class StorageAnalyticsClient extends BaseApiClient<StorageError> 
    * @param headers - HTTP headers to include in requests
    * @param fetch - Optional custom fetch implementation
    *
-   * @example Creating a StorageAnalyticsClient instance
+   * @example Using supabase-js (recommended)
    * ```typescript
+   * import { createClient } from '@supabase/supabase-js'
+   *
+   * const supabase = createClient('https://xyzcompany.supabase.co', 'public-anon-key')
+   * const { data, error } = await supabase.storage.analytics.listBuckets()
+   * ```
+   *
+   * @example Standalone import for bundle-sensitive environments
+   * ```typescript
+   * import { StorageAnalyticsClient } from '@supabase/storage-js'
+   *
    * const client = new StorageAnalyticsClient(url, headers)
    * ```
    */

--- a/packages/core/storage-js/src/packages/StorageVectorsClient.ts
+++ b/packages/core/storage-js/src/packages/StorageVectorsClient.ts
@@ -90,8 +90,18 @@ export class StorageVectorsClient extends VectorBucketApi {
    * @param options.headers - Optional headers (for example `Authorization`) applied to every request.
    * @param options.fetch - Optional custom `fetch` implementation for non-browser runtimes.
    *
-   * @example Creating a StorageVectorsClient instance
+   * @example Using supabase-js (recommended)
    * ```typescript
+   * import { createClient } from '@supabase/supabase-js'
+   *
+   * const supabase = createClient('https://xyzcompany.supabase.co', 'public-anon-key')
+   * const bucket = supabase.storage.vectors.from('embeddings-prod')
+   * ```
+   *
+   * @example Standalone import for bundle-sensitive environments
+   * ```typescript
+   * import { StorageVectorsClient } from '@supabase/storage-js'
+   *
    * const client = new StorageVectorsClient(url, options)
    * ```
    */

--- a/packages/core/storage-js/src/packages/StorageVectorsClient.ts
+++ b/packages/core/storage-js/src/packages/StorageVectorsClient.ts
@@ -94,7 +94,7 @@ export class StorageVectorsClient extends VectorBucketApi {
    * ```typescript
    * import { createClient } from '@supabase/supabase-js'
    *
-   * const supabase = createClient('https://xyzcompany.supabase.co', 'public-anon-key')
+   * const supabase = createClient('https://xyzcompany.supabase.co', 'publishable-or-anon-key')
    * const bucket = supabase.storage.vectors.from('embeddings-prod')
    * ```
    *

--- a/packages/core/supabase-js/src/SupabaseClient.ts
+++ b/packages/core/supabase-js/src/SupabaseClient.ts
@@ -271,7 +271,7 @@ export default class SupabaseClient<
    * ```ts
    * import { createClient } from '@supabase/supabase-js'
    *
-   * const supabase = createClient('https://xyzcompany.supabase.co', 'public-anon-key')
+   * const supabase = createClient('https://xyzcompany.supabase.co', 'publishable-or-anon-key')
    *
    * const { data } = await supabase.from('profiles').select('*')
    * ```

--- a/packages/core/supabase-js/src/index.ts
+++ b/packages/core/supabase-js/src/index.ts
@@ -39,7 +39,7 @@ export type {
  * ```ts
  * import { createClient } from '@supabase/supabase-js'
  *
- * const supabase = createClient('https://xyzcompany.supabase.co', 'public-anon-key')
+ * const supabase = createClient('https://xyzcompany.supabase.co', 'publishable-or-anon-key')
  * const { data, error } = await supabase.from('profiles').select('*')
  * ```
  */


### PR DESCRIPTION
Updates all TSDoc `@example` blocks across the monorepo to show `createClient` from `@supabase/supabase-js` as the primary initialization pattern, with standalone sub-library imports preserved as a secondary example for bundle-sensitive environments. Also normalizes the placeholder API key from `public-anon-key` to `publishable-or-anon-key` across all examples to align with the current API key documentation. Duplicate examples in PostgrestClient, PostgrestBuilder, and FunctionsClient are consolidated.