### PR TITLE
fix(auth): add toJSON to WebAuthnError for correct JSON serialization

### DIFF
--- a/packages/core/auth-js/src/lib/webauthn.errors.ts
+++ b/packages/core/auth-js/src/lib/webauthn.errors.ts
@@ -45,6 +45,18 @@ export class WebAuthnError extends Error {
     this.name = name ?? (cause instanceof Error ? cause.name : undefined) ?? 'Unknown Error'
     this.code = code
   }
+
+  toJSON(): {
+    name: string
+    message: string
+    code: WebAuthnErrorCode
+  } {
+    return {
+      name: this.name,
+      message: this.message,
+      code: this.code,
+    }
+  }
 }
 
 /**

--- a/packages/core/auth-js/test/webauthn.errors.test.ts
+++ b/packages/core/auth-js/test/webauthn.errors.test.ts
@@ -1,0 +1,48 @@
+import 'jest'
+
+import { WebAuthnError, WebAuthnUnknownError } from '../src/lib/webauthn.errors'
+
+describe('WebAuthnError serialization', () => {
+  test('WebAuthnError serializes message, name, and code with JSON.stringify', () => {
+    const err = new WebAuthnError({
+      message: 'Registration ceremony was sent an abort signal',
+      code: 'ERROR_CEREMONY_ABORTED',
+    })
+
+    const serialized = JSON.parse(JSON.stringify(err))
+
+    expect(serialized.message).toBe('Registration ceremony was sent an abort signal')
+    expect(serialized.code).toBe('ERROR_CEREMONY_ABORTED')
+    expect(serialized.name).toBe('Unknown Error')
+  })
+
+  test('WebAuthnError preserves explicit name when provided', () => {
+    const err = new WebAuthnError({
+      message: 'something went wrong',
+      code: 'ERROR_AUTHENTICATOR_GENERAL_ERROR',
+      name: 'CustomName',
+    })
+
+    const serialized = JSON.parse(JSON.stringify(err))
+
+    expect(serialized.name).toBe('CustomName')
+  })
+
+  test('WebAuthnUnknownError serializes message, name, and code with JSON.stringify', () => {
+    const err = new WebAuthnUnknownError('passkey failed', new Error('boom'))
+
+    const serialized = JSON.parse(JSON.stringify(err))
+
+    expect(serialized.message).toBe('passkey failed')
+    expect(serialized.name).toBe('WebAuthnUnknownError')
+    expect(serialized.code).toBe('ERROR_PASSTHROUGH_SEE_CAUSE_PROPERTY')
+  })
+
+  test('WebAuthnUnknownError does not leak originalError on serialization', () => {
+    const err = new WebAuthnUnknownError('passkey failed', new Error('boom'))
+
+    const serialized = JSON.parse(JSON.stringify(err))
+
+    expect(serialized.originalError).toBeUndefined()
+  })
+})


### PR DESCRIPTION
`WebAuthnError` and `WebAuthnUnknownError` extend `Error`, so `JSON.stringify` produces an object missing `message`, `name`, and `code` (those props are non-enumerable on `Error`). `AuthError`, `FunctionsError`, `StorageError`, and several other auth error subclasses already have `toJSON`; the WebAuthn classes added in #2283 missed it.

Adds a `toJSON` to `WebAuthnError` returning `{ name, message, code }`. `WebAuthnUnknownError` inherits the method, so its `originalError` is no longer surfaced in serialized form.

Tests in `test/webauthn.errors.test.ts` cover both classes and confirm the inherited path doesn't leak `originalError`.

Closes #2306