### PR TITLE
fix(auth): emit PASSWORD_RECOVERY event for PKCE recovery flows

### DIFF
--- a/packages/core/auth-js/src/GoTrueClient.ts
+++ b/packages/core/auth-js/src/GoTrueClient.ts
@@ -1835,7 +1835,10 @@ export default class GoTrueClient {
       }
       if (data.session) {
         await this._saveSession(data.session)
-        await this._notifyAllSubscribers('SIGNED_IN', data.session)
+        await this._notifyAllSubscribers(
+          redirectType === 'recovery' ? 'PASSWORD_RECOVERY' : 'SIGNED_IN',
+          data.session
+        )
       }
       return this._returnResult({ data: { ...data, redirectType: redirectType ?? null }, error })
     } catch (error) {
@@ -3584,7 +3587,10 @@ export default class GoTrueClient {
 
         window.history.replaceState(window.history.state, '', url.toString())
 
-        return { data: { session: data.session, redirectType: null }, error: null }
+        return {
+          data: { session: data.session, redirectType: data.redirectType ?? null },
+          error: null,
+        }
       }
 
       const {

--- a/packages/core/auth-js/src/lib/helpers.ts
+++ b/packages/core/auth-js/src/lib/helpers.ts
@@ -304,7 +304,7 @@ export async function getCodeChallengeAndMethod(
   const codeVerifier = generatePKCEVerifier()
   let storedCodeVerifier = codeVerifier
   if (isPasswordRecovery) {
-    storedCodeVerifier += '/PASSWORD_RECOVERY'
+    storedCodeVerifier += '/recovery'
   }
   await setItemAsync(storage, `${storageKey}-code-verifier`, storedCodeVerifier)
   const codeChallenge = await generatePKCEChallenge(codeVerifier)

--- a/packages/core/auth-js/test/helpers.test.ts
+++ b/packages/core/auth-js/test/helpers.test.ts
@@ -271,11 +271,11 @@ describe('getAlgorithm', () => {
 describe('getCodeChallengeAndMethod', () => {
   const testCases = [
     {
-      name: 'should append /PASSWORD_RECOVERY to stored code_verifier',
+      name: 'should append /recovery to stored code_verifier',
       isPasswordRecovery: true,
     },
     {
-      name: 'should not append /PASSWORD_RECOVERY for other flows',
+      name: 'should not append /recovery for other flows',
       isPasswordRecovery: false,
     },
   ]
@@ -297,9 +297,9 @@ describe('getCodeChallengeAndMethod', () => {
     expect(setItemCall[0]).toBe('test-storage-key-code-verifier')
     const storedValue = JSON.parse(setItemCall[1])
     if (isPasswordRecovery) {
-      expect(storedValue).toContain('/PASSWORD_RECOVERY')
+      expect(storedValue).toContain('/recovery')
     } else {
-      expect(storedValue).not.toContain('/PASSWORD_RECOVERY')
+      expect(storedValue).not.toContain('/recovery')
     }
     expect(codeChallenge).toBeDefined()
     expect(codeChallengeMethod).toBeDefined()


### PR DESCRIPTION
The PKCE recovery flow never emitted the `PASSWORD_RECOVERY` event due to three bugs: the `redirectType` was discarded in `_getSessionFromURL`, the stored code verifier suffix used `'PASSWORD_RECOVERY'` instead of `'recovery'` (mismatching `_initialize`'s check), and `_exchangeCodeForSession` always emitted `SIGNED_IN` regardless of flow type.                                                                                                                                                                                      
                                                     