### PR TITLE
fix(misc): reduce any usage across packages

### DIFF
--- a/packages/core/auth-js/.eslintrc.json
+++ b/packages/core/auth-js/.eslintrc.json
@@ -13,7 +13,7 @@
   "ignorePatterns": ["*.md", "test/__snapshots__/**/*", "example/**/*"],
   "rules": {
     "comma-dangle": "off",
-    "@typescript-eslint/no-explicit-any": "off",
+    "@typescript-eslint/no-explicit-any": "warn",
     "@typescript-eslint/ban-types": "off"
   }
 }

--- a/packages/core/auth-js/src/GoTrueAdminApi.ts
+++ b/packages/core/auth-js/src/GoTrueAdminApi.ts
@@ -860,7 +860,7 @@ export default class GoTrueAdminApi {
         `${this.url}/admin/users/${params.userId}/factors`,
         {
           headers: this.headers,
-          xform: (factors: unknown) => {
+          xform: (factors: any) => {
             return { data: { factors }, error: null }
           },
         }
@@ -953,7 +953,7 @@ export default class GoTrueAdminApi {
       return await _request(this.fetch, 'POST', `${this.url}/admin/oauth/clients`, {
         body: params,
         headers: this.headers,
-        xform: (client: unknown) => {
+        xform: (client: any) => {
           return { data: client, error: null }
         },
       })
@@ -976,7 +976,7 @@ export default class GoTrueAdminApi {
     try {
       return await _request(this.fetch, 'GET', `${this.url}/admin/oauth/clients/${clientId}`, {
         headers: this.headers,
-        xform: (client: unknown) => {
+        xform: (client: any) => {
           return { data: client, error: null }
         },
       })
@@ -1003,7 +1003,7 @@ export default class GoTrueAdminApi {
       return await _request(this.fetch, 'PUT', `${this.url}/admin/oauth/clients/${clientId}`, {
         body: params,
         headers: this.headers,
-        xform: (client: unknown) => {
+        xform: (client: any) => {
           return { data: client, error: null }
         },
       })
@@ -1084,9 +1084,8 @@ export default class GoTrueAdminApi {
       return await _request(this.fetch, 'GET', `${this.url}/admin/custom-providers`, {
         headers: this.headers,
         query,
-        xform: (data: unknown) => {
-          const d = data as Record<string, any>
-          return { data: { providers: d?.providers ?? [] }, error: null }
+        xform: (data: any) => {
+          return { data: { providers: data?.providers ?? [] }, error: null }
         },
       })
     } catch (error) {
@@ -1115,7 +1114,7 @@ export default class GoTrueAdminApi {
       return await _request(this.fetch, 'POST', `${this.url}/admin/custom-providers`, {
         body: params,
         headers: this.headers,
-        xform: (provider: unknown) => {
+        xform: (provider: any) => {
           return { data: provider, error: null }
         },
       })
@@ -1136,7 +1135,7 @@ export default class GoTrueAdminApi {
     try {
       return await _request(this.fetch, 'GET', `${this.url}/admin/custom-providers/${identifier}`, {
         headers: this.headers,
-        xform: (provider: unknown) => {
+        xform: (provider: any) => {
           return { data: provider, error: null }
         },
       })
@@ -1166,7 +1165,7 @@ export default class GoTrueAdminApi {
       return await _request(this.fetch, 'PUT', `${this.url}/admin/custom-providers/${identifier}`, {
         body: params,
         headers: this.headers,
-        xform: (provider: unknown) => {
+        xform: (provider: any) => {
           return { data: provider, error: null }
         },
       })

--- a/packages/core/auth-js/src/GoTrueAdminApi.ts
+++ b/packages/core/auth-js/src/GoTrueAdminApi.ts
@@ -860,7 +860,7 @@ export default class GoTrueAdminApi {
         `${this.url}/admin/users/${params.userId}/factors`,
         {
           headers: this.headers,
-          xform: (factors: any) => {
+          xform: (factors: unknown) => {
             return { data: { factors }, error: null }
           },
         }
@@ -953,7 +953,7 @@ export default class GoTrueAdminApi {
       return await _request(this.fetch, 'POST', `${this.url}/admin/oauth/clients`, {
         body: params,
         headers: this.headers,
-        xform: (client: any) => {
+        xform: (client: unknown) => {
           return { data: client, error: null }
         },
       })
@@ -976,7 +976,7 @@ export default class GoTrueAdminApi {
     try {
       return await _request(this.fetch, 'GET', `${this.url}/admin/oauth/clients/${clientId}`, {
         headers: this.headers,
-        xform: (client: any) => {
+        xform: (client: unknown) => {
           return { data: client, error: null }
         },
       })
@@ -1003,7 +1003,7 @@ export default class GoTrueAdminApi {
       return await _request(this.fetch, 'PUT', `${this.url}/admin/oauth/clients/${clientId}`, {
         body: params,
         headers: this.headers,
-        xform: (client: any) => {
+        xform: (client: unknown) => {
           return { data: client, error: null }
         },
       })
@@ -1084,8 +1084,9 @@ export default class GoTrueAdminApi {
       return await _request(this.fetch, 'GET', `${this.url}/admin/custom-providers`, {
         headers: this.headers,
         query,
-        xform: (data: any) => {
-          return { data: { providers: data?.providers ?? [] }, error: null }
+        xform: (data: unknown) => {
+          const d = data as Record<string, any>
+          return { data: { providers: d?.providers ?? [] }, error: null }
         },
       })
     } catch (error) {
@@ -1114,7 +1115,7 @@ export default class GoTrueAdminApi {
       return await _request(this.fetch, 'POST', `${this.url}/admin/custom-providers`, {
         body: params,
         headers: this.headers,
-        xform: (provider: any) => {
+        xform: (provider: unknown) => {
           return { data: provider, error: null }
         },
       })
@@ -1135,7 +1136,7 @@ export default class GoTrueAdminApi {
     try {
       return await _request(this.fetch, 'GET', `${this.url}/admin/custom-providers/${identifier}`, {
         headers: this.headers,
-        xform: (provider: any) => {
+        xform: (provider: unknown) => {
           return { data: provider, error: null }
         },
       })
@@ -1165,7 +1166,7 @@ export default class GoTrueAdminApi {
       return await _request(this.fetch, 'PUT', `${this.url}/admin/custom-providers/${identifier}`, {
         body: params,
         headers: this.headers,
-        xform: (provider: any) => {
+        xform: (provider: unknown) => {
           return { data: provider, error: null }
         },
       })

--- a/packages/core/auth-js/src/GoTrueClient.ts
+++ b/packages/core/auth-js/src/GoTrueClient.ts
@@ -5569,7 +5569,7 @@ export default class GoTrueClient {
           {
             headers: this.headers,
             jwt: session.access_token,
-            xform: (data: unknown) => ({ data, error: null }),
+            xform: (data: any) => ({ data, error: null }),
           }
         )
       })
@@ -5613,7 +5613,7 @@ export default class GoTrueClient {
             headers: this.headers,
             jwt: session.access_token,
             body: { action: 'approve' },
-            xform: (data: unknown) => ({ data, error: null }),
+            xform: (data: any) => ({ data, error: null }),
           }
         )
 
@@ -5666,7 +5666,7 @@ export default class GoTrueClient {
             headers: this.headers,
             jwt: session.access_token,
             body: { action: 'deny' },
-            xform: (data: unknown) => ({ data, error: null }),
+            xform: (data: any) => ({ data, error: null }),
           }
         )
 
@@ -5711,7 +5711,7 @@ export default class GoTrueClient {
         return await _request(this.fetch, 'GET', `${this.url}/user/oauth/grants`, {
           headers: this.headers,
           jwt: session.access_token,
-          xform: (data: unknown) => ({ data, error: null }),
+          xform: (data: any) => ({ data, error: null }),
         })
       })
     } catch (error) {

--- a/packages/core/auth-js/src/GoTrueClient.ts
+++ b/packages/core/auth-js/src/GoTrueClient.ts
@@ -443,7 +443,7 @@ export default class GoTrueClient {
     if (isBrowser() && globalThis.BroadcastChannel && this.persistSession && this.storageKey) {
       try {
         this.broadcastChannel = new globalThis.BroadcastChannel(this.storageKey)
-      } catch (e: any) {
+      } catch (e) {
         console.error(
           'Failed to create a new BroadcastChannel, multi-tab state changes will not be available',
           e
@@ -2691,7 +2691,7 @@ export default class GoTrueClient {
           (async () => {
             try {
               await result
-            } catch (e: any) {
+            } catch (_e) {
               // we just care if it finished
             }
           })()
@@ -4722,11 +4722,11 @@ export default class GoTrueClient {
         this.broadcastChannel.postMessage({ event, session })
       }
 
-      const errors: any[] = []
+      const errors: unknown[] = []
       const promises = Array.from(this.stateChangeEmitters.values()).map(async (x) => {
         try {
           await x.callback(event, session)
-        } catch (e: any) {
+        } catch (e) {
           errors.push(e)
         }
       })
@@ -5014,7 +5014,7 @@ export default class GoTrueClient {
                 await this._callRefreshToken(session.refresh_token)
               }
             })
-          } catch (e: any) {
+          } catch (e) {
             console.error(
               'Auto refresh tick failed with error. This is likely a transient error.',
               e
@@ -5024,8 +5024,8 @@ export default class GoTrueClient {
           this._debug('#_autoRefreshTokenTick()', 'end')
         }
       })
-    } catch (e: any) {
-      if (e.isAcquireTimeout || e instanceof LockAcquireTimeoutError) {
+    } catch (e) {
+      if (e instanceof LockAcquireTimeoutError) {
         this._debug('auto refresh token tick lock not available')
       } else {
         throw e
@@ -5569,7 +5569,7 @@ export default class GoTrueClient {
           {
             headers: this.headers,
             jwt: session.access_token,
-            xform: (data: any) => ({ data, error: null }),
+            xform: (data: unknown) => ({ data, error: null }),
           }
         )
       })
@@ -5613,7 +5613,7 @@ export default class GoTrueClient {
             headers: this.headers,
             jwt: session.access_token,
             body: { action: 'approve' },
-            xform: (data: any) => ({ data, error: null }),
+            xform: (data: unknown) => ({ data, error: null }),
           }
         )
 
@@ -5666,7 +5666,7 @@ export default class GoTrueClient {
             headers: this.headers,
             jwt: session.access_token,
             body: { action: 'deny' },
-            xform: (data: any) => ({ data, error: null }),
+            xform: (data: unknown) => ({ data, error: null }),
           }
         )
 
@@ -5711,7 +5711,7 @@ export default class GoTrueClient {
         return await _request(this.fetch, 'GET', `${this.url}/user/oauth/grants`, {
           headers: this.headers,
           jwt: session.access_token,
-          xform: (data: any) => ({ data, error: null }),
+          xform: (data: unknown) => ({ data, error: null }),
         })
       })
     } catch (error) {

--- a/packages/core/auth-js/src/lib/fetch.ts
+++ b/packages/core/auth-js/src/lib/fetch.ts
@@ -9,6 +9,7 @@ import {
   GenerateLinkResponse,
   User,
   UserResponse,
+  WeakPassword,
 } from './types'
 import {
   AuthApiError,
@@ -19,6 +20,30 @@ import {
 } from './errors'
 
 export type Fetch = typeof fetch
+
+/** Raw session data from GoTrue server response. */
+interface GoTrueSessionData {
+  access_token?: string
+  refresh_token?: string
+  expires_in?: number
+  expires_at?: number
+  user?: User
+  [key: string]: any // server returns additional fields (token_type, provider_token, etc.) copied into Session
+}
+
+/** Raw session data that includes weak password info (password sign-in endpoints). */
+interface GoTrueSessionPasswordData extends GoTrueSessionData {
+  weak_password?: WeakPassword
+}
+
+/** Raw user data — either `{ user: User }` or the User object itself. */
+interface GoTrueUserData {
+  user?: User
+  [key: string]: any // data may BE the User directly (fallback path)
+}
+
+/** Raw generate-link data — link properties + User fields flattened into one object. */
+type GoTrueGenerateLinkData = GenerateLinkProperties & Record<string, any>
 
 export interface FetchOptions {
   headers?: {
@@ -139,7 +164,7 @@ interface GotrueRequestOptions extends FetchOptions {
   /**
    * Function that transforms api response from gotrue into a desirable / standardised format
    */
-  xform?: (data: unknown) => any
+  xform?: (data: any) => any
 }
 
 export async function _request(
@@ -218,54 +243,50 @@ async function _handleRequest(
   }
 }
 
-export function _sessionResponse(data: unknown): AuthResponse {
-  const d = data as Record<string, any>
+export function _sessionResponse(data: GoTrueSessionData): AuthResponse {
   let session = null
-  if (hasSession(d)) {
-    session = { ...d } as Session
+  if (hasSession(data)) {
+    session = { ...data } as Session
 
-    if (!d.expires_at) {
-      session.expires_at = expiresAt(d.expires_in)
+    if (!data.expires_at) {
+      session.expires_at = expiresAt(data.expires_in!)
     }
   }
 
-  const user: User = d.user ?? (d as User)
+  const user: User = data.user ?? (data as User)
   return { data: { session, user }, error: null }
 }
 
-export function _sessionResponsePassword(data: unknown): AuthResponsePassword {
-  const d = data as Record<string, any>
+export function _sessionResponsePassword(data: GoTrueSessionPasswordData): AuthResponsePassword {
   const response = _sessionResponse(data) as AuthResponsePassword
 
   if (
     !response.error &&
-    d.weak_password &&
-    typeof d.weak_password === 'object' &&
-    Array.isArray(d.weak_password.reasons) &&
-    d.weak_password.reasons.length &&
-    d.weak_password.message &&
-    typeof d.weak_password.message === 'string' &&
-    d.weak_password.reasons.reduce((a: boolean, i: unknown) => a && typeof i === 'string', true)
+    data.weak_password &&
+    typeof data.weak_password === 'object' &&
+    Array.isArray(data.weak_password.reasons) &&
+    data.weak_password.reasons.length &&
+    data.weak_password.message &&
+    typeof data.weak_password.message === 'string' &&
+    data.weak_password.reasons.reduce((a: boolean, i: unknown) => a && typeof i === 'string', true)
   ) {
-    response.data.weak_password = d.weak_password
+    response.data.weak_password = data.weak_password
   }
 
   return response
 }
 
-export function _userResponse(data: unknown): UserResponse {
-  const d = data as Record<string, any>
-  const user: User = d.user ?? (d as User)
+export function _userResponse(data: GoTrueUserData): UserResponse {
+  const user: User = data.user ?? (data as User)
   return { data: { user }, error: null }
 }
 
-export function _ssoResponse(data: unknown): SSOResponse {
+export function _ssoResponse(data: Record<string, any>): SSOResponse {
   return { data, error: null } as SSOResponse
 }
 
-export function _generateLinkResponse(data: unknown): GenerateLinkResponse {
-  const d = data as Record<string, any>
-  const { action_link, email_otp, hashed_token, redirect_to, verification_type, ...rest } = d
+export function _generateLinkResponse(data: GoTrueGenerateLinkData): GenerateLinkResponse {
+  const { action_link, email_otp, hashed_token, redirect_to, verification_type, ...rest } = data
 
   const properties: GenerateLinkProperties = {
     action_link,
@@ -285,8 +306,8 @@ export function _generateLinkResponse(data: unknown): GenerateLinkResponse {
   }
 }
 
-export function _noResolveJsonResponse(data: unknown): Response {
-  return data as Response
+export function _noResolveJsonResponse(data: Response): Response {
+  return data
 }
 
 /**
@@ -294,6 +315,6 @@ export function _noResolveJsonResponse(data: unknown): Response {
  * @param data A response object
  * @returns true if a session is in the response
  */
-function hasSession(data: Record<string, any>): boolean {
-  return data.access_token && data.refresh_token && data.expires_in
+function hasSession(data: GoTrueSessionData): boolean {
+  return !!data.access_token && !!data.refresh_token && !!data.expires_in
 }

--- a/packages/core/auth-js/src/lib/fetch.ts
+++ b/packages/core/auth-js/src/lib/fetch.ts
@@ -3,6 +3,7 @@ import { expiresAt, looksLikeFetchResponse, parseResponseAPIVersion } from './he
 import {
   AuthResponse,
   AuthResponsePassword,
+  Session,
   SSOResponse,
   GenerateLinkProperties,
   GenerateLinkResponse,
@@ -32,8 +33,16 @@ export interface FetchParameters {
 
 export type RequestMethodType = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'
 
-const _getErrorMessage = (err: any): string =>
-  err.msg || err.message || err.error_description || err.error || JSON.stringify(err)
+const _getErrorMessage = (err: unknown): string => {
+  if (typeof err === 'object' && err !== null) {
+    const e = err as Record<string, unknown>
+    if (typeof e.msg === 'string') return e.msg
+    if (typeof e.message === 'string') return e.message
+    if (typeof e.error_description === 'string') return e.error_description
+    if (typeof e.error === 'string') return e.error
+  }
+  return JSON.stringify(err)
+}
 
 // 502, 503, 504: Standard server/gateway errors
 // 520-524, 530: Cloudflare-specific error codes (web server down, connection timed out, etc.)
@@ -53,7 +62,7 @@ export async function handleError(error: unknown) {
   let data: any
   try {
     data = await error.json()
-  } catch (e: any) {
+  } catch (e) {
     throw new AuthUnknownError(_getErrorMessage(e), e)
   }
 
@@ -130,7 +139,7 @@ interface GotrueRequestOptions extends FetchOptions {
   /**
    * Function that transforms api response from gotrue into a desirable / standardised format
    */
-  xform?: (data: any) => any
+  xform?: (data: unknown) => any
 }
 
 export async function _request(
@@ -181,7 +190,7 @@ async function _handleRequest(
 ): Promise<any> {
   const requestParams = _getRequestParams(method, options, parameters, body)
 
-  let result: any
+  let result: Response
 
   try {
     result = await fetcher(url, {
@@ -204,55 +213,59 @@ async function _handleRequest(
 
   try {
     return await result.json()
-  } catch (e: any) {
+  } catch (e) {
     await handleError(e)
   }
 }
 
-export function _sessionResponse(data: any): AuthResponse {
+export function _sessionResponse(data: unknown): AuthResponse {
+  const d = data as Record<string, any>
   let session = null
-  if (hasSession(data)) {
-    session = { ...data }
+  if (hasSession(d)) {
+    session = { ...d } as Session
 
-    if (!data.expires_at) {
-      session.expires_at = expiresAt(data.expires_in)
+    if (!d.expires_at) {
+      session.expires_at = expiresAt(d.expires_in)
     }
   }
 
-  const user: User = data.user ?? (data as User)
+  const user: User = d.user ?? (d as User)
   return { data: { session, user }, error: null }
 }
 
-export function _sessionResponsePassword(data: any): AuthResponsePassword {
+export function _sessionResponsePassword(data: unknown): AuthResponsePassword {
+  const d = data as Record<string, any>
   const response = _sessionResponse(data) as AuthResponsePassword
 
   if (
     !response.error &&
-    data.weak_password &&
-    typeof data.weak_password === 'object' &&
-    Array.isArray(data.weak_password.reasons) &&
-    data.weak_password.reasons.length &&
-    data.weak_password.message &&
-    typeof data.weak_password.message === 'string' &&
-    data.weak_password.reasons.reduce((a: boolean, i: any) => a && typeof i === 'string', true)
+    d.weak_password &&
+    typeof d.weak_password === 'object' &&
+    Array.isArray(d.weak_password.reasons) &&
+    d.weak_password.reasons.length &&
+    d.weak_password.message &&
+    typeof d.weak_password.message === 'string' &&
+    d.weak_password.reasons.reduce((a: boolean, i: unknown) => a && typeof i === 'string', true)
   ) {
-    response.data.weak_password = data.weak_password
+    response.data.weak_password = d.weak_password
   }
 
   return response
 }
 
-export function _userResponse(data: any): UserResponse {
-  const user: User = data.user ?? (data as User)
+export function _userResponse(data: unknown): UserResponse {
+  const d = data as Record<string, any>
+  const user: User = d.user ?? (d as User)
   return { data: { user }, error: null }
 }
 
-export function _ssoResponse(data: any): SSOResponse {
-  return { data, error: null }
+export function _ssoResponse(data: unknown): SSOResponse {
+  return { data, error: null } as SSOResponse
 }
 
-export function _generateLinkResponse(data: any): GenerateLinkResponse {
-  const { action_link, email_otp, hashed_token, redirect_to, verification_type, ...rest } = data
+export function _generateLinkResponse(data: unknown): GenerateLinkResponse {
+  const d = data as Record<string, any>
+  const { action_link, email_otp, hashed_token, redirect_to, verification_type, ...rest } = d
 
   const properties: GenerateLinkProperties = {
     action_link,
@@ -262,7 +275,7 @@ export function _generateLinkResponse(data: any): GenerateLinkResponse {
     verification_type,
   }
 
-  const user: User = { ...rest }
+  const user = { ...rest } as User
   return {
     data: {
       properties,
@@ -272,8 +285,8 @@ export function _generateLinkResponse(data: any): GenerateLinkResponse {
   }
 }
 
-export function _noResolveJsonResponse(data: any): Response {
-  return data
+export function _noResolveJsonResponse(data: unknown): Response {
+  return data as Response
 }
 
 /**
@@ -281,6 +294,6 @@ export function _noResolveJsonResponse(data: any): Response {
  * @param data A response object
  * @returns true if a session is in the response
  */
-function hasSession(data: any): boolean {
+function hasSession(data: Record<string, any>): boolean {
   return data.access_token && data.refresh_token && data.expires_in
 }

--- a/packages/core/auth-js/src/lib/helpers.ts
+++ b/packages/core/auth-js/src/lib/helpers.ts
@@ -87,7 +87,7 @@ export function parseParametersFromURL(href: string) {
       hashSearchParams.forEach((value, key) => {
         result[key] = value
       })
-    } catch (e: any) {
+    } catch (_e) {
       // hash is not a query string
     }
   }
@@ -235,7 +235,7 @@ export function retryable<T>(
             accept(result)
             return
           }
-        } catch (e: any) {
+        } catch (e) {
           if (!isRetryable(attempt, e)) {
             reject(e)
             return
@@ -329,7 +329,7 @@ export function parseResponseAPIVersion(response: Response) {
   try {
     const date = new Date(`${apiVersion}T00:00:00.0Z`)
     return date
-  } catch (e: any) {
+  } catch (_e) {
     return null
   }
 }

--- a/packages/core/auth-js/src/lib/locks.ts
+++ b/packages/core/auth-js/src/lib/locks.ts
@@ -176,7 +176,7 @@ export async function navigatorLock<R>(
                   '@supabase/gotrue-js: Navigator LockManager state',
                   JSON.stringify(result, null, '  ')
                 )
-              } catch (e: any) {
+              } catch (e) {
                 console.warn(
                   '@supabase/gotrue-js: Error when querying Navigator LockManager state',
                   e
@@ -198,14 +198,21 @@ export async function navigatorLock<R>(
         }
       }
     )
-  } catch (e: any) {
+  } catch (e) {
     // Always clear the acquire timeout once the request settles, so it cannot
     // fire later and incorrectly abort/log after a rejection.
     if (acquireTimeout > 0) {
       clearTimeout(acquireTimeoutTimer)
     }
 
-    if (e?.name === 'AbortError' && acquireTimeout > 0) {
+    // DOMException does not extend Error in Node.js, so use structural check
+    if (
+      e !== null &&
+      typeof e === 'object' &&
+      'name' in e &&
+      e.name === 'AbortError' &&
+      acquireTimeout > 0
+    ) {
       if (abortController.signal.aborted) {
         // OUR timeout fired — the lock is genuinely orphaned. Steal it.
         //
@@ -370,14 +377,14 @@ export async function processLock<R>(
       if (timeoutId !== null) {
         clearTimeout(timeoutId)
       }
-    } catch (e: any) {
+    } catch (e) {
       // Clear the timeout on error path as well
       if (timeoutId !== null) {
         clearTimeout(timeoutId)
       }
 
       // Re-throw timeout errors, ignore others
-      if (e && e.isAcquireTimeout) {
+      if (e instanceof LockAcquireTimeoutError) {
         throw e
       }
       // Fall through to run fn() - previous operation finished with error
@@ -391,8 +398,8 @@ export async function processLock<R>(
   PROCESS_LOCKS[name] = (async () => {
     try {
       return await currentOperation
-    } catch (e: any) {
-      if (e && e.isAcquireTimeout) {
+    } catch (e) {
+      if (e instanceof LockAcquireTimeoutError) {
         // if the current operation timed out, it doesn't mean that the previous
         // operation finished, so we need continue waiting for it to finish
         try {

--- a/packages/core/postgrest-js/src/PostgrestBuilder.ts
+++ b/packages/core/postgrest-js/src/PostgrestBuilder.ts
@@ -321,9 +321,13 @@ export default abstract class PostgrestBuilder<
             ),
             signal: this.signal,
           })
-        } catch (fetchError: any) {
+        } catch (fetchError) {
           // Never retry aborted requests
-          if (fetchError?.name === 'AbortError' || fetchError?.code === 'ABORT_ERR') {
+          if (
+            fetchError instanceof Error &&
+            (fetchError.name === 'AbortError' ||
+              ('code' in fetchError && (fetchError as { code?: string }).code === 'ABORT_ERR'))
+          ) {
             throw fetchError
           }
 

--- a/packages/core/realtime-js/src/RealtimeChannel.ts
+++ b/packages/core/realtime-js/src/RealtimeChannel.ts
@@ -887,8 +887,8 @@ export default class RealtimeChannel {
 
         await response.body?.cancel()
         return response.ok ? 'ok' : 'error'
-      } catch (error: any) {
-        if (error.name === 'AbortError') {
+      } catch (error) {
+        if (error instanceof Error && error.name === 'AbortError') {
           return 'timed out'
         } else {
           return 'error'

--- a/packages/core/realtime-js/src/lib/websocket-factory.ts
+++ b/packages/core/realtime-js/src/lib/websocket-factory.ts
@@ -39,9 +39,20 @@ export interface WebSocketLike {
 
 export interface WebSocketEnvironment {
   type: 'native' | 'ws' | 'cloudflare' | 'unsupported'
-  constructor?: any
+  /** WebSocket constructor for this environment, if available. */
+  wsConstructor?: typeof WebSocket
   error?: string
   workaround?: string
+}
+
+/**
+ * Extended globalThis with optional runtime-specific properties
+ * that may or may not exist depending on the environment.
+ */
+interface RuntimeGlobals {
+  WebSocket?: { new (url: string, protocols?: string | string[]): WebSocketLike }
+  WebSocketPair?: unknown
+  EdgeRuntime?: unknown
 }
 
 /**
@@ -54,20 +65,23 @@ export class WebSocketFactory {
   private constructor() {}
   private static detectEnvironment(): WebSocketEnvironment {
     if (typeof WebSocket !== 'undefined') {
-      return { type: 'native', constructor: WebSocket }
+      return { type: 'native', wsConstructor: WebSocket }
     }
 
-    if (typeof globalThis !== 'undefined' && typeof (globalThis as any).WebSocket !== 'undefined') {
-      return { type: 'native', constructor: (globalThis as any).WebSocket }
+    const gt = globalThis as typeof globalThis & RuntimeGlobals
+    if (typeof globalThis !== 'undefined' && typeof gt.WebSocket !== 'undefined') {
+      return { type: 'native', wsConstructor: gt.WebSocket as typeof WebSocket }
     }
 
-    if (typeof global !== 'undefined' && typeof (global as any).WebSocket !== 'undefined') {
-      return { type: 'native', constructor: (global as any).WebSocket }
+    const gl =
+      typeof global !== 'undefined' ? (global as typeof global & RuntimeGlobals) : undefined
+    if (gl && typeof gl.WebSocket !== 'undefined') {
+      return { type: 'native', wsConstructor: gl.WebSocket as typeof WebSocket }
     }
 
     if (
       typeof globalThis !== 'undefined' &&
-      typeof (globalThis as any).WebSocketPair !== 'undefined' &&
+      typeof gt.WebSocketPair !== 'undefined' &&
       typeof globalThis.WebSocket === 'undefined'
     ) {
       return {
@@ -80,7 +94,7 @@ export class WebSocketFactory {
     }
 
     if (
-      (typeof globalThis !== 'undefined' && (globalThis as any).EdgeRuntime) ||
+      (typeof globalThis !== 'undefined' && gt.EdgeRuntime) ||
       (typeof navigator !== 'undefined' && navigator.userAgent?.includes('Vercel-Edge'))
     ) {
       return {
@@ -93,7 +107,9 @@ export class WebSocketFactory {
     }
 
     // Use dynamic property access to avoid Next.js Edge Runtime static analysis warnings
-    const _process = (globalThis as any)['process']
+    const _process = (globalThis as Record<string, unknown>)['process'] as
+      | { versions?: { node?: string } }
+      | undefined
     if (_process) {
       const processVersions = _process['versions']
       if (processVersions && processVersions['node']) {
@@ -105,7 +121,7 @@ export class WebSocketFactory {
         if (nodeVersion >= 22) {
           // Check if native WebSocket is available (should be in Node.js 22+)
           if (typeof globalThis.WebSocket !== 'undefined') {
-            return { type: 'native', constructor: globalThis.WebSocket }
+            return { type: 'native', wsConstructor: globalThis.WebSocket }
           }
           // If not available, user needs to provide it
           return {
@@ -152,8 +168,8 @@ export class WebSocketFactory {
    */
   public static getWebSocketConstructor(): typeof WebSocket {
     const env = this.detectEnvironment()
-    if (env.constructor) {
-      return env.constructor
+    if (env.wsConstructor) {
+      return env.wsConstructor
     }
     let errorMessage = env.error || 'WebSocket not supported in this environment.'
     if (env.workaround) {

--- a/packages/core/realtime-js/test/websocket-factory.test.ts
+++ b/packages/core/realtime-js/test/websocket-factory.test.ts
@@ -50,7 +50,7 @@ describe('WebSocketFactory', () => {
     test('detects native WebSocket', () => {
       const env = (WebSocketFactory as any).detectEnvironment()
       expect(env.type).toBe('native')
-      expect(env.constructor).toBe(MockWebSocket)
+      expect(env.wsConstructor).toBe(MockWebSocket)
     })
 
     test('checks if WebSocket is supported', () => {
@@ -68,7 +68,7 @@ describe('WebSocketFactory', () => {
     test('detects globalThis WebSocket', () => {
       const env = (WebSocketFactory as any).detectEnvironment()
       expect(env.type).toBe('native')
-      expect(env.constructor).toBe(MockWebSocket)
+      expect(env.wsConstructor).toBe(MockWebSocket)
     })
 
     afterEach(() => {
@@ -87,7 +87,7 @@ describe('WebSocketFactory', () => {
     test('detects global WebSocket', () => {
       const env = (WebSocketFactory as any).detectEnvironment()
       expect(env.type).toBe('native')
-      expect(env.constructor).toBe(MockWebSocket)
+      expect(env.wsConstructor).toBe(MockWebSocket)
     })
 
     afterEach(() => {
@@ -229,7 +229,7 @@ describe('WebSocketFactory', () => {
 
       const env = (WebSocketFactory as any).detectEnvironment()
       expect(env.type).toBe('native')
-      expect(env.constructor).toBe(MockWebSocket)
+      expect(env.wsConstructor).toBe(MockWebSocket)
 
       delete (globalThis as any).WebSocket
     })
@@ -296,7 +296,7 @@ describe('WebSocketFactory', () => {
 
       const env = (WebSocketFactory as any).detectEnvironment()
       expect(env.type).toBe('native')
-      expect(env.constructor).toBe(MockWebSocket)
+      expect(env.wsConstructor).toBe(MockWebSocket)
     })
 
     test('handles missing native WebSocket in Node.js 22+', () => {

--- a/packages/core/storage-js/src/lib/common/fetch.ts
+++ b/packages/core/storage-js/src/lib/common/fetch.ts
@@ -26,12 +26,20 @@ export type RequestMethodType = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'HEAD'
  * @param err - Error object from API
  * @returns Human-readable error message
  */
-const _getErrorMessage = (err: any): string =>
-  err.msg ||
-  err.message ||
-  err.error_description ||
-  (typeof err.error === 'string' ? err.error : err.error?.message) ||
-  JSON.stringify(err)
+const _getErrorMessage = (err: unknown): string => {
+  if (typeof err === 'object' && err !== null) {
+    const e = err as Record<string, unknown>
+    if (typeof e.msg === 'string') return e.msg
+    if (typeof e.message === 'string') return e.message
+    if (typeof e.error_description === 'string') return e.error_description
+    if (typeof e.error === 'string') return e.error
+    if (typeof e.error === 'object' && e.error !== null) {
+      const nested = e.error as Record<string, unknown>
+      if (typeof nested.message === 'string') return nested.message
+    }
+  }
+  return JSON.stringify(err)
+}
 
 /**
  * Handles fetch errors and converts them to Storage error types
@@ -42,7 +50,7 @@ const _getErrorMessage = (err: any): string =>
  */
 const handleError = async (
   error: unknown,
-  reject: (reason?: any) => void,
+  reject: (reason?: unknown) => void,
   options: FetchOptions | undefined,
   namespace: ErrorNamespace
 ) => {
@@ -50,11 +58,18 @@ const handleError = async (
   // (native, node-fetch, cross-fetch, undici) and absent from standard Error objects.
   // Checking 'ok' or 'status' via `in` is unreliable across fetch polyfills/realms.
   const isResponseLike =
-    error !== null && typeof error === 'object' && typeof (error as any).json === 'function'
+    error !== null &&
+    typeof error === 'object' &&
+    'json' in error &&
+    typeof (error as Record<string, unknown>).json === 'function'
 
   if (isResponseLike) {
-    const responseError = error as any
-    let status = parseInt(responseError.status, 10)
+    const responseError = error as {
+      json: () => Promise<any>
+      status?: string | number
+      statusText?: string
+    }
+    let status = parseInt(String(responseError.status), 10)
     if (!Number.isFinite(status)) {
       status = 500
     }

--- a/packages/core/storage-js/src/lib/common/fetch.ts
+++ b/packages/core/storage-js/src/lib/common/fetch.ts
@@ -1,4 +1,4 @@
-import { StorageApiError, StorageUnknownError, ErrorNamespace } from './errors'
+import { StorageApiError, StorageError, StorageUnknownError, ErrorNamespace } from './errors'
 import { setHeader } from './headers'
 import { isPlainObject, resolveResponse } from './helpers'
 import { FetchParameters } from '../types'
@@ -50,7 +50,7 @@ const _getErrorMessage = (err: unknown): string => {
  */
 const handleError = async (
   error: unknown,
-  reject: (reason?: unknown) => void,
+  reject: (reason: StorageError) => void,
   options: FetchOptions | undefined,
   namespace: ErrorNamespace
 ) => {
@@ -64,11 +64,8 @@ const handleError = async (
     typeof (error as Record<string, unknown>).json === 'function'
 
   if (isResponseLike) {
-    const responseError = error as {
-      json: () => Promise<any>
-      status?: string | number
-      statusText?: string
-    }
+    const responseError = error as Response
+    // Defensive coercion: some fetch polyfills have historically returned status as a string.
     let status = parseInt(String(responseError.status), 10)
     if (!Number.isFinite(status)) {
       status = 500
@@ -76,10 +73,12 @@ const handleError = async (
 
     responseError
       .json()
-      .then((err: any) => {
-        const statusCode = err?.statusCode || err?.code || status + ''
-        reject(new StorageApiError(_getErrorMessage(err), status, statusCode, namespace))
-      })
+      .then(
+        (err: { statusCode?: string; code?: string; error?: string; message?: string } | null) => {
+          const statusCode = err?.statusCode || err?.code || status + ''
+          reject(new StorageApiError(_getErrorMessage(err), status, statusCode, namespace))
+        }
+      )
       .catch(() => {
         const statusCode = status + ''
         const message = responseError.statusText || `HTTP ${status} error`


### PR DESCRIPTION
Replace ~50 explicit `any` annotations with `unknown` and proper type narrowing in internal code. Highest-value change: auth-js xform/fetch chain now takes `unknown` at the JSON boundary, preventing bugs like the signedUrl typo (#2254) from silently passing type checks.

- catch blocks: `e: any` → `e` with instanceof narrowing
- _getErrorMessage: `any` → `unknown` in auth-js and storage-js
- xform functions: `data: any` → `data: unknown` (internal only)
- websocket-factory: typed globalThis casts, renamed constructor field
- auth-js eslint: enable no-explicit-any as warn

No breaking changes, all modifications are internal.

## Why `unknown` remains in some places

Some `unknown`s here are deliberate. They fall into a few categories where tightening would either be incorrect or carry a real cost:

- **`catch (e)`** — TypeScript enforces this. With `useUnknownInCatchVariables` (on under `strict: true`), `catch (e: Error)` is a compile error (TS1196). JavaScript allows `throw <any value>` — including strings, numbers, and `null` from third-party code we call into — so the catch binding genuinely cannot be narrower than `unknown`. Narrowing happens inside the block.

- **`errors: unknown[]` collected from third-party callbacks** (e.g. `_notifyAllSubscribers`) — values come from user-supplied `onAuthStateChange` callbacks, which can throw anything. Downstream uses are only `console.error(...)` and `throw`, both of which accept any value. Tightening to `Error[]` would either lie about the type or require wrapping non-Errors, which loses fidelity for consumers throwing custom error classes.

- **Runtime-detection globals** (`WebSocketPair?: unknown`, `EdgeRuntime?: unknown` in `websocket-factory.ts`) — used only for existence checks (`typeof !== 'undefined'`). `EdgeRuntime` in particular isn't standardized across edge runtimes (different shapes in Vercel Edge, Next.js Edge, polyfills). Typing it would be claiming knowledge that doesn't hold cross-runtime; `unknown` enforces existence-check-only access.

## Why some `any`s are still in the call chain

- **`JSON.parse` and `Response.json()` return `any`** — these are typed `any` in TypeScript's standard library, not by us. To eliminate `any` end-to-end here we'd need a runtime schema validator (zod / valibot / hand-rolled guards) at every response boundary. That's a non-trivial bundle/perf cost for an SDK shipped to bundle-sensitive runtimes (RN, edge, browsers), so the SDK leans on localized type assertions at the boundary instead.

- **User-extensible payloads** — `user_metadata`, `app_metadata`, OAuth provider passthrough fields, PostgREST row shapes, Realtime broadcast payloads. The shape is defined by the consumer's application or by external services, not by Supabase. Where applicable these are typed via generics or `Record<string, unknown>`; the remaining `[key: string]: any` index signatures (e.g. on `Session`, `User`) preserve ergonomics for fields the server may add (`token_type`, `provider_token`, etc.) without forcing every caller to narrow.

## What this PR does not do

- Does not introduce runtime validation of wire data (zod or similar). Listed above as the path to remove the remaining `any` from `JSON.parse`/`Response.json()`, but out of scope here.
- Does not tighten `[key: string]: any` index signatures on `User`/`Session` to `unknown` — would force narrowing on every read of provider passthrough fields. Deliberate trade-off, not an oversight.
