### PR TITLE
fix(postgrest): query reassignment regression

### DIFF
--- a/packages/core/postgrest-js/src/PostgrestFilterBuilder.ts
+++ b/packages/core/postgrest-js/src/PostgrestFilterBuilder.ts
@@ -1747,7 +1747,8 @@ export default class PostgrestFilterBuilder<
     RelationName,
     Relationships,
     Method
-  >
+  > &
+    this
   not<ColumnName extends string & keyof Row>(
     column: ColumnName,
     operator: FilterOperator,
@@ -1816,7 +1817,8 @@ export default class PostgrestFilterBuilder<
     column: string,
     operator: string,
     value: unknown
-  ): PostgrestFilterBuilder<ClientOptions, Schema, any, any, RelationName, Relationships, Method> {
+  ): PostgrestFilterBuilder<ClientOptions, Schema, any, any, RelationName, Relationships, Method> &
+    this {
     this.url.searchParams.append(column, `not.${operator}.${value}`)
     return this as any
   }

--- a/packages/core/postgrest-js/test/index.test-d.ts
+++ b/packages/core/postgrest-js/test/index.test-d.ts
@@ -349,6 +349,40 @@ const postgrestWithOptions = new PostgrestClient<DatabaseWithOptions>(REST_URL)
 
 // `.not(col, 'is', null)` narrows nullable column to non-nullable in result (#1360)
 {
+  {
+    type Database = {
+      public: {
+        Tables: {
+          articles: {
+            Row: { id: string; published_at: string | null }
+            Insert: never
+            Update: never
+            Relationships: []
+          }
+        }
+        Views: {}
+        Functions: {}
+        Enums: {}
+        CompositeTypes: {}
+      }
+    }
+
+    const client = new PostgrestClient<Database>(REST_URL)
+    let query = client.from('articles').select('id, published_at')
+
+    const hasPublishedAt = true
+    if (hasPublishedAt) {
+      query = query.not('published_at', 'is', null)
+    }
+
+    const result = await query
+    if (result.error) {
+      throw new Error(result.error.message)
+    }
+
+    expectType<{ id: string; published_at: string | null }[]>(result.data)
+  }
+
   // Basic narrowing: message goes from `string | null` to `string`
   {
     const result = await postgrest.from('messages').select('id, message').not('message', 'is', null)


### PR DESCRIPTION
## TL;DR

Fixes a regression introduced in 
- #2264 which solved
-  https://github.com/supabase/supabase-js/issues/1360
 where `.not(column, 'is', null)` ig broke `let query` + reassignment patterns

## sol
preserved `this` in the `.not()` return type
(added a smol test aswell)

## ref:
- closes #2291
