### PR TITLE
fix(postgrest): narrow column types after not(column, is, null)

### DIFF
--- a/packages/core/postgrest-js/src/PostgrestFilterBuilder.ts
+++ b/packages/core/postgrest-js/src/PostgrestFilterBuilder.ts
@@ -1812,7 +1812,11 @@ export default class PostgrestFilterBuilder<
    *
    * ```
    */
-  not(column: string, operator: string, value: unknown): this {
+  not(
+    column: string,
+    operator: string,
+    value: unknown
+  ): PostgrestFilterBuilder<ClientOptions, Schema, any, any, RelationName, Relationships, Method> {
     this.url.searchParams.append(column, `not.${operator}.${value}`)
     return this as any
   }

--- a/packages/core/postgrest-js/src/PostgrestFilterBuilder.ts
+++ b/packages/core/postgrest-js/src/PostgrestFilterBuilder.ts
@@ -76,6 +76,22 @@ type ResolveFilterRelationshipValue<
 
 export type InvalidMethodError<S extends string> = { Error: S }
 
+type NonNullableColumn<T extends Record<string, unknown>, Col extends string> = Col extends keyof T
+  ? { [K in keyof T]: K extends Col ? NonNullable<T[K]> : T[K] }
+  : T
+
+type NarrowResultColumn<T, Col extends string> = T extends (infer Item)[]
+  ? Item extends Record<string, unknown>
+    ? Col extends keyof Item
+      ? { [K in keyof Item]: K extends Col ? NonNullable<Item[K]> : Item[K] }[]
+      : T
+    : T
+  : T extends Record<string, unknown>
+    ? Col extends keyof T
+      ? { [K in keyof T]: K extends Col ? NonNullable<T[K]> : T[K] }
+      : T
+    : T
+
 export default class PostgrestFilterBuilder<
   ClientOptions extends ClientServerOptions,
   Schema extends GenericSchema,
@@ -1721,6 +1737,19 @@ export default class PostgrestFilterBuilder<
 
   not<ColumnName extends string & keyof Row>(
     column: ColumnName,
+    operator: 'is',
+    value: null
+  ): PostgrestFilterBuilder<
+    ClientOptions,
+    Schema,
+    NonNullableColumn<Row, ColumnName>,
+    NarrowResultColumn<Result, ColumnName>,
+    RelationName,
+    Relationships,
+    Method
+  >
+  not<ColumnName extends string & keyof Row>(
+    column: ColumnName,
     operator: FilterOperator,
     value: Row[ColumnName]
   ): this
@@ -1785,7 +1814,7 @@ export default class PostgrestFilterBuilder<
    */
   not(column: string, operator: string, value: unknown): this {
     this.url.searchParams.append(column, `not.${operator}.${value}`)
-    return this
+    return this as any
   }
 
   /**

--- a/packages/core/postgrest-js/test/index.test-d.ts
+++ b/packages/core/postgrest-js/test/index.test-d.ts
@@ -388,16 +388,16 @@ const postgrestWithOptions = new PostgrestClient<DatabaseWithOptions>(REST_URL)
   {
     const result = await postgrest
       .from('messages')
-      .select('id, message, data')
+      .select('id, message, blurb_message')
       .not('message', 'is', null)
-      .not('data', 'is', null)
+      .not('blurb_message', 'is', null)
     if (result.error) {
       throw new Error(result.error.message)
     }
     const item = result.data[0]
     expectType<number>(item.id)
     expectType<string>(item.message)
-    expectType<Json>(item.data)
+    expectType<string>(item.blurb_message)
   }
 
   // Non-nullable column: type stays the same

--- a/packages/core/postgrest-js/test/index.test-d.ts
+++ b/packages/core/postgrest-js/test/index.test-d.ts
@@ -346,3 +346,104 @@ const postgrestWithOptions = new PostgrestClient<DatabaseWithOptions>(REST_URL)
     }[]
   >(result.data)
 }
+
+// `.not(col, 'is', null)` narrows nullable column to non-nullable in result (#1360)
+{
+  // Basic narrowing: message goes from `string | null` to `string`
+  {
+    const result = await postgrest.from('messages').select('id, message').not('message', 'is', null)
+    if (result.error) {
+      throw new Error(result.error.message)
+    }
+    expectType<TypeEqual<typeof result.data, { id: number; message: string }[]>>(true)
+  }
+
+  // Narrowing with .single()
+  {
+    const result = await postgrest
+      .from('messages')
+      .select('id, message')
+      .not('message', 'is', null)
+      .single()
+    if (result.error) {
+      throw new Error(result.error.message)
+    }
+    expectType<TypeEqual<typeof result.data, { id: number; message: string }>>(true)
+  }
+
+  // Narrowing with .maybeSingle()
+  {
+    const result = await postgrest
+      .from('messages')
+      .select('id, message')
+      .not('message', 'is', null)
+      .maybeSingle()
+    if (result.error) {
+      throw new Error(result.error.message)
+    }
+    expectType<TypeEqual<typeof result.data, { id: number; message: string } | null>>(true)
+  }
+
+  // Chaining multiple .not() calls narrows both columns
+  {
+    const result = await postgrest
+      .from('messages')
+      .select('id, message, data')
+      .not('message', 'is', null)
+      .not('data', 'is', null)
+    if (result.error) {
+      throw new Error(result.error.message)
+    }
+    const item = result.data[0]
+    expectType<number>(item.id)
+    expectType<string>(item.message)
+    expectType<Json>(item.data)
+  }
+
+  // Non-nullable column: type stays the same
+  {
+    const result = await postgrest
+      .from('messages')
+      .select('id, username')
+      .not('username', 'is', null)
+    if (result.error) {
+      throw new Error(result.error.message)
+    }
+    expectType<TypeEqual<typeof result.data, { id: number; username: string }[]>>(true)
+  }
+
+  // Other operators do NOT narrow
+  {
+    const result = await postgrest
+      .from('messages')
+      .select('id, message')
+      .not('message', 'eq', 'hello')
+    if (result.error) {
+      throw new Error(result.error.message)
+    }
+    expectType<TypeEqual<typeof result.data, { id: number; message: string | null }[]>>(true)
+  }
+
+  // Dynamic string column: falls through to untyped overload, no narrowing
+  {
+    const col: string = 'message'
+    const result = await postgrest.from('messages').select('id, message').not(col, 'is', null)
+    if (result.error) {
+      throw new Error(result.error.message)
+    }
+    expectType<TypeEqual<typeof result.data, { id: number; message: string | null }[]>>(true)
+  }
+
+  // Chaining filters after narrowing preserves narrowed type
+  {
+    const result = await postgrest
+      .from('messages')
+      .select('id, message')
+      .not('message', 'is', null)
+      .eq('id', 1)
+    if (result.error) {
+      throw new Error(result.error.message)
+    }
+    expectType<TypeEqual<typeof result.data, { id: number; message: string }[]>>(true)
+  }
+}


### PR DESCRIPTION
When filtering with `.not(col, 'is', null)`, the resulting row type now marks that column as non-nullable in both the Row (for filter chaining) and Result (for the returned data type).                                                                                                                                                                            
                                                                                                                                                                                                                      
Closes #1360 

Thanks to @DevanshTyagi04 and https://github.com/supabase/supabase-js/pull/2028 for the motivation to address the issue.