### PR TITLE
fix(storage): apply metadata, headers, and cacheControl dedupe to uploadToSignedUrl

### DIFF
--- a/packages/core/storage-js/src/packages/StorageFileApi.ts
+++ b/packages/core/storage-js/src/packages/StorageFileApi.ts
@@ -269,22 +269,41 @@ export default class StorageFileApi extends BaseApiClient<StorageError> {
     return this.handleOperation(async () => {
       let body
       const options = { ...DEFAULT_FILE_OPTIONS, ...fileOptions }
-      const headers: Record<string, string> = {
+      let headers: Record<string, string> = {
         ...this.headers,
         ...{ 'x-upsert': String(options.upsert as boolean) },
       }
 
+      const metadata = options.metadata
+
       if (typeof Blob !== 'undefined' && fileBody instanceof Blob) {
         body = new FormData()
         body.append('cacheControl', options.cacheControl as string)
+        if (metadata) {
+          body.append('metadata', this.encodeMetadata(metadata))
+        }
         body.append('', fileBody)
       } else if (typeof FormData !== 'undefined' && fileBody instanceof FormData) {
         body = fileBody
-        body.append('cacheControl', options.cacheControl as string)
+        if (!body.has('cacheControl')) {
+          body.append('cacheControl', options.cacheControl as string)
+        }
+        if (metadata && !body.has('metadata')) {
+          body.append('metadata', this.encodeMetadata(metadata))
+        }
       } else {
         body = fileBody
         headers['cache-control'] = `max-age=${options.cacheControl}`
         headers['content-type'] = options.contentType as string
+        if (metadata) {
+          headers['x-metadata'] = this.toBase64(this.encodeMetadata(metadata))
+        }
+      }
+
+      if (fileOptions?.headers) {
+        for (const [key, value] of Object.entries(fileOptions.headers)) {
+          headers = setHeader(headers, key, value)
+        }
       }
 
       const data = await put(this.fetch, url.toString(), body as object, { headers })

--- a/packages/core/storage-js/test/storageFileApi.test.ts
+++ b/packages/core/storage-js/test/storageFileApi.test.ts
@@ -1206,5 +1206,80 @@ describe('StorageFileApi Edge Cases', () => {
       expect(headers['Content-Type']).toBeUndefined()
       expect(new Headers(headers).get('content-type')).toBe('image/png')
     })
+
+    test('uploadToSignedUrl with metadata (Blob body)', async () => {
+      const testBlob = new Blob(['test content'], { type: 'text/plain' })
+      const metadata = { customKey: 'customValue', author: 'test' }
+
+      await storage
+        .from('test-bucket')
+        .uploadToSignedUrl('test-path', 'test-token', testBlob, { metadata })
+
+      expect(mockPut).toHaveBeenCalled()
+      const [, , body] = mockPut.mock.calls[0]
+      expect(body.constructor.name).toBe('FormData')
+      expect((body as FormData).get('metadata')).toBe(JSON.stringify(metadata))
+    })
+
+    test('uploadToSignedUrl with metadata (FormData body)', async () => {
+      const testFormData = new FormData()
+      testFormData.append('file', 'test content')
+      const metadata = { blah: 'abc213' }
+
+      await storage
+        .from('test-bucket')
+        .uploadToSignedUrl('test-path', 'test-token', testFormData, { metadata })
+
+      expect(mockPut).toHaveBeenCalled()
+      const [, , body] = mockPut.mock.calls[0] as [null, null, FormData]
+      expect(body).toBe(testFormData)
+      expect(body.get('metadata')).toBe(JSON.stringify(metadata))
+    })
+
+    test('uploadToSignedUrl with metadata (raw body sends x-metadata header)', async () => {
+      const metadata = { blah: 'abc213' }
+
+      await storage
+        .from('test-bucket')
+        .uploadToSignedUrl('test-path', 'test-token', 'test content', { metadata })
+
+      expect(mockPut).toHaveBeenCalled()
+      const [, , , { headers }] = mockPut.mock.calls[0]
+      expect(headers['x-metadata']).toBeDefined()
+      expect(Buffer.from(headers['x-metadata'], 'base64').toString('utf8')).toBe(
+        JSON.stringify(metadata)
+      )
+    })
+
+    test('uploadToSignedUrl passes headers', async () => {
+      const testFormData = new FormData()
+      testFormData.append('file', 'test content')
+
+      const testHeaderKey = 'x-test-header'
+      const testHeaderValue = 'abc123'
+
+      await storage.from('test-bucket').uploadToSignedUrl('test-path', 'test-token', testFormData, {
+        headers: { [testHeaderKey]: testHeaderValue },
+      })
+
+      expect(mockPut).toHaveBeenCalled()
+      const [, , body, { headers }] = mockPut.mock.calls[0]
+      expect(body).toBe(testFormData)
+      expect(headers[testHeaderKey]).toBe(testHeaderValue)
+    })
+
+    test('uploadToSignedUrl does not duplicate cacheControl when caller FormData has one', async () => {
+      const testFormData = new FormData()
+      testFormData.append('cacheControl', '7200')
+      testFormData.append('file', 'test content')
+
+      await storage
+        .from('test-bucket')
+        .uploadToSignedUrl('test-path', 'test-token', testFormData, { cacheControl: '3600' })
+
+      expect(mockPut).toHaveBeenCalled()
+      const [, , body] = mockPut.mock.calls[0] as [null, null, FormData]
+      expect(body.getAll('cacheControl')).toEqual(['7200'])
+    })
   })
 })


### PR DESCRIPTION
Closes #2274.

## Summary

`uploadToSignedUrl` silently drops three `FileOptions` that `upload`/`update` honor via `uploadOrUpdate`:

1. `options.metadata` is ignored. No form field on Blob/FormData bodies, no `x-metadata` header on raw bodies.
2. `fileOptions.headers` is ignored. The `setHeader` merge loop was missing.
3. `cacheControl` on caller-supplied FormData got appended unconditionally, producing two entries when the caller already added one.

This patch mirrors the handling from `uploadOrUpdate` across all three body branches (Blob, FormData, raw) and adds the post-branch headers merge. No behavioral change for the content-type / cache-control defaults on raw bodies, nor for the fallbacks when the options are absent.

## Test plan

- [x] `uploadToSignedUrl with metadata (Blob body)`. FormData includes a `metadata` field.
- [x] `uploadToSignedUrl with metadata (FormData body)`. Caller's FormData keeps its own entries and gains `metadata`.
- [x] `uploadToSignedUrl with metadata (raw body sends x-metadata header)`. Base64-encoded JSON in the `x-metadata` request header.
- [x] `uploadToSignedUrl passes headers`. `fileOptions.headers` keys reach the outgoing request.
- [x] `uploadToSignedUrl does not duplicate cacheControl when caller FormData has one`. Caller's `7200` wins, SDK's `3600` default is skipped.

All 10 `uploadToSignedUrl` tests pass, including the 5 new ones. The fix was also reproduced end-to-end against a local `supabase/storage` Docker server.