### PR TITLE
feat(realtime): Realtime deferred disconnect

### DIFF
--- a/packages/core/realtime-js/src/RealtimeClient.ts
+++ b/packages/core/realtime-js/src/RealtimeClient.ts
@@ -532,6 +532,7 @@ export default class RealtimeClient {
   _remove(channel: RealtimeChannel) {
     this.channels = this.channels.filter((c) => c.topic !== channel.topic)
     if (this.channels.length === 0) {
+      this.log('transport', 'no channels remaining, scheduling disconnect')
       this._schedulePendingDisconnect()
     }
   }
@@ -540,20 +541,27 @@ export default class RealtimeClient {
   private _schedulePendingDisconnect() {
     this._cancelPendingDisconnect()
     if (this._disconnectOnEmptyChannelsAfterMs === 0) {
+      this.log('transport', 'disconnecting immediately - no channels')
       this.disconnect()
       return
     }
     this._pendingDisconnectTimer = setTimeout(() => {
       this._pendingDisconnectTimer = null
       if (this.channels.length === 0) {
+        this.log('transport', 'deferred disconnect fired - no channels, disconnecting')
         this.disconnect()
       }
     }, this._disconnectOnEmptyChannelsAfterMs)
+    this.log(
+      'transport',
+      `deferred disconnect scheduled in ${this._disconnectOnEmptyChannelsAfterMs}ms`
+    )
   }
 
   /** @internal */
   private _cancelPendingDisconnect() {
     if (this._pendingDisconnectTimer !== null) {
+      this.log('transport', 'pending disconnect cancelled - channel activity detected')
       clearTimeout(this._pendingDisconnectTimer)
       this._pendingDisconnectTimer = null
     }

--- a/packages/core/realtime-js/src/RealtimeClient.ts
+++ b/packages/core/realtime-js/src/RealtimeClient.ts
@@ -72,6 +72,7 @@ export type RealtimeClientOptions = {
   worker?: boolean
   workerUrl?: string
   accessToken?: () => Promise<string | null>
+  disconnectOnEmptyChannelsAfterMs?: number
 }
 
 const WORKER_SCRIPT = `
@@ -177,6 +178,8 @@ export default class RealtimeClient {
   private _authPromise: Promise<void> | null = null
   private _workerHeartbeatTimer: HeartbeatTimer = undefined
   private _pendingWorkerHeartbeatRef: string | null = null
+  private _pendingDisconnectTimer: ReturnType<typeof setTimeout> | null = null
+  private _disconnectOnEmptyChannelsAfterMs: number = 0
 
   /**
    * Initializes the Socket.
@@ -301,6 +304,7 @@ export default class RealtimeClient {
    * @category Realtime
    */
   async disconnect(code?: number, reason?: string) {
+    this._cancelPendingDisconnect()
     if (this.isDisconnecting()) {
       return 'ok'
     }
@@ -336,10 +340,6 @@ export default class RealtimeClient {
       channel.teardown()
     }
 
-    if (this.channels.length === 0) {
-      this.disconnect()
-    }
-
     return status
   }
 
@@ -356,7 +356,7 @@ export default class RealtimeClient {
     })
 
     const result = await Promise.all(promises)
-    this.disconnect()
+    await this.disconnect()
     return result
   }
 
@@ -422,6 +422,7 @@ export default class RealtimeClient {
 
     if (!exists) {
       const chan = new RealtimeChannel(`realtime:${topic}`, params, this)
+      this._cancelPendingDisconnect()
       this.channels.push(chan)
 
       return chan
@@ -530,6 +531,32 @@ export default class RealtimeClient {
    */
   _remove(channel: RealtimeChannel) {
     this.channels = this.channels.filter((c) => c.topic !== channel.topic)
+    if (this.channels.length === 0) {
+      this._schedulePendingDisconnect()
+    }
+  }
+
+  /** @internal */
+  private _schedulePendingDisconnect() {
+    this._cancelPendingDisconnect()
+    if (this._disconnectOnEmptyChannelsAfterMs === 0) {
+      this.disconnect()
+      return
+    }
+    this._pendingDisconnectTimer = setTimeout(() => {
+      this._pendingDisconnectTimer = null
+      if (this.channels.length === 0) {
+        this.disconnect()
+      }
+    }, this._disconnectOnEmptyChannelsAfterMs)
+  }
+
+  /** @internal */
+  private _cancelPendingDisconnect() {
+    if (this._pendingDisconnectTimer !== null) {
+      clearTimeout(this._pendingDisconnectTimer)
+      this._pendingDisconnectTimer = null
+    }
   }
 
   /**
@@ -711,6 +738,10 @@ export default class RealtimeClient {
     result.timeout = options?.timeout ?? DEFAULT_TIMEOUT
     result.heartbeatIntervalMs =
       options?.heartbeatIntervalMs ?? CONNECTION_TIMEOUTS.HEARTBEAT_INTERVAL
+
+    this._disconnectOnEmptyChannelsAfterMs =
+      options?.disconnectOnEmptyChannelsAfterMs ??
+      2 * (options?.heartbeatIntervalMs ?? CONNECTION_TIMEOUTS.HEARTBEAT_INTERVAL)
 
     // @ts-ignore - mismatch between phoenix and supabase
     result.transport = options?.transport ?? WebSocketFactory.getWebSocketConstructor()

--- a/packages/core/realtime-js/test/RealtimeClient.channels.test.ts
+++ b/packages/core/realtime-js/test/RealtimeClient.channels.test.ts
@@ -138,6 +138,89 @@ describe('channel', () => {
   )
 })
 
+describe('deferred disconnect', () => {
+  test('does not disconnect immediately when last channel removed via removeChannel', async () => {
+    testSetup.cleanup()
+    testSetup = setupRealtimeTest({ useFakeTimers: true })
+    const disconnectSpy = vi.spyOn(testSetup.client, 'disconnect')
+
+    const channel = testSetup.client.channel('topic')
+    await testSetup.client.removeChannel(channel)
+
+    expect(disconnectSpy).not.toHaveBeenCalled()
+  })
+
+  test('disconnects after disconnectOnEmptyChannelsAfterMs when channels stay empty', async () => {
+    testSetup.cleanup()
+    testSetup = setupRealtimeTest({ useFakeTimers: true, disconnectOnEmptyChannelsAfterMs: 200 })
+    const disconnectSpy = vi.spyOn(testSetup.client, 'disconnect')
+
+    const channel = testSetup.client.channel('topic')
+    await testSetup.client.removeChannel(channel)
+
+    expect(disconnectSpy).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(200)
+    expect(disconnectSpy).toHaveBeenCalledOnce()
+  })
+
+  test('cancels pending disconnect when a new channel is created before timer fires', async () => {
+    testSetup.cleanup()
+    testSetup = setupRealtimeTest({ useFakeTimers: true, disconnectOnEmptyChannelsAfterMs: 200 })
+    const disconnectSpy = vi.spyOn(testSetup.client, 'disconnect')
+
+    const channel = testSetup.client.channel('topic')
+    await testSetup.client.removeChannel(channel)
+
+    // Create new channel before timer fires
+    testSetup.client.channel('new-topic')
+
+    vi.advanceTimersByTime(300)
+    expect(disconnectSpy).not.toHaveBeenCalled()
+  })
+
+  test('direct channel.unsubscribe() also triggers deferred disconnect', async () => {
+    testSetup.cleanup()
+    testSetup = setupRealtimeTest({ useFakeTimers: true, disconnectOnEmptyChannelsAfterMs: 200 })
+    testSetup.connect()
+    await testSetup.socketConnected()
+
+    const disconnectSpy = vi.spyOn(testSetup.client, 'disconnect')
+    const channel = testSetup.client.channel('topic')
+    channel.subscribe()
+    await waitForChannelSubscribed(channel)
+
+    await channel.unsubscribe()
+
+    expect(disconnectSpy).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(200)
+    expect(disconnectSpy).toHaveBeenCalledOnce()
+  })
+
+  test('disconnectOnEmptyChannelsAfterMs: 0 disconnects immediately', async () => {
+    testSetup.cleanup()
+    testSetup = setupRealtimeTest({ disconnectOnEmptyChannelsAfterMs: 0 })
+    const disconnectSpy = vi.spyOn(testSetup.client, 'disconnect')
+
+    const channel = testSetup.client.channel('topic')
+    await testSetup.client.removeChannel(channel)
+
+    expect(disconnectSpy).toHaveBeenCalledOnce()
+  })
+
+  test('removeAllChannels still disconnects immediately', async () => {
+    testSetup.cleanup()
+    testSetup = setupRealtimeTest({ useFakeTimers: true, disconnectOnEmptyChannelsAfterMs: 200 })
+    const disconnectSpy = vi.spyOn(testSetup.client, 'disconnect')
+
+    testSetup.client.channel('chan1').subscribe()
+    testSetup.client.channel('chan2').subscribe()
+
+    await testSetup.client.removeAllChannels()
+
+    expect(disconnectSpy).toHaveBeenCalledOnce()
+  })
+})
+
 describe('leaveOpenTopic', () => {
   test('enforces client to subscribe to unique topics', async () => {
     const logSpy = vi.fn()

--- a/packages/core/supabase-js/test/integration.test.ts
+++ b/packages/core/supabase-js/test/integration.test.ts
@@ -327,6 +327,46 @@ describe('Supabase Integration Tests', () => {
       expect(receivedMessage).toBeDefined()
       expect(supabase.realtime.getChannels().length).toBe(1)
     }, 10000)
+
+    test('socket stays connected when switching channels (no race condition)', async () => {
+      const config = { broadcast: { ack: true, self: true }, private: true }
+
+      // Subscribe channel A and wait for it to be joined
+      const channelA = supabase.channel(`${channelName}-a`, { config })
+      await new Promise<void>((resolve, reject) => {
+        const timeout = setTimeout(() => reject(new Error('Timeout waiting for channelA')), 8000)
+        channelA.subscribe((status) => {
+          if (status === 'SUBSCRIBED') {
+            clearTimeout(timeout)
+            resolve()
+          }
+        })
+      })
+
+      // Remove channel A — should NOT disconnect immediately
+      await supabase.removeChannel(channelA)
+      expect(supabase.realtime.isConnected()).toBe(true)
+
+      // Immediately subscribe channel B — should reuse the open socket
+      const channelB = supabase.channel(`${channelName}-b`, { config })
+      let channelBSubscribed = false
+      await new Promise<void>((resolve, reject) => {
+        const timeout = setTimeout(() => reject(new Error('Timeout waiting for channelB')), 8000)
+        channelB
+          .on('broadcast', { event: 'ping' }, () => {})
+          .subscribe((status) => {
+            if (status === 'SUBSCRIBED') {
+              channelBSubscribed = true
+              clearTimeout(timeout)
+              resolve()
+            }
+          })
+      })
+
+      expect(channelBSubscribed).toBe(true)
+      // Socket was never disconnected — channelB joined on the existing connection
+      expect(supabase.realtime.isConnected()).toBe(true)
+    }, 20000)
   })
 })
 

--- a/packages/core/supabase-js/test/integration.test.ts
+++ b/packages/core/supabase-js/test/integration.test.ts
@@ -417,6 +417,38 @@ describe('Supabase Integration Tests', () => {
       await new Promise((resolve) => setTimeout(resolve, 1200))
       expect(supabase.realtime.isConnected()).toBe(false)
     }, 15000)
+
+    test('removeAllChannels disconnects socket immediately', async () => {
+      const channelA = supabase.channel(`${channelName}-a`)
+      const channelB = supabase.channel(`${channelName}-b`)
+
+      await Promise.all([
+        new Promise<void>((resolve, reject) => {
+          const timeout = setTimeout(() => reject(new Error('Timeout waiting for channelA')), 8000)
+          channelA.subscribe((status) => {
+            if (status === 'SUBSCRIBED') {
+              clearTimeout(timeout)
+              resolve()
+            }
+          })
+        }),
+        new Promise<void>((resolve, reject) => {
+          const timeout = setTimeout(() => reject(new Error('Timeout waiting for channelB')), 8000)
+          channelB.subscribe((status) => {
+            if (status === 'SUBSCRIBED') {
+              clearTimeout(timeout)
+              resolve()
+            }
+          })
+        }),
+      ])
+
+      expect(supabase.realtime.isConnected()).toBe(true)
+
+      await supabase.removeAllChannels()
+      // removeAllChannels is an explicit teardown — no deferred timer, disconnect is immediate
+      expect(supabase.realtime.isConnected()).toBe(false)
+    }, 20000)
   })
 })
 

--- a/packages/core/supabase-js/test/integration.test.ts
+++ b/packages/core/supabase-js/test/integration.test.ts
@@ -367,6 +367,56 @@ describe('Supabase Integration Tests', () => {
       // Socket was never disconnected — channelB joined on the existing connection
       expect(supabase.realtime.isConnected()).toBe(true)
     }, 20000)
+
+    test('socket disconnects after removeChannel when no channels remain', async () => {
+      await new Promise<void>((resolve, reject) => {
+        const timeout = setTimeout(
+          () => reject(new Error('Timeout waiting for subscription')),
+          8000
+        )
+        channel.subscribe((status) => {
+          if (status === 'SUBSCRIBED') {
+            clearTimeout(timeout)
+            resolve()
+          }
+        })
+      })
+
+      expect(supabase.realtime.isConnected()).toBe(true)
+
+      await supabase.removeChannel(channel)
+      // Deferred disconnect is scheduled — socket still open
+      expect(supabase.realtime.isConnected()).toBe(true)
+
+      // Wait for deferred disconnect (2 * heartbeatIntervalMs = 1000 ms)
+      await new Promise((resolve) => setTimeout(resolve, 1200))
+      expect(supabase.realtime.isConnected()).toBe(false)
+    }, 15000)
+
+    test('socket disconnects after channel.unsubscribe() when no channels remain', async () => {
+      await new Promise<void>((resolve, reject) => {
+        const timeout = setTimeout(
+          () => reject(new Error('Timeout waiting for subscription')),
+          8000
+        )
+        channel.subscribe((status) => {
+          if (status === 'SUBSCRIBED') {
+            clearTimeout(timeout)
+            resolve()
+          }
+        })
+      })
+
+      expect(supabase.realtime.isConnected()).toBe(true)
+
+      await channel.unsubscribe()
+      // Deferred disconnect is scheduled — socket still open
+      expect(supabase.realtime.isConnected()).toBe(true)
+
+      // Wait for deferred disconnect (2 * heartbeatIntervalMs = 1000 ms)
+      await new Promise((resolve) => setTimeout(resolve, 1200))
+      expect(supabase.realtime.isConnected()).toBe(false)
+    }, 15000)
   })
 })
 


### PR DESCRIPTION
<!-- Your PR title should follow the conventional commit format:
<type>(<scope>): <description> -->

## 🔍 Description

### What changed?

* Adds a `disconnectOnEmptyChannelsAfterMs` option to `RealtimeClientOptions` that delays the WebSocket disconnect after the last channel is removed                                                                                                                                                                                                
* Defaults to 2 × heartbeatIntervalMs — giving a window to reuse the existing connection when switching channels without a reconnect penalty
* Cancels the pending disconnect if a new channel is created before the timer fires                                                                                                                                                                                                                                                             
* removeAllChannels() continues to disconnect immediately (explicit teardown intent)                                                                                                                                                                                                                                                           

### Why was this change needed?

WebSockets could be left open wasting resources (both on client and server side) even when all channels have been removed

## 📸 Screenshots/Examples

<!-- If applicable, add screenshots or code examples to help explain your changes -->

## 🔄 Breaking changes

<!-- If this PR contains breaking changes, describe them here -->

- [x] This PR contains no breaking changes

## 📋 Checklist

<!-- Ensure all items are checked before submitting -->

- [x] I have read the [Contributing Guidelines](https://github.com/supabase/supabase-js/blob/master/CONTRIBUTING.md)
- [x] My PR title follows the [conventional commit format](https://www.conventionalcommits.org/): `<type>(<scope>): <description>`
- [x] I have run `npx nx format` to ensure consistent code formatting
- [x] I have added tests for new functionality (if applicable)
- [x] I have updated documentation (if applicable)
