### PR TITLE
feat(auth): add passkey support with WebAuthn registration, authentication, and management

### DIFF
--- a/packages/core/auth-js/src/GoTrueAdminApi.ts
+++ b/packages/core/auth-js/src/GoTrueAdminApi.ts
@@ -5,7 +5,7 @@ import {
   _request,
   _userResponse,
 } from './lib/fetch'
-import { resolveFetch, validateUUID } from './lib/helpers'
+import { assertPasskeyExperimentalEnabled, resolveFetch, validateUUID } from './lib/helpers'
 import {
   AdminUserAttributes,
   GenerateLinkParams,
@@ -37,6 +37,7 @@ import {
   AuthPasskeyAdminDeleteParams,
   AuthPasskeyListResponse,
   AuthPasskeyDeleteResponse,
+  ExperimentalFeatureFlags,
 } from './lib/types'
 import { AuthError, isAuthError } from './lib/errors'
 
@@ -53,7 +54,11 @@ export default class GoTrueAdminApi {
   /** Contains all custom OIDC/OAuth provider administration methods. */
   customProviders: GoTrueAdminCustomProvidersApi
 
-  /** Contains all passkey administration methods. */
+  /**
+   * Contains all passkey administration methods.
+   *
+   * Requires `auth.experimental.passkey: true`; otherwise all methods throw.
+   */
   passkey: GoTrueAdminPasskeyApi
 
   protected url: string
@@ -61,6 +66,7 @@ export default class GoTrueAdminApi {
     [key: string]: string
   }
   protected fetch: Fetch
+  protected experimental: ExperimentalFeatureFlags
 
   /**
    * Creates an admin API client that can be used to manage users and OAuth clients.
@@ -87,16 +93,19 @@ export default class GoTrueAdminApi {
     url = '',
     headers = {},
     fetch,
+    experimental,
   }: {
     url: string
     headers?: {
       [key: string]: string
     }
     fetch?: Fetch
+    experimental?: ExperimentalFeatureFlags
   }) {
     this.url = url
     this.headers = headers
     this.fetch = resolveFetch(fetch)
+    this.experimental = experimental ?? {}
     this.mfa = {
       listFactors: this._listFactors.bind(this),
       deleteFactor: this._deleteFactor.bind(this),
@@ -1194,10 +1203,13 @@ export default class GoTrueAdminApi {
    * Lists all passkeys for a user.
    *
    * This function should only be called on a server. Never expose your secret key in the browser.
+   *
+   * Requires `auth.experimental.passkey: true`.
    */
   private async _adminListPasskeys(
     params: AuthPasskeyAdminListParams
   ): Promise<AuthPasskeyListResponse> {
+    assertPasskeyExperimentalEnabled(this.experimental)
     validateUUID(params.userId)
 
     try {
@@ -1219,10 +1231,13 @@ export default class GoTrueAdminApi {
    * Deletes a user's passkey.
    *
    * This function should only be called on a server. Never expose your secret key in the browser.
+   *
+   * Requires `auth.experimental.passkey: true`.
    */
   private async _adminDeletePasskey(
     params: AuthPasskeyAdminDeleteParams
   ): Promise<AuthPasskeyDeleteResponse> {
+    assertPasskeyExperimentalEnabled(this.experimental)
     validateUUID(params.userId)
     validateUUID(params.passkeyId)
 

--- a/packages/core/auth-js/src/GoTrueAdminApi.ts
+++ b/packages/core/auth-js/src/GoTrueAdminApi.ts
@@ -32,6 +32,11 @@ import {
   ListCustomProvidersParams,
   CustomProviderResponse,
   CustomProviderListResponse,
+  GoTrueAdminPasskeyApi,
+  AuthPasskeyAdminListParams,
+  AuthPasskeyAdminDeleteParams,
+  AuthPasskeyListResponse,
+  AuthPasskeyDeleteResponse,
 } from './lib/types'
 import { AuthError, isAuthError } from './lib/errors'
 
@@ -47,6 +52,9 @@ export default class GoTrueAdminApi {
 
   /** Contains all custom OIDC/OAuth provider administration methods. */
   customProviders: GoTrueAdminCustomProvidersApi
+
+  /** Contains all passkey administration methods. */
+  passkey: GoTrueAdminPasskeyApi
 
   protected url: string
   protected headers: {
@@ -107,6 +115,10 @@ export default class GoTrueAdminApi {
       getProvider: this._getCustomProvider.bind(this),
       updateProvider: this._updateCustomProvider.bind(this),
       deleteProvider: this._deleteCustomProvider.bind(this),
+    }
+    this.passkey = {
+      listPasskeys: this._adminListPasskeys.bind(this),
+      deletePasskey: this._adminDeletePasskey.bind(this),
     }
   }
 
@@ -1169,6 +1181,58 @@ export default class GoTrueAdminApi {
         headers: this.headers,
         noResolveJson: true,
       })
+      return { data: null, error: null }
+    } catch (error) {
+      if (isAuthError(error)) {
+        return { data: null, error }
+      }
+      throw error
+    }
+  }
+
+  /**
+   * Lists all passkeys for a user.
+   *
+   * This function should only be called on a server. Never expose your secret key in the browser.
+   */
+  private async _adminListPasskeys(
+    params: AuthPasskeyAdminListParams
+  ): Promise<AuthPasskeyListResponse> {
+    validateUUID(params.userId)
+
+    try {
+      return await _request(
+        this.fetch,
+        'GET',
+        `${this.url}/admin/users/${params.userId}/passkeys`,
+        { headers: this.headers, xform: (data: any) => ({ data, error: null }) }
+      )
+    } catch (error) {
+      if (isAuthError(error)) {
+        return { data: null, error }
+      }
+      throw error
+    }
+  }
+
+  /**
+   * Deletes a user's passkey.
+   *
+   * This function should only be called on a server. Never expose your secret key in the browser.
+   */
+  private async _adminDeletePasskey(
+    params: AuthPasskeyAdminDeleteParams
+  ): Promise<AuthPasskeyDeleteResponse> {
+    validateUUID(params.userId)
+    validateUUID(params.passkeyId)
+
+    try {
+      await _request(
+        this.fetch,
+        'DELETE',
+        `${this.url}/admin/users/${params.userId}/passkeys/${params.passkeyId}`,
+        { headers: this.headers, noResolveJson: true }
+      )
       return { data: null, error: null }
     } catch (error) {
       if (isAuthError(error)) {

--- a/packages/core/auth-js/src/GoTrueClient.ts
+++ b/packages/core/auth-js/src/GoTrueClient.ts
@@ -136,6 +136,21 @@ import type {
   UserResponse,
   VerifyOtpParams,
   Web3Credentials,
+  AuthPasskeyApi,
+  SignInWithPasskeyCredentials,
+  RegisterPasskeyCredentials,
+  VerifyPasskeyRegistrationParams,
+  StartPasskeyAuthenticationParams,
+  VerifyPasskeyAuthenticationParams,
+  PasskeyUpdateParams,
+  PasskeyDeleteParams,
+  AuthPasskeyRegistrationOptionsResponse,
+  AuthPasskeyRegistrationVerifyResponse,
+  AuthPasskeyAuthenticationOptionsResponse,
+  AuthPasskeyAuthenticationVerifyResponse,
+  AuthPasskeyListResponse,
+  AuthPasskeyUpdateResponse,
+  AuthPasskeyDeleteResponse,
 } from './lib/types'
 import {
   createSiweMessage,
@@ -146,10 +161,14 @@ import {
   toHex,
 } from './lib/web3/ethereum'
 import {
+  createCredential,
   deserializeCredentialCreationOptions,
   deserializeCredentialRequestOptions,
+  getCredential,
   serializeCredentialCreationResponse,
   serializeCredentialRequestResponse,
+  browserSupportsWebAuthn,
+  webAuthnAbortService,
   WebAuthnApi,
 } from './lib/webauthn'
 import {
@@ -212,6 +231,11 @@ export default class GoTrueClient {
    * Used to implement the authorization code flow on the consent page.
    */
   oauth: AuthOAuthServerApi
+  /**
+   * Namespace for passkey methods.
+   * Includes lower-level two-step registration/authentication and passkey management.
+   */
+  passkey: AuthPasskeyApi
   /**
    * The storage key used to identify the values saved in localStorage
    */
@@ -372,6 +396,16 @@ export default class GoTrueClient {
       denyAuthorization: this._denyAuthorization.bind(this),
       listGrants: this._listOAuthGrants.bind(this),
       revokeGrant: this._revokeOAuthGrant.bind(this),
+    }
+
+    this.passkey = {
+      startRegistration: this._startPasskeyRegistration.bind(this),
+      verifyRegistration: this._verifyPasskeyRegistration.bind(this),
+      startAuthentication: this._startPasskeyAuthentication.bind(this),
+      verifyAuthentication: this._verifyPasskeyAuthentication.bind(this),
+      list: this._listPasskeys.bind(this),
+      update: this._updatePasskey.bind(this),
+      delete: this._deletePasskey.bind(this),
     }
 
     if (this.persistSession) {
@@ -5899,6 +5933,379 @@ export default class GoTrueClient {
         },
         error: null,
       }
+    } catch (error) {
+      if (isAuthError(error)) {
+        return this._returnResult({ data: null, error })
+      }
+      throw error
+    }
+  }
+
+  // --- Passkey Methods ---
+
+  /**
+   * Sign in with a passkey. Handles the full WebAuthn ceremony:
+   * 1. Fetches authentication challenge from server
+   * 2. Prompts user via navigator.credentials.get()
+   * 3. Verifies credential with server and creates session
+   */
+  async signInWithPasskey(
+    credentials?: SignInWithPasskeyCredentials
+  ): Promise<AuthPasskeyAuthenticationVerifyResponse> {
+    try {
+      if (!browserSupportsWebAuthn()) {
+        return this._returnResult({
+          data: null,
+          error: new AuthUnknownError('Browser does not support WebAuthn', null),
+        })
+      }
+
+      // 1. Get challenge options from server
+      const { data: options, error: optionsError } = await this._startPasskeyAuthentication({
+        options: { captchaToken: credentials?.options?.captchaToken },
+      })
+      if (optionsError || !options) {
+        return this._returnResult({ data: null, error: optionsError })
+      }
+
+      // 2. Deserialize and prompt user via browser WebAuthn API
+      const publicKeyOptions = deserializeCredentialRequestOptions(options.options)
+      const signal = credentials?.options?.signal ?? webAuthnAbortService.createNewAbortSignal()
+      const { data: credential, error: credentialError } = await getCredential({
+        publicKey: publicKeyOptions,
+        signal,
+      })
+      if (credentialError || !credential) {
+        return this._returnResult({
+          data: null,
+          error: credentialError ?? new AuthUnknownError('WebAuthn ceremony failed', null),
+        })
+      }
+
+      // 3. Serialize and verify with server
+      const serialized = serializeCredentialRequestResponse(credential)
+      return this._verifyPasskeyAuthentication({
+        challengeId: options.challenge_id,
+        credential: serialized,
+      })
+    } catch (error) {
+      if (isAuthError(error)) {
+        return this._returnResult({ data: null, error })
+      }
+      throw error
+    }
+  }
+
+  /**
+   * Register a passkey for the current authenticated user. Handles the full WebAuthn ceremony:
+   * 1. Fetches registration challenge from server
+   * 2. Prompts user via navigator.credentials.create()
+   * 3. Verifies credential with server
+   *
+   * Requires an active session.
+   */
+  async registerPasskey(
+    credentials?: RegisterPasskeyCredentials
+  ): Promise<AuthPasskeyRegistrationVerifyResponse> {
+    try {
+      if (!browserSupportsWebAuthn()) {
+        return this._returnResult({
+          data: null,
+          error: new AuthUnknownError('Browser does not support WebAuthn', null),
+        })
+      }
+
+      // 1. Get challenge options from server
+      const { data: options, error: optionsError } = await this._startPasskeyRegistration()
+      if (optionsError || !options) {
+        return this._returnResult({ data: null, error: optionsError })
+      }
+
+      // 2. Deserialize and prompt user via browser WebAuthn API
+      const publicKeyOptions = deserializeCredentialCreationOptions(options.options)
+      const signal = credentials?.options?.signal ?? webAuthnAbortService.createNewAbortSignal()
+      const { data: credential, error: credentialError } = await createCredential({
+        publicKey: publicKeyOptions,
+        signal,
+      })
+      if (credentialError || !credential) {
+        return this._returnResult({
+          data: null,
+          error: credentialError ?? new AuthUnknownError('WebAuthn ceremony failed', null),
+        })
+      }
+
+      // 3. Serialize and verify with server
+      const serialized = serializeCredentialCreationResponse(credential)
+      return this._verifyPasskeyRegistration({
+        challengeId: options.challenge_id,
+        credential: serialized,
+      })
+    } catch (error) {
+      if (isAuthError(error)) {
+        return this._returnResult({ data: null, error })
+      }
+      throw error
+    }
+  }
+
+  /**
+   * Start passkey registration for the current authenticated user.
+   * Returns WebAuthn credential creation options to pass to navigator.credentials.create().
+   */
+  private async _startPasskeyRegistration(): Promise<AuthPasskeyRegistrationOptionsResponse> {
+    try {
+      return await this._useSession(async (result) => {
+        const {
+          data: { session },
+          error: sessionError,
+        } = result
+        if (sessionError) {
+          return this._returnResult({ data: null, error: sessionError })
+        }
+        if (!session) {
+          return this._returnResult({ data: null, error: new AuthSessionMissingError() })
+        }
+        const { data, error } = await _request(
+          this.fetch,
+          'POST',
+          `${this.url}/passkeys/registration/options`,
+          {
+            headers: this.headers,
+            jwt: session.access_token,
+            body: {},
+          }
+        )
+        if (error) {
+          return this._returnResult({ data: null, error })
+        }
+        return this._returnResult({ data, error: null })
+      })
+    } catch (error) {
+      if (isAuthError(error)) {
+        return this._returnResult({ data: null, error })
+      }
+      throw error
+    }
+  }
+
+  /**
+   * Verify passkey registration with the credential response.
+   * The credentialResponse should be the serialized output of navigator.credentials.create().
+   */
+  private async _verifyPasskeyRegistration(
+    params: VerifyPasskeyRegistrationParams
+  ): Promise<AuthPasskeyRegistrationVerifyResponse> {
+    try {
+      return await this._useSession(async (result) => {
+        const {
+          data: { session },
+          error: sessionError,
+        } = result
+        if (sessionError) {
+          return this._returnResult({ data: null, error: sessionError })
+        }
+        if (!session) {
+          return this._returnResult({ data: null, error: new AuthSessionMissingError() })
+        }
+        const { data, error } = await _request(
+          this.fetch,
+          'POST',
+          `${this.url}/passkeys/registration/verify`,
+          {
+            headers: this.headers,
+            jwt: session.access_token,
+            body: {
+              challenge_id: params.challengeId,
+              credential: params.credential,
+            },
+          }
+        )
+        if (error) {
+          return this._returnResult({ data: null, error })
+        }
+        return this._returnResult({ data, error: null })
+      })
+    } catch (error) {
+      if (isAuthError(error)) {
+        return this._returnResult({ data: null, error })
+      }
+      throw error
+    }
+  }
+
+  /**
+   * Start passkey authentication.
+   * Returns WebAuthn credential request options to pass to navigator.credentials.get().
+   */
+  private async _startPasskeyAuthentication(
+    params?: StartPasskeyAuthenticationParams
+  ): Promise<AuthPasskeyAuthenticationOptionsResponse> {
+    try {
+      const { data, error } = await _request(
+        this.fetch,
+        'POST',
+        `${this.url}/passkeys/authentication/options`,
+        {
+          headers: this.headers,
+          body: {
+            gotrue_meta_security: { captcha_token: params?.options?.captchaToken },
+          },
+        }
+      )
+      if (error) {
+        return this._returnResult({ data: null, error })
+      }
+      return this._returnResult({ data, error: null })
+    } catch (error) {
+      if (isAuthError(error)) {
+        return this._returnResult({ data: null, error })
+      }
+      throw error
+    }
+  }
+
+  /**
+   * Verify passkey authentication and create a session.
+   * The credential should be the serialized output of navigator.credentials.get().
+   */
+  private async _verifyPasskeyAuthentication(
+    params: VerifyPasskeyAuthenticationParams
+  ): Promise<AuthPasskeyAuthenticationVerifyResponse> {
+    try {
+      const { data, error } = await _request(
+        this.fetch,
+        'POST',
+        `${this.url}/passkeys/authentication/verify`,
+        {
+          headers: this.headers,
+          body: {
+            challenge_id: params.challengeId,
+            credential: params.credential,
+          },
+          xform: _sessionResponse,
+        }
+      )
+      if (error) {
+        return this._returnResult({ data: null, error })
+      }
+      if (data.session) {
+        await this._saveSession(data.session)
+        await this._notifyAllSubscribers('SIGNED_IN', data.session)
+      }
+      return this._returnResult({ data, error: null })
+    } catch (error) {
+      if (isAuthError(error)) {
+        return this._returnResult({ data: null, error })
+      }
+      throw error
+    }
+  }
+
+  /**
+   * List all passkeys for the current user.
+   */
+  private async _listPasskeys(): Promise<AuthPasskeyListResponse> {
+    try {
+      return await this._useSession(async (result) => {
+        const {
+          data: { session },
+          error: sessionError,
+        } = result
+        if (sessionError) {
+          return this._returnResult({ data: null, error: sessionError })
+        }
+        if (!session) {
+          return this._returnResult({ data: null, error: new AuthSessionMissingError() })
+        }
+        const { data, error } = await _request(this.fetch, 'GET', `${this.url}/passkeys`, {
+          headers: this.headers,
+          jwt: session.access_token,
+          xform: (data: any) => ({ data, error: null }),
+        })
+        if (error) {
+          return this._returnResult({ data: null, error })
+        }
+        return this._returnResult({ data, error: null })
+      })
+    } catch (error) {
+      if (isAuthError(error)) {
+        return this._returnResult({ data: null, error })
+      }
+      throw error
+    }
+  }
+
+  /**
+   * Update a passkey.
+   */
+  private async _updatePasskey(params: PasskeyUpdateParams): Promise<AuthPasskeyUpdateResponse> {
+    try {
+      return await this._useSession(async (result) => {
+        const {
+          data: { session },
+          error: sessionError,
+        } = result
+        if (sessionError) {
+          return this._returnResult({ data: null, error: sessionError })
+        }
+        if (!session) {
+          return this._returnResult({ data: null, error: new AuthSessionMissingError() })
+        }
+        const { data, error } = await _request(
+          this.fetch,
+          'PATCH',
+          `${this.url}/passkeys/${params.passkeyId}`,
+          {
+            headers: this.headers,
+            jwt: session.access_token,
+            body: { friendly_name: params.friendlyName },
+          }
+        )
+        if (error) {
+          return this._returnResult({ data: null, error })
+        }
+        return this._returnResult({ data, error: null })
+      })
+    } catch (error) {
+      if (isAuthError(error)) {
+        return this._returnResult({ data: null, error })
+      }
+      throw error
+    }
+  }
+
+  /**
+   * Delete a passkey.
+   */
+  private async _deletePasskey(params: PasskeyDeleteParams): Promise<AuthPasskeyDeleteResponse> {
+    try {
+      return await this._useSession(async (result) => {
+        const {
+          data: { session },
+          error: sessionError,
+        } = result
+        if (sessionError) {
+          return this._returnResult({ data: null, error: sessionError })
+        }
+        if (!session) {
+          return this._returnResult({ data: null, error: new AuthSessionMissingError() })
+        }
+        const { error } = await _request(
+          this.fetch,
+          'DELETE',
+          `${this.url}/passkeys/${params.passkeyId}`,
+          {
+            headers: this.headers,
+            jwt: session.access_token,
+            noResolveJson: true,
+          }
+        )
+        if (error) {
+          return this._returnResult({ data: null, error })
+        }
+        return this._returnResult({ data: null, error: null })
+      })
     } catch (error) {
       if (isAuthError(error)) {
         return this._returnResult({ data: null, error })

--- a/packages/core/auth-js/src/GoTrueClient.ts
+++ b/packages/core/auth-js/src/GoTrueClient.ts
@@ -33,6 +33,7 @@ import {
   _userResponse,
 } from './lib/fetch'
 import {
+  assertPasskeyExperimentalEnabled,
   decodeJWT,
   deepClone,
   Deferred,
@@ -137,6 +138,7 @@ import type {
   VerifyOtpParams,
   Web3Credentials,
   AuthPasskeyApi,
+  ExperimentalFeatureFlags,
   SignInWithPasskeyCredentials,
   RegisterPasskeyCredentials,
   VerifyPasskeyRegistrationParams,
@@ -195,6 +197,7 @@ const DEFAULT_OPTIONS: Omit<
   throwOnError: false,
   lockAcquireTimeout: 5000, // 5 seconds
   skipAutoInitialize: false,
+  experimental: {},
 }
 
 async function lockNoOp<R>(name: string, acquireTimeout: number, fn: () => Promise<R>): Promise<R> {
@@ -234,6 +237,8 @@ export default class GoTrueClient {
   /**
    * Namespace for passkey methods.
    * Includes lower-level two-step registration/authentication and passkey management.
+   *
+   * Requires `auth.experimental.passkey: true`; otherwise all methods throw.
    */
   passkey: AuthPasskeyApi
   /**
@@ -297,6 +302,11 @@ export default class GoTrueClient {
   protected pendingInLock: Promise<any>[] = []
   protected throwOnError: boolean
   protected lockAcquireTimeout: number
+  /**
+   * Opt-in flags for experimental features. Defaults to an empty object.
+   * See `GoTrueClientOptions.experimental`.
+   */
+  protected experimental: ExperimentalFeatureFlags
 
   /**
    * Used to broadcast state change events to other tabs listening.
@@ -350,10 +360,12 @@ export default class GoTrueClient {
 
     this.persistSession = settings.persistSession
     this.autoRefreshToken = settings.autoRefreshToken
+    this.experimental = settings.experimental ?? {}
     this.admin = new GoTrueAdminApi({
       url: settings.url,
       headers: settings.headers,
       fetch: settings.fetch,
+      experimental: this.experimental,
     })
 
     this.url = settings.url
@@ -5948,10 +5960,13 @@ export default class GoTrueClient {
    * 1. Fetches authentication challenge from server
    * 2. Prompts user via navigator.credentials.get()
    * 3. Verifies credential with server and creates session
+   *
+   * Requires `auth.experimental.passkey: true`.
    */
   async signInWithPasskey(
     credentials?: SignInWithPasskeyCredentials
   ): Promise<AuthPasskeyAuthenticationVerifyResponse> {
+    assertPasskeyExperimentalEnabled(this.experimental)
     try {
       if (!browserSupportsWebAuthn()) {
         return this._returnResult({
@@ -6002,11 +6017,12 @@ export default class GoTrueClient {
    * 2. Prompts user via navigator.credentials.create()
    * 3. Verifies credential with server
    *
-   * Requires an active session.
+   * Requires an active session. Requires `auth.experimental.passkey: true`.
    */
   async registerPasskey(
     credentials?: RegisterPasskeyCredentials
   ): Promise<AuthPasskeyRegistrationVerifyResponse> {
+    assertPasskeyExperimentalEnabled(this.experimental)
     try {
       if (!browserSupportsWebAuthn()) {
         return this._returnResult({
@@ -6054,6 +6070,7 @@ export default class GoTrueClient {
    * Returns WebAuthn credential creation options to pass to navigator.credentials.create().
    */
   private async _startPasskeyRegistration(): Promise<AuthPasskeyRegistrationOptionsResponse> {
+    assertPasskeyExperimentalEnabled(this.experimental)
     try {
       return await this._useSession(async (result) => {
         const {
@@ -6096,6 +6113,7 @@ export default class GoTrueClient {
   private async _verifyPasskeyRegistration(
     params: VerifyPasskeyRegistrationParams
   ): Promise<AuthPasskeyRegistrationVerifyResponse> {
+    assertPasskeyExperimentalEnabled(this.experimental)
     try {
       return await this._useSession(async (result) => {
         const {
@@ -6141,6 +6159,7 @@ export default class GoTrueClient {
   private async _startPasskeyAuthentication(
     params?: StartPasskeyAuthenticationParams
   ): Promise<AuthPasskeyAuthenticationOptionsResponse> {
+    assertPasskeyExperimentalEnabled(this.experimental)
     try {
       const { data, error } = await _request(
         this.fetch,
@@ -6172,6 +6191,7 @@ export default class GoTrueClient {
   private async _verifyPasskeyAuthentication(
     params: VerifyPasskeyAuthenticationParams
   ): Promise<AuthPasskeyAuthenticationVerifyResponse> {
+    assertPasskeyExperimentalEnabled(this.experimental)
     try {
       const { data, error } = await _request(
         this.fetch,
@@ -6206,6 +6226,7 @@ export default class GoTrueClient {
    * List all passkeys for the current user.
    */
   private async _listPasskeys(): Promise<AuthPasskeyListResponse> {
+    assertPasskeyExperimentalEnabled(this.experimental)
     try {
       return await this._useSession(async (result) => {
         const {
@@ -6240,6 +6261,7 @@ export default class GoTrueClient {
    * Update a passkey.
    */
   private async _updatePasskey(params: PasskeyUpdateParams): Promise<AuthPasskeyUpdateResponse> {
+    assertPasskeyExperimentalEnabled(this.experimental)
     try {
       return await this._useSession(async (result) => {
         const {
@@ -6279,6 +6301,7 @@ export default class GoTrueClient {
    * Delete a passkey.
    */
   private async _deletePasskey(params: PasskeyDeleteParams): Promise<AuthPasskeyDeleteResponse> {
+    assertPasskeyExperimentalEnabled(this.experimental)
     try {
       return await this._useSession(async (result) => {
         const {

--- a/packages/core/auth-js/src/lib/fetch.ts
+++ b/packages/core/auth-js/src/lib/fetch.ts
@@ -30,7 +30,7 @@ export interface FetchParameters {
   signal?: AbortSignal
 }
 
-export type RequestMethodType = 'GET' | 'POST' | 'PUT' | 'DELETE'
+export type RequestMethodType = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'
 
 const _getErrorMessage = (err: any): string =>
   err.msg || err.message || err.error_description || err.error || JSON.stringify(err)

--- a/packages/core/auth-js/src/lib/helpers.ts
+++ b/packages/core/auth-js/src/lib/helpers.ts
@@ -372,6 +372,14 @@ export function validateUUID(str: string) {
   }
 }
 
+export function assertPasskeyExperimentalEnabled(experimental: { passkey?: boolean }): void {
+  if (!experimental.passkey) {
+    throw new Error(
+      '@supabase/auth-js: the passkey API is experimental and disabled by default. Enable it by passing `auth: { experimental: { passkey: true } }` to createClient (or to the GoTrueClient constructor).'
+    )
+  }
+}
+
 export function userNotAvailableProxy(): User {
   const proxyTarget = {} as User
 

--- a/packages/core/auth-js/src/lib/types.ts
+++ b/packages/core/auth-js/src/lib/types.ts
@@ -6,6 +6,12 @@ import {
   ServerCredentialCreationOptions,
   ServerCredentialRequestOptions,
   WebAuthnApi,
+  WebAuthnError,
+} from './webauthn'
+import type {
+  RegistrationResponseJSON,
+  AuthenticationResponseJSON,
+  ServerCredentialResponse,
 } from './webauthn'
 import {
   AuthenticationCredential,
@@ -2623,4 +2629,155 @@ export interface AuthOAuthServerApi {
    * @category Auth
    */
   revokeGrant(options: { clientId: string }): Promise<AuthOAuthRevokeGrantResponse>
+}
+
+// --- Passkey Types ---
+
+/** Response from POST /passkeys/registration/options */
+export type PasskeyRegistrationOptionsResponse = {
+  challenge_id: string
+  options: ServerCredentialCreationOptions
+  expires_at: number
+}
+
+/** Request body for POST /passkeys/registration/verify */
+export type PasskeyRegistrationVerifyParams = {
+  challenge_id: string
+  credential: RegistrationResponseJSON
+}
+
+/** Response from POST /passkeys/registration/verify */
+export type PasskeyMetadata = {
+  id: string
+  friendly_name?: string
+  created_at: string
+}
+
+/** Response from POST /passkeys/authentication/options */
+export type PasskeyAuthenticationOptionsResponse = {
+  challenge_id: string
+  options: ServerCredentialRequestOptions
+  expires_at: number
+}
+
+/** Request body for POST /passkeys/authentication/verify */
+export type PasskeyAuthenticationVerifyParams = {
+  challenge_id: string
+  credential: AuthenticationResponseJSON
+}
+
+/** Item in the passkeys list (GET /passkeys/ and admin list) */
+export type PasskeyListItem = {
+  id: string
+  friendly_name?: string
+  created_at: string
+  last_used_at?: string
+}
+
+// --- Passkey SDK Method Parameter/Response Types ---
+
+export type SignInWithPasskeyCredentials = {
+  options?: {
+    captchaToken?: string
+    signal?: AbortSignal
+  }
+}
+
+export type RegisterPasskeyCredentials = {
+  options?: {
+    signal?: AbortSignal
+  }
+}
+
+export type VerifyPasskeyRegistrationParams = {
+  /** Challenge ID from startRegistration */
+  challengeId: string
+  /** Serialized credential from navigator.credentials.create() */
+  credential: ServerCredentialResponse
+}
+
+export type StartPasskeyAuthenticationParams = {
+  options?: {
+    captchaToken?: string
+  }
+}
+
+export type VerifyPasskeyAuthenticationParams = {
+  /** Challenge ID from startAuthentication */
+  challengeId: string
+  /** Serialized credential from navigator.credentials.get() */
+  credential: ServerCredentialResponse
+}
+
+export type PasskeyUpdateParams = {
+  /** UUID of the passkey to update */
+  passkeyId: string
+  /** New friendly name (max 120 chars) */
+  friendlyName: string
+}
+
+export type PasskeyDeleteParams = {
+  /** UUID of the passkey to delete */
+  passkeyId: string
+}
+
+// --- Passkey Response Types ---
+
+export type AuthPasskeyRegistrationOptionsResponse =
+  RequestResult<PasskeyRegistrationOptionsResponse>
+export type AuthPasskeyRegistrationVerifyResponse = RequestResult<
+  PasskeyMetadata,
+  WebAuthnError | AuthError
+>
+export type AuthPasskeyAuthenticationOptionsResponse =
+  RequestResult<PasskeyAuthenticationOptionsResponse>
+export type AuthPasskeyAuthenticationVerifyResponse = RequestResult<
+  { session: Session | null; user: User | null },
+  WebAuthnError | AuthError
+>
+export type AuthPasskeyListResponse = RequestResult<PasskeyListItem[]>
+export type AuthPasskeyUpdateResponse = RequestResult<PasskeyListItem>
+export type AuthPasskeyDeleteResponse = RequestResult<null>
+
+// --- Passkey Admin Types ---
+
+export type AuthPasskeyAdminListParams = {
+  userId: string
+}
+
+export type AuthPasskeyAdminDeleteParams = {
+  userId: string
+  passkeyId: string
+}
+
+// --- Passkey Namespace Interfaces ---
+
+/**
+ * Lower-level two-step API and management methods for passkeys.
+ * Access via `supabase.auth.passkey`.
+ */
+export interface AuthPasskeyApi {
+  // Two-step registration
+  startRegistration(): Promise<AuthPasskeyRegistrationOptionsResponse>
+  verifyRegistration(
+    params: VerifyPasskeyRegistrationParams
+  ): Promise<AuthPasskeyRegistrationVerifyResponse>
+
+  // Two-step authentication
+  startAuthentication(
+    params?: StartPasskeyAuthenticationParams
+  ): Promise<AuthPasskeyAuthenticationOptionsResponse>
+  verifyAuthentication(
+    params: VerifyPasskeyAuthenticationParams
+  ): Promise<AuthPasskeyAuthenticationVerifyResponse>
+
+  // Management
+  list(): Promise<AuthPasskeyListResponse>
+  update(params: PasskeyUpdateParams): Promise<AuthPasskeyUpdateResponse>
+  delete(params: PasskeyDeleteParams): Promise<AuthPasskeyDeleteResponse>
+}
+
+export interface GoTrueAdminPasskeyApi {
+  listPasskeys(params: AuthPasskeyAdminListParams): Promise<AuthPasskeyListResponse>
+  deletePasskey(params: AuthPasskeyAdminDeleteParams): Promise<AuthPasskeyDeleteResponse>
 }

--- a/packages/core/auth-js/src/lib/types.ts
+++ b/packages/core/auth-js/src/lib/types.ts
@@ -180,6 +180,27 @@ export type GoTrueClientOptions = {
    * @default false
    */
   skipAutoInitialize?: boolean
+
+  /**
+   * Opt-in flags for experimental features. These APIs may change without
+   * notice and are disabled by default.
+   *
+   * @experimental
+   */
+  experimental?: ExperimentalFeatureFlags
+}
+
+export type ExperimentalFeatureFlags = {
+  /**
+   * Enables passkey support:
+   *   - `auth.signInWithPasskey()`, `auth.registerPasskey()`
+   *   - `auth.passkey.*`
+   *   - `auth.admin.passkey.*`
+   *
+   * Defaults to `false`. Calling any passkey method while this flag is
+   * disabled throws a descriptive error at call time.
+   */
+  passkey?: boolean
 }
 
 const WeakPasswordReasons = ['length', 'characters', 'pwned'] as const

--- a/packages/core/auth-js/src/lib/webauthn.ts
+++ b/packages/core/auth-js/src/lib/webauthn.ts
@@ -356,7 +356,7 @@ export function isValidDomain(hostname: string): boolean {
  * @returns {boolean} True if browser supports WebAuthn
  * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/PublicKeyCredential#browser_compatibility MDN - PublicKeyCredential Browser Compatibility}
  */
-function browserSupportsWebAuthn(): boolean {
+export function browserSupportsWebAuthn(): boolean {
   return !!(
     isBrowser() &&
     'PublicKeyCredential' in window &&

--- a/packages/core/auth-js/test/passkey.test.ts
+++ b/packages/core/auth-js/test/passkey.test.ts
@@ -1,0 +1,55 @@
+import { GoTrueAdminApi, GoTrueClient } from '../src/index'
+
+const ERROR_MESSAGE_FRAGMENT = 'the passkey API is experimental and disabled by default'
+
+// Guard runs before any network I/O, so the URL never needs to resolve.
+const TEST_URL = 'http://127.0.0.1:1/auth/v1'
+const TEST_HEADERS = { apikey: 'test-anon-key' }
+const TEST_UUID = '00000000-0000-0000-0000-000000000000'
+
+describe('Passkey experimental gating', () => {
+  let client: GoTrueClient
+  let admin: GoTrueAdminApi
+
+  beforeEach(() => {
+    client = new GoTrueClient({
+      url: TEST_URL,
+      headers: TEST_HEADERS,
+      autoRefreshToken: false,
+      persistSession: false,
+    })
+    admin = new GoTrueAdminApi({
+      url: TEST_URL,
+      headers: TEST_HEADERS,
+    })
+  })
+
+  test.each<[string, () => Promise<unknown>]>([
+    ['signInWithPasskey', () => client.signInWithPasskey()],
+    ['registerPasskey', () => client.registerPasskey()],
+    ['passkey.startRegistration', () => client.passkey.startRegistration()],
+    [
+      'passkey.verifyRegistration',
+      () => client.passkey.verifyRegistration({ challengeId: 'c', credential: {} as any }),
+    ],
+    ['passkey.startAuthentication', () => client.passkey.startAuthentication()],
+    [
+      'passkey.verifyAuthentication',
+      () => client.passkey.verifyAuthentication({ challengeId: 'c', credential: {} as any }),
+    ],
+    ['passkey.list', () => client.passkey.list()],
+    ['passkey.update', () => client.passkey.update({ passkeyId: 'p', friendlyName: 'n' })],
+    ['passkey.delete', () => client.passkey.delete({ passkeyId: 'p' })],
+    ['admin.passkey.listPasskeys', () => admin.passkey.listPasskeys({ userId: TEST_UUID })],
+    [
+      'admin.passkey.deletePasskey',
+      () => admin.passkey.deletePasskey({ userId: TEST_UUID, passkeyId: TEST_UUID }),
+    ],
+  ])('%s throws when experimental.passkey is not set', async (_name, invoke) => {
+    await expect(invoke()).rejects.toThrow(ERROR_MESSAGE_FRAGMENT)
+  })
+
+  test('error message references the opt-in key', async () => {
+    await expect(client.passkey.list()).rejects.toThrow(/experimental.*passkey/)
+  })
+})

--- a/packages/core/supabase-js/src/SupabaseClient.ts
+++ b/packages/core/supabase-js/src/SupabaseClient.ts
@@ -552,6 +552,7 @@ export default class SupabaseClient<
       lock,
       debug,
       throwOnError,
+      experimental,
     }: SupabaseAuthClientOptions,
     headers?: Record<string, string>,
     fetch?: Fetch
@@ -573,6 +574,7 @@ export default class SupabaseClient<
       lock,
       debug,
       throwOnError,
+      experimental,
       fetch,
       // auth checks if there is a custom authorizaiton header using this flag
       // so it knows whether to return an error when getUser is called with no session

--- a/packages/core/supabase-js/src/lib/types.ts
+++ b/packages/core/supabase-js/src/lib/types.ts
@@ -124,6 +124,13 @@ export type SupabaseClientOptions<SchemaName> = {
      * throwing the error instead of returning it as part of a successful response.
      */
     throwOnError?: SupabaseAuthClientOptions['throwOnError']
+    /**
+     * Opt-in flags for experimental features. These APIs may change without
+     * notice and are disabled by default.
+     *
+     * @experimental
+     */
+    experimental?: SupabaseAuthClientOptions['experimental']
   }
   /**
    * Options passed to the realtime-js instance

--- a/packages/core/supabase-js/test/unit/SupabaseAuthClient.test.ts
+++ b/packages/core/supabase-js/test/unit/SupabaseAuthClient.test.ts
@@ -51,3 +51,8 @@ test('createClient should accept auth.throwOnError and wire it to auth client', 
   })
   expect((supa.auth as any).isThrowOnErrorEnabled()).toBe(true)
 })
+
+test('createClient gates passkey methods when auth.experimental.passkey is not set', async () => {
+  const supa = new SupabaseClient('https://example.supabase.com', 'supabaseKey')
+  await expect(supa.auth.passkey.list()).rejects.toThrow(/experimental.*passkey/)
+})


### PR DESCRIPTION
Adds client-side passkey API with full WebAuthn ceremony handling, a lower-level two-step API via auth.passkey namespace, passkey management, and admin endpoints for server-side passkey operations.

The new API:

```
// High-level (full WebAuthn ceremony)
auth.signInWithPasskey()
auth.registerPasskey()

// Lower-level two-step API (for native flows or complete control over the ceremony)
auth.passkey.startRegistration()
auth.passkey.verifyRegistration()
auth.passkey.startAuthentication()
auth.passkey.verifyAuthentication()

// Management
auth.passkey.list()
auth.passkey.update()
auth.passkey.delete()

// Admin
auth.admin.passkey.listPasskeys()
auth.admin.passkey.deletePasskey()
```

Introduces concept of experimental feature flags to require callers to explicitly opt in explicitly:

Enable it when creating the client:

```ts
const supabase = createClient(supabaseUrl, supabaseKey, {
  auth: {
    experimental: { passkey: true },
  },
})
```

Without the flag, every passkey method throws a descriptive Error pointing to the opt-in key.