### PR TITLE
fix(storage): forward duplex option for stream uploads via uploadToSignedUrl

### DIFF
--- a/packages/core/storage-js/src/packages/StorageFileApi.ts
+++ b/packages/core/storage-js/src/packages/StorageFileApi.ts
@@ -298,6 +298,14 @@ export default class StorageFileApi extends BaseApiClient<StorageError> {
         if (metadata) {
           headers['x-metadata'] = this.toBase64(this.encodeMetadata(metadata))
         }
+
+        const isStream =
+          (typeof ReadableStream !== 'undefined' && body instanceof ReadableStream) ||
+          (body && typeof body === 'object' && 'pipe' in body && typeof body.pipe === 'function')
+
+        if (isStream && !options.duplex) {
+          options.duplex = 'half'
+        }
       }
 
       if (fileOptions?.headers) {
@@ -306,7 +314,10 @@ export default class StorageFileApi extends BaseApiClient<StorageError> {
         }
       }
 
-      const data = await put(this.fetch, url.toString(), body as object, { headers })
+      const data = await put(this.fetch, url.toString(), body as object, {
+        headers,
+        ...(options?.duplex ? { duplex: options.duplex } : {}),
+      })
 
       return { path: cleanPath, fullPath: data.Key }
     })

--- a/packages/core/storage-js/test/storageFileApi.test.ts
+++ b/packages/core/storage-js/test/storageFileApi.test.ts
@@ -1281,5 +1281,25 @@ describe('StorageFileApi Edge Cases', () => {
       const [, , body] = mockPut.mock.calls[0] as [null, null, FormData]
       expect(body.getAll('cacheControl')).toEqual(['7200'])
     })
+
+    test('uploadToSignedUrl auto-sets duplex to half when raw body is a stream', async () => {
+      const fakeStream = { pipe: () => {} } as unknown as NodeJS.ReadableStream
+
+      await storage.from('test-bucket').uploadToSignedUrl('test-path', 'test-token', fakeStream)
+
+      expect(mockPut).toHaveBeenCalled()
+      const [, , , options] = mockPut.mock.calls[0]
+      expect(options.duplex).toBe('half')
+    })
+
+    test('uploadToSignedUrl forwards caller-provided duplex', async () => {
+      await storage
+        .from('test-bucket')
+        .uploadToSignedUrl('test-path', 'test-token', 'test content', { duplex: 'half' })
+
+      expect(mockPut).toHaveBeenCalled()
+      const [, , , options] = mockPut.mock.calls[0]
+      expect(options.duplex).toBe('half')
+    })
   })
 })

--- a/packages/core/storage-js/test/storageFileApiNode.test.ts
+++ b/packages/core/storage-js/test/storageFileApiNode.test.ts
@@ -39,5 +39,18 @@ describe('Object API', () => {
       expect(res.error).toBeNull()
       expect(res.data?.path).toEqual(uploadPathWithDuplex)
     })
+
+    test('uploadToSignedUrl auto-detects stream and sets duplex', async () => {
+      const uploadPath = `testpath/signed-stream-${Date.now()}.txt`
+
+      const signed = await storage.from(bucketName).createSignedUploadUrl(uploadPath)
+      expect(signed.error).toBeNull()
+      const token = signed.data!.token
+
+      const file = await fs.createReadStream(uploadFilePath('file.txt'))
+      const res = await storage.from(bucketName).uploadToSignedUrl(uploadPath, token, file)
+      expect(res.error).toBeNull()
+      expect(res.data?.path).toEqual(uploadPath)
+    })
   })
 })


### PR DESCRIPTION
## Description

Closes the residual stream-handling parity gap in `uploadToSignedUrl` left over from #2275. Without this, uploading a `ReadableStream` or Node `Readable` through a signed URL fails on Node 20+ with `RequestInit: duplex option is required when sending a body`.

### What changed?

- `packages/core/storage-js/src/packages/StorageFileApi.ts`: in the raw-body branch of `uploadToSignedUrl`, mirror the stream detection block from `uploadOrUpdate` (`StorageFileApi.ts:122-130`). When the body is a `ReadableStream` or a Node `Readable` (duck-typed via `.pipe`), set `options.duplex = 'half'` if the caller did not already supply it. Forward `duplex` through the `put` call so it reaches `fetch`.
- `packages/core/storage-js/test/storageFileApi.test.ts`: two mock-based tests proving (a) auto-detection sets `duplex: 'half'` for stream-shaped bodies, and (b) a caller-provided `duplex` is forwarded.
- `packages/core/storage-js/test/storageFileApiNode.test.ts`: real-infrastructure test that creates a signed URL and uploads `fs.createReadStream` through it, with no explicit `duplex`, against the Supabase storage Docker server.

No new helpers were needed: `FileOptions.duplex` (`src/lib/types.ts:160-162`) and `FetchOptions.duplex` (`src/lib/common/fetch.ts:11-17`) already exist, and the `put` helper already forwards `duplex` to `fetch` via `_getRequestParams` (`src/lib/common/fetch.ts:114-116`).

### Why was this change needed?

`uploadOrUpdate` honors stream bodies; `uploadToSignedUrl` did not. PR #2275 brought parity for `metadata`, `fileOptions.headers`, and `cacheControl` de-dup on caller FormData, but the stream/duplex case stayed broken. Verified server-side that this is safe: `PUT /object/upload/sign/:bucket/*` and `POST /object/:bucket/*` route through the same `fileUploadFromRequest` -> `Uploader.upload()` pipeline (`uploader.ts:421-568`), so raw stream bodies parse identically on both endpoints.

Closes #2274 (residual gap), helps close supabase/storage#823.

## Screenshots/Examples

Before this change on Node 20+:

```js
import fs from 'fs'

const { data: { token } } = await supabase.storage
  .from('bucket')
  .createSignedUploadUrl('path/file.txt')

await supabase.storage
  .from('bucket')
  .uploadToSignedUrl('path/file.txt', token, fs.createReadStream('file.txt'))
// throws: RequestInit: duplex option is required when sending a body
```

After: succeeds and the file lands in storage. Callers can also pass `{ duplex: 'half' }` explicitly to override.

## Breaking changes

- [x] This PR contains no breaking changes

The change is additive: the only new behavior is auto-setting `duplex: 'half'` when the body is detected as a stream. Existing callers (Blob, FormData, raw string/Buffer/Uint8Array) are unaffected.

## Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/supabase/supabase-js/blob/master/CONTRIBUTING.md)
- [x] My PR title follows the [conventional commit format](https://www.conventionalcommits.org/): `<type>(<scope>): <description>`
- [x] I have run `npx nx format` to ensure consistent code formatting
- [x] I have added tests for new functionality (if applicable)
- [ ] I have updated documentation (if applicable)

## Additional notes

Test results locally:

- `nx build storage-js`: ok
- `nx test storage-js` (mock unit tests): 12/12 `uploadToSignedUrl` tests pass, including the 2 new ones
- `nx test:storage storage-js` (full Docker suite, includes the new Node integration test): 388 passed, 2 skipped