### PR TITLE
fix(supabase): propagate custom fetch to realtime client

### DIFF
--- a/packages/core/supabase-js/src/SupabaseClient.ts
+++ b/packages/core/supabase-js/src/SupabaseClient.ts
@@ -328,6 +328,7 @@ export default class SupabaseClient<
     this.realtime = this._initRealtimeClient({
       headers: this.headers,
       accessToken: this._getAccessToken.bind(this),
+      fetch: this.fetch,
       ...settings.realtime,
     })
     if (this.accessToken) {

--- a/packages/core/supabase-js/test/unit/SupabaseClient.test.ts
+++ b/packages/core/supabase-js/test/unit/SupabaseClient.test.ts
@@ -446,6 +446,23 @@ describe('SupabaseClient', () => {
         })
       })
 
+      test('should propagate custom fetch to realtime client', async () => {
+        const mockFetch = jest.fn().mockResolvedValue({
+          ok: true,
+          json: () => Promise.resolve({}),
+        })
+
+        const client = createClient(URL, KEY, {
+          global: { fetch: mockFetch },
+        })
+
+        // Call realtime's fetch directly to verify custom fetch was propagated
+        // @ts-ignore accessing private property to verify fetch propagation
+        await client.realtime.fetch('http://example.com')
+
+        expect(mockFetch).toHaveBeenCalled()
+      })
+
       test('should use supabaseKey fallback in fetchWithAuth', async () => {
         const mockFetch = jest.fn().mockResolvedValue({
           ok: true,


### PR DESCRIPTION
The custom `fetch` passed via `createClient(url, key, { global: { fetch } })` was propagated to auth-js, postgrest-js, storage-js, and functions-js, but not to realtime-js. This was a bug since `RealtimeClient` already accepts a `fetch` option in its constructor. This PR passes `this.fetch` to `_initRealtimeClient()` (before the `settings.realtime` spread so it can still be overridden) and adds a unit test confirming the custom fetch reaches the realtime client.