### PR TITLE
docs(storage): clarify upsert has no effect on update

### DIFF
--- a/packages/core/storage-js/src/packages/StorageFileApi.ts
+++ b/packages/core/storage-js/src/packages/StorageFileApi.ts
@@ -406,7 +406,10 @@ export default class StorageFileApi extends BaseApiClient<StorageError> {
    * @category File Buckets
    * @param path The relative file path. Should be of the format `folder/subfolder/filename.png`. The bucket must already exist before attempting to update.
    * @param fileBody The body of the file to be stored in the bucket.
-   * @param fileOptions Optional file upload options including cacheControl, contentType, upsert, and metadata.
+   * @param fileOptions Optional file upload options including cacheControl, contentType, and metadata.
+   * **Note:** The `upsert` option has no effect here. `update()` always replaces the
+   * file at the given path, so the `x-upsert` header is not sent. To control upsert
+   * behavior, use `upload()` instead.
    * @returns Promise with response containing file path, id, and fullPath or error
    *
    * @example Update file
@@ -416,8 +419,7 @@ export default class StorageFileApi extends BaseApiClient<StorageError> {
    *   .storage
    *   .from('avatars')
    *   .update('public/avatar1.png', avatarFile, {
-   *     cacheControl: '3600',
-   *     upsert: true
+   *     cacheControl: '3600'
    *   })
    * ```
    *
@@ -448,6 +450,7 @@ export default class StorageFileApi extends BaseApiClient<StorageError> {
    * - RLS policy permissions required:
    *   - `buckets` table permissions: none
    *   - `objects` table permissions: `update` and `select`
+   * - `update()` always replaces the file at the given path regardless of the `upsert` option.
    * - Refer to the [Storage guide](/docs/guides/storage/security/access-control) on how access control works
    * - For React Native, using either `Blob`, `File` or `FormData` does not work as intended. Update file using `ArrayBuffer` from base64 file data instead, see example below.
    */


### PR DESCRIPTION
## Description

Clarifies in the JSDoc for `StorageFileApi.update()` that the `upsert` option has no effect, mirroring the precedent set by #1915 for `uploadToSignedUrl`.

### What changed?

In `packages/core/storage-js/src/packages/StorageFileApi.ts`:

- Removed `upsert` from the `@param fileOptions` description for `update()`.
- Added a `**Note:**` block explaining that `update()` always replaces the file at the given path, so `x-upsert` is not sent. Pointed users to `upload()` if they need to control upsert behavior.
- Removed `upsert: true` from the `@example Update file` snippet so the example no longer implies the option is meaningful.
- Added a bullet to the `@remarks` list reinforcing that `update()` always replaces the existing file regardless of `upsert`.

No runtime code, types, or behavior changed.

### Why was this change needed?

Issue #1669 reports that the `upsert` option appears to do nothing when calling `update()`. The investigation confirmed:

- The SDK only sets the `x-upsert` header on POST (`upload()`), not on PUT (`update()`), at `StorageFileApi.ts:92`.
- The storage server's PUT route (`storage/src/http/routes/object/updateObject.ts`) hardcodes `isUpsert: true` regardless of the header. So `update()` always replaces the file, which matches the documented behavior even though the option itself is inert.

The defect was therefore in the JSDoc, which advertised a no-op option and showed it in the canonical example. This change makes the documented surface match reality.

Closes #1669

### Why is `upsert` still on the type?

`update()` and `upload()` share the same public `FileOptions` type. The `upsert` field is meaningful for `upload()` (POST), where the SDK sends `x-upsert` and the server reads it. It is inert for `update()` (PUT) on both ends.

Two alternatives were considered and rejected:

1. Introduce a narrower `UpdateFileOptions = Omit<FileOptions, 'upsert'>` for `update()`. This would surface the no-op as a TypeScript error, but would break any caller currently passing `upsert` to `update()`, even though it does nothing today. That is a breaking change to a widely used public type for a docs-level confusion, which does not justify the cost.
2. Send `x-upsert` from `update()` for symmetry. The server PUT route ignores the header, so this would have no effect and would only mask the underlying contract.

Documenting the no-op follows the same pattern used in #1915 for `uploadToSignedUrl`, where the same shared type situation exists.

## Screenshots/Examples

N/A. JSDoc-only change.

## Breaking changes

- [x] This PR contains no breaking changes

## Checklist

- [x] I have read the Contributing Guidelines
- [x] My PR title follows the conventional commit format: `docs(storage): clarify upsert has no effect on update`
- [x] I have run `npx nx format` to ensure consistent code formatting
- [ ] I have added tests for new functionality (if applicable)
- [x] I have updated documentation (if applicable)

## Additional notes

N/A.