### PR TITLE
fix(postgrest): unify insert/upsert signatures

### DIFF
--- a/packages/core/postgrest-js/src/PostgrestQueryBuilder.ts
+++ b/packages/core/postgrest-js/src/PostgrestQueryBuilder.ts
@@ -936,42 +936,6 @@ export default class PostgrestQueryBuilder<
     })
   }
 
-  // TODO(v3): Make `defaultToNull` consistent for both single & bulk inserts.
-  insert<Row extends Relation extends { Insert: unknown } ? Relation['Insert'] : never>(
-    values: RejectExcessProperties<
-      Relation extends { Insert: unknown } ? Relation['Insert'] : never,
-      Row
-    >,
-    options?: {
-      count?: 'exact' | 'planned' | 'estimated' | (string & {})
-    }
-  ): PostgrestFilterBuilder<
-    ClientOptions,
-    Schema,
-    Relation['Row'],
-    null,
-    RelationName,
-    Relationships,
-    'POST'
-  >
-  insert<Row extends Relation extends { Insert: unknown } ? Relation['Insert'] : never>(
-    values: RejectExcessProperties<
-      Relation extends { Insert: unknown } ? Relation['Insert'] : never,
-      Row
-    >[],
-    options?: {
-      count?: 'exact' | 'planned' | 'estimated' | (string & {})
-      defaultToNull?: boolean
-    }
-  ): PostgrestFilterBuilder<
-    ClientOptions,
-    Schema,
-    Relation['Row'],
-    null,
-    RelationName,
-    Relationships,
-    'POST'
-  >
   /**
    * Perform an INSERT into the table or view.
    *
@@ -1139,46 +1103,6 @@ export default class PostgrestQueryBuilder<
     })
   }
 
-  // TODO(v3): Make `defaultToNull` consistent for both single & bulk upserts.
-  upsert<Row extends Relation extends { Insert: unknown } ? Relation['Insert'] : never>(
-    values: RejectExcessProperties<
-      Relation extends { Insert: unknown } ? Relation['Insert'] : never,
-      Row
-    >,
-    options?: {
-      onConflict?: string
-      ignoreDuplicates?: boolean
-      count?: 'exact' | 'planned' | 'estimated' | (string & {})
-    }
-  ): PostgrestFilterBuilder<
-    ClientOptions,
-    Schema,
-    Relation['Row'],
-    null,
-    RelationName,
-    Relationships,
-    'POST'
-  >
-  upsert<Row extends Relation extends { Insert: unknown } ? Relation['Insert'] : never>(
-    values: RejectExcessProperties<
-      Relation extends { Insert: unknown } ? Relation['Insert'] : never,
-      Row
-    >[],
-    options?: {
-      onConflict?: string
-      ignoreDuplicates?: boolean
-      count?: 'exact' | 'planned' | 'estimated' | (string & {})
-      defaultToNull?: boolean
-    }
-  ): PostgrestFilterBuilder<
-    ClientOptions,
-    Schema,
-    Relation['Row'],
-    null,
-    RelationName,
-    Relationships,
-    'POST'
-  >
   /**
    * Perform an UPSERT on the table or view. Depending on the column(s) passed
    * to `onConflict`, `.upsert()` allows you to perform the equivalent of

--- a/packages/core/postgrest-js/test/index.test-d.ts
+++ b/packages/core/postgrest-js/test/index.test-d.ts
@@ -175,7 +175,7 @@ const postgrestWithOptions = new PostgrestClient<DatabaseWithOptions>(REST_URL)
 
 // reject excess properties on insert, update, and upsert (#1636)
 {
-  // @ts-expect-error No overload matches this call.
+  // @ts-expect-error Type 'string' is not assignable to type 'never'.
   postgrest.from('users').insert({ username: 'foo', nonexistent: 'bad' })
 }
 {
@@ -183,7 +183,7 @@ const postgrestWithOptions = new PostgrestClient<DatabaseWithOptions>(REST_URL)
   postgrest.from('users').update({ username: 'foo', nonexistent: 'bad' })
 }
 {
-  // @ts-expect-error No overload matches this call.
+  // @ts-expect-error Type 'string' is not assignable to type 'never'.
   postgrest.from('users').upsert({ username: 'foo', nonexistent: 'bad' })
 }
 


### PR DESCRIPTION
The two public overloads on insert() and upsert() forced TypeScript into overload resolution, which produces "No overload matches this call" on type mismatches and highlights the entire call site. Collapsing them into the implementation's unified signature lets TS report property-level errors (e.g. "Type 'string' is not assignable to type 'never'") that point at the actual bad field.

No runtime change, the implementation already accepted `single | array`. `defaultToNull` on single-row insert/upsert is now a typed no-op, matching existing runtime behavior.                                                                                                                  
                                                                                                                                              
Closes #1652 