### PR TITLE
fix(realtime): annotate Timer/Vsn getters to avoid deep phoenix imports

### DIFF
--- a/packages/core/realtime-js/src/RealtimeChannel.ts
+++ b/packages/core/realtime-js/src/RealtimeChannel.ts
@@ -11,6 +11,7 @@ import * as Transformers from './lib/transformers'
 import { httpEndpointURL } from './lib/transformers'
 import ChannelAdapter from './phoenix/channelAdapter'
 import { ChannelBindingCallback, ChannelOnErrorCallback } from './phoenix/types'
+import type { Timer } from './phoenix/types'
 
 type ReplayOption = {
   since: number
@@ -200,7 +201,7 @@ export default class RealtimeChannel {
     return this.channelAdapter.joinPush
   }
 
-  get rejoinTimer() {
+  get rejoinTimer(): Timer {
     return this.channelAdapter.rejoinTimer
   }
 

--- a/packages/core/realtime-js/src/RealtimeClient.ts
+++ b/packages/core/realtime-js/src/RealtimeClient.ts
@@ -15,7 +15,15 @@ import { httpEndpointURL } from './lib/transformers'
 import RealtimeChannel from './RealtimeChannel'
 import type { RealtimeChannelOptions } from './RealtimeChannel'
 import SocketAdapter from './phoenix/socketAdapter'
-import type { Message, SocketOptions, HeartbeatCallback, Encode, Decode } from './phoenix/types'
+import type {
+  Message,
+  SocketOptions,
+  HeartbeatCallback,
+  Encode,
+  Decode,
+  Timer,
+  Vsn,
+} from './phoenix/types'
 
 type Fetch = typeof fetch
 
@@ -141,11 +149,11 @@ export default class RealtimeClient {
     return this.socketAdapter.pendingHeartbeatRef
   }
 
-  get reconnectTimer() {
+  get reconnectTimer(): Timer {
     return this.socketAdapter.reconnectTimer
   }
 
-  get vsn() {
+  get vsn(): Vsn {
     return this.socketAdapter.vsn
   }
 


### PR DESCRIPTION
## Description

Fixes type-checking failures for consumers using `moduleResolution: NodeNext`. The published `.d.ts` files in `@supabase/realtime-js` were inlining inferred return types via `import("@supabase/phoenix/priv/static/types/timer")` and `import("@supabase/phoenix/priv/static/types/types")`. `@supabase/phoenix@0.4.0`'s `exports` map only publishes the root entry, so those deep paths fail to resolve and produce `TS2307` errors unless consumers enable `skipLibCheck`.

### What changed?

- `packages/core/realtime-js/src/RealtimeChannel.ts`: added `import type { Timer } from './phoenix/types'` and annotated `get rejoinTimer(): Timer`.
- `packages/core/realtime-js/src/RealtimeClient.ts`: added `Timer` and `Vsn` to the existing type-only import from `./phoenix/types` and annotated `get reconnectTimer(): Timer` and `get vsn(): Vsn`.

`Timer` and `Vsn` are already re-exported from `src/phoenix/types.ts`, originating from the public root entry of `@supabase/phoenix`. With explicit annotations on the three getters, TypeScript's declaration emit references those names directly instead of falling back to `import("...")` against the original phoenix internal files.

### Why was this change needed?

Without explicit return type annotations, TypeScript's declaration emit inferred the types and inlined them via `import()` pointing at the original definitions inside `node_modules/@supabase/phoenix/priv/static/types/`. Phoenix's `exports` map blocks resolution of those deep paths under `NodeNext`, so consumers got:

```
error TS2307: Cannot find module '@supabase/phoenix/priv/static/types/timer'
error TS2307: Cannot find module '@supabase/phoenix/priv/static/types/types'
```

Verified against the published `@supabase/realtime-js@2.104.1` tarball that the three offending lines were:

- `dist/module/RealtimeChannel.d.ts:169` → `get rejoinTimer(): import("@supabase/phoenix/priv/static/types/timer").default;`
- `dist/module/RealtimeClient.d.ts:76` → `get reconnectTimer(): import("@supabase/phoenix/priv/static/types/timer").default;`
- `dist/module/RealtimeClient.d.ts:77` → `get vsn(): import("@supabase/phoenix/priv/static/types/types").Vsn;`

After this fix, `nx build realtime-js` emits `get rejoinTimer(): Timer;`, `get reconnectTimer(): Timer;`, and `get vsn(): Vsn;` instead. A `grep` for `phoenix/priv/static` across `dist/` returns zero matches.

This keeps phoenix's internal file layout private (preferred fix from the issue) rather than exposing it through phoenix's `exports` map.

Closes #2276

## Screenshots/Examples

N/A. The change is in TypeScript declaration emit only.

## Breaking changes

- [x] This PR contains no breaking changes

The runtime behavior is unchanged. The only effect is on the emitted `.d.ts`: the public return types (`Timer`, `Vsn`) are equivalent to what was previously inferred, just referenced via the public re-export rather than a deep path.

## Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/supabase/supabase-js/blob/master/CONTRIBUTING.md)
- [x] My PR title follows the [conventional commit format](https://www.conventionalcommits.org/): `<type>(<scope>): <description>`
- [x] I have run `npx nx format` to ensure consistent code formatting
- [ ] I have added tests for new functionality (if applicable)
- [ ] I have updated documentation (if applicable)

No new tests added: the fix is a pure type annotation change with no runtime behavior to test, and the existing 333 unit tests pass unchanged via `nx test realtime-js`. A regression test that greps the built `.d.ts` for `phoenix/priv/static` paths could be added as a follow-up if desired.

## Additional notes

The reporter on #2276 also offered an alternative fix in `@supabase/phoenix` (publish subpath exports for `./priv/static/types/*`). That alternative would unblock type-checking but bake phoenix's internal file layout into realtime-js's public contract. The annotation fix here is preferred and self-contained in this repo.