### PR TITLE
fix(postgrest): restore runtime test files to tstyche scope

### DIFF
--- a/packages/core/postgrest-js/tsconfig.tstyche.json
+++ b/packages/core/postgrest-js/tsconfig.tstyche.json
@@ -7,7 +7,7 @@
     "outDir": "dist/cjs",
     "rootDir": ".",
     "sourceMap": true,
-    "target": "ES2017",
+    "target": "ES2020",
     "lib": ["ES2022"],
 
     "strict": true,
@@ -18,6 +18,8 @@
     "forceConsistentCasingInFileNames": true,
     "stripInternal": true,
     "noImplicitOverride": false,
-    "isolatedModules": false
+    "isolatedModules": false,
+    "types": ["jest", "node"],
+    "skipLibCheck": true
   }
 }

--- a/packages/core/postgrest-js/tstyche.config.json
+++ b/packages/core/postgrest-js/tstyche.config.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://tstyche.org/schemas/config.json",
   "tsconfig": "tsconfig.tstyche.json",
-  "testFileMatch": ["./test/**/*.test-d.ts"],
+  "testFileMatch": ["./test/**/*.test.ts", "./test/**/*.test-d.ts"],
   "checkSourceFiles": false,
   "checkSuppressedErrors": true
 }


### PR DESCRIPTION
PR #2193 removed `./test/**/*.test.ts` from `testFileMatch` to fix CI failures with TypeScript 5.9. The actual root cause was missing type restrictions in `tsconfig.tstyche.json`, not the test files themselves.                                                                                                                                                                  
                                                                                                                                                                                                                                         
- Restore `./test/**/*.test.ts` to testFileMatch (intentionally included per PR #1777 review for cross-version type assertion validation)                                                                                                                                                                     
- Add `types: ["jest", "node"]` to avoid auto-discovering all 57 `@types`                                                                                                                                                               
- Add `skipLibCheck: true` for TS 4.7 compat with modern `@types`                                                                                                                                                                          
- Bump target to ES2020 for BigInt literal support in `rpc.test.ts`    