### PR TITLE
fix(postgrest): sanitize leading slashes in relation and function namesfix(postgrest): sanitize leading slashes in relation and function names

### DIFF
--- a/packages/core/postgrest-js/src/PostgrestClient.ts
+++ b/packages/core/postgrest-js/src/PostgrestClient.ts
@@ -18,21 +18,21 @@ export default class PostgrestClient<
   ClientOptions extends ClientServerOptions = Database extends {
     __InternalSupabase: infer I extends ClientServerOptions
   }
-    ? I
-    : {},
+  ? I
+  : {},
   SchemaName extends string &
-    keyof Omit<Database, '__InternalSupabase'> = 'public' extends keyof Omit<
+  keyof Omit<Database, '__InternalSupabase'> = 'public' extends keyof Omit<
     Database,
     '__InternalSupabase'
   >
-    ? 'public'
-    : string & keyof Omit<Database, '__InternalSupabase'>,
+  ? 'public'
+  : string & keyof Omit<Database, '__InternalSupabase'>,
   Schema extends GenericSchema = Omit<
     Database,
     '__InternalSupabase'
   >[SchemaName] extends GenericSchema
-    ? Omit<Database, '__InternalSupabase'>[SchemaName]
-    : any,
+  ? Omit<Database, '__InternalSupabase'>[SchemaName]
+  : any,
 > {
   url: string
   headers: Headers
@@ -169,8 +169,9 @@ export default class PostgrestClient<
     if (!relation || typeof relation !== 'string' || relation.trim() === '') {
       throw new Error('Invalid relation name: relation must be a non-empty string.')
     }
-
-    const url = new URL(`${this.url}/${relation}`)
+    const _relation = relation.startsWith('/') ?
+      relation.substring(1) : relation
+    const url = new URL(`${this.url}/${_relation}`)
     return new PostgrestQueryBuilder(url, {
       headers: new Headers(this.headers),
       schema: this.schemaName,
@@ -401,11 +402,14 @@ export default class PostgrestClient<
     'RPC'
   > {
     let method: 'HEAD' | 'GET' | 'POST'
+    const _fn = fn.startsWith('/') ?
+      fn.substring(1) : fn
     const url = new URL(`${this.url}/rpc/${fn}`)
     let body: unknown | undefined
     // objects/arrays-of-objects can't be serialized to URL params, use POST + return=minimal instead
     const _isObject = (v: unknown): boolean =>
       v !== null && typeof v === 'object' && (!Array.isArray(v) || v.some(_isObject))
+
     const _hasObjectArg = head && Object.values(args as object).some(_isObject)
     if (_hasObjectArg) {
       method = 'POST'

--- a/packages/core/postgrest-js/test/url-sanitization.test.ts
+++ b/packages/core/postgrest-js/test/url-sanitization.test.ts
@@ -1,0 +1,48 @@
+import { PostgrestClient } from '../src/index'
+import { Database } from './types.override'
+
+describe('URL Sanitization', () => {
+    test('from() should remove leading slashes from relation names', async () => {
+        const mockFetch = jest.fn().mockResolvedValue({
+            ok: true,
+            status: 200,
+            headers: new Headers(),
+            json: async () => [],
+            text: async () => '[]',
+        })
+
+        const postgrest = new PostgrestClient<Database>('https://example.com', {
+            fetch: mockFetch as any,
+        })
+
+        // Passing a relation with a leading slash
+        await postgrest.from('/users' as any).select()
+
+        const [url] = mockFetch.mock.calls[0]
+        // Verify it produced a clean URL without a double slash
+        expect(url.toString()).toContain('example.com/users')
+        expect(url.toString()).not.toContain('example.com//users')
+    })
+
+    test('rpc() should remove leading slashes from function names', async () => {
+        const mockFetch = jest.fn().mockResolvedValue({
+            ok: true,
+            status: 200,
+            headers: new Headers(),
+            json: async () => [],
+            text: async () => '[]',
+        })
+
+        const postgrest = new PostgrestClient<Database>('https://example.com', {
+            fetch: mockFetch as any,
+        })
+
+        // Passing a function name with a leading slash
+        await postgrest.rpc('/my_function' as any)
+
+        const [url] = mockFetch.mock.calls[0]
+        // Verify it produced a clean /rpc/my_function path
+        expect(url.toString()).toContain('example.com/rpc/my_function')
+        expect(url.toString()).not.toContain('example.com/rpc//my_function')
+    })
+})


### PR DESCRIPTION
 A regression was introduced in PR #1425 that causes PostgrestClient to generate URLs with double slashes (//) if a user provides a relation or function name with a leading slash (e.g., .from('/users')).

**Steps to Reproduce:**

**javascript**
const client = new PostgrestClient('https://xyz.supabase.co/rest/v1');
const url = client.from('/users').select().url; 
console.log(url.toString()); 

**Results in**: https://xyz.supabase.co/rest/v1//users
**Expected Behavior:** The leading slash should be sanitized to produce a clean URL: https://xyz.supabase.co/rest/v1/users.

**Additional Context:** This affects both from() and rpc() in PostgrestClient.ts.