### PR TITLE
fix(postgrest): remove leading slashes from relation and function names

### DIFF
--- a/packages/core/postgrest-js/src/PostgrestClient.ts
+++ b/packages/core/postgrest-js/src/PostgrestClient.ts
@@ -170,7 +170,8 @@ export default class PostgrestClient<
       throw new Error('Invalid relation name: relation must be a non-empty string.')
     }
 
-    const url = new URL(`${this.url}/${relation}`)
+    const _relation = relation.startsWith('/') ? relation.substring(1) : relation
+    const url = new URL(`${this.url}/${_relation}`)
     return new PostgrestQueryBuilder(url, {
       headers: new Headers(this.headers),
       schema: this.schemaName,
@@ -401,7 +402,8 @@ export default class PostgrestClient<
     'RPC'
   > {
     let method: 'HEAD' | 'GET' | 'POST'
-    const url = new URL(`${this.url}/rpc/${fn}`)
+    const _fn = fn.startsWith('/') ? fn.substring(1) : fn
+    const url = new URL(`${this.url}/rpc/${_fn}`)
     let body: unknown | undefined
     // objects/arrays-of-objects can't be serialized to URL params, use POST + return=minimal instead
     const _isObject = (v: unknown): boolean =>

--- a/packages/core/postgrest-js/test/url-sanitization.test.ts
+++ b/packages/core/postgrest-js/test/url-sanitization.test.ts
@@ -1,0 +1,48 @@
+import { PostgrestClient } from '../src/index'
+import { Database } from './types.override'
+
+describe('URL Sanitization', () => {
+  test('from() should remove leading slashes from relation names', async () => {
+    const mockFetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers(),
+      json: async () => [],
+      text: async () => '[]',
+    })
+
+    const postgrest = new PostgrestClient<Database>('https://example.com', {
+      fetch: mockFetch as any,
+    })
+
+    // Passing a relation with a leading slash
+    await postgrest.from('/users' as any).select()
+
+    const [url] = mockFetch.mock.calls[0]
+    // Verify it produced a clean URL without a double slash
+    expect(url.toString()).toContain('example.com/users')
+    expect(url.toString()).not.toContain('example.com//users')
+  })
+
+  test('rpc() should remove leading slashes from function names', async () => {
+    const mockFetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers(),
+      json: async () => [],
+      text: async () => '[]',
+    })
+
+    const postgrest = new PostgrestClient<Database>('https://example.com', {
+      fetch: mockFetch as any,
+    })
+
+    // Passing a function name with a leading slash
+    await postgrest.rpc('/my_function' as any)
+
+    const [url] = mockFetch.mock.calls[0]
+    // Verify it produced a clean /rpc/my_function path
+    expect(url.toString()).toContain('example.com/rpc/my_function')
+    expect(url.toString()).not.toContain('example.com/rpc//my_function')
+  })
+})


### PR DESCRIPTION
 **Overview**
This PR fixes a regression where `PostgrestClient` generates URLs with double slashes (`//`) if a user provides a relation or function name with a leading slash (e.g., `.from('/users')` or `.rpc('/my_function')`).

 **Changes**
- Updated `PostgrestClient.from()` to sanitize leading slashes from relation names.
- Updated `PostgrestClient.rpc()` to sanitize leading slashes from function names.
- Added a new test suite `test/url-sanitization.test.ts` to verify the fix and prevent future regressions.

 **Steps to Reproduce**
**javascript**
const client = new PostgrestClient('https://xyz.supabase.co/rest/v1');
const url = client.from('/users').select().url;
console.log(url.toString());

**Current Result:** https://xyz.supabase.co/rest/v1//users
**Expected Behavior:** https://xyz.supabase.co/rest/v1/users
