### PR TITLE
fix(auth): forward lockAcquireTimeout to SupabaseAuthClient

### DIFF
--- a/packages/core/supabase-js/src/SupabaseClient.ts
+++ b/packages/core/supabase-js/src/SupabaseClient.ts
@@ -556,6 +556,7 @@ export default class SupabaseClient<
       throwOnError,
       experimental,
       lockAcquireTimeout,
+      skipAutoInitialize,
     }: SupabaseAuthClientOptions,
     headers?: Record<string, string>,
     fetch?: Fetch
@@ -580,6 +581,7 @@ export default class SupabaseClient<
       experimental,
       fetch,
       lockAcquireTimeout,
+      skipAutoInitialize,
       // auth checks if there is a custom authorizaiton header using this flag
       // so it knows whether to return an error when getUser is called with no session
       hasCustomAuthorizationHeader: Object.keys(this.headers).some(

--- a/packages/core/supabase-js/src/SupabaseClient.ts
+++ b/packages/core/supabase-js/src/SupabaseClient.ts
@@ -555,6 +555,7 @@ export default class SupabaseClient<
       debug,
       throwOnError,
       experimental,
+      lockAcquireTimeout,
     }: SupabaseAuthClientOptions,
     headers?: Record<string, string>,
     fetch?: Fetch
@@ -578,6 +579,7 @@ export default class SupabaseClient<
       throwOnError,
       experimental,
       fetch,
+      lockAcquireTimeout,
       // auth checks if there is a custom authorizaiton header using this flag
       // so it knows whether to return an error when getUser is called with no session
       hasCustomAuthorizationHeader: Object.keys(this.headers).some(

--- a/packages/core/supabase-js/src/lib/types.ts
+++ b/packages/core/supabase-js/src/lib/types.ts
@@ -131,6 +131,22 @@ export type SupabaseClientOptions<SchemaName> = {
      * @experimental
      */
     experimental?: SupabaseAuthClientOptions['experimental']
+    /**
+     * Maximum time in milliseconds to wait when acquiring the auth lock before
+     * stealing it from the previous holder. See `GoTrueClientOptions.lockAcquireTimeout`
+     * for full semantics (zero fails immediately, negative waits indefinitely).
+     *
+     * @default 5000
+     */
+    lockAcquireTimeout?: SupabaseAuthClientOptions['lockAcquireTimeout']
+    /**
+     * If true, skips automatic initialization in the auth client constructor.
+     * Useful for SSR contexts where initialization timing must be controlled to
+     * prevent race conditions with HTTP response generation.
+     *
+     * @default false
+     */
+    skipAutoInitialize?: SupabaseAuthClientOptions['skipAutoInitialize']
   }
   /**
    * Options passed to the realtime-js instance

--- a/packages/core/supabase-js/test/unit/SupabaseAuthClient.test.ts
+++ b/packages/core/supabase-js/test/unit/SupabaseAuthClient.test.ts
@@ -1,3 +1,4 @@
+import { GoTrueClient } from '@supabase/auth-js'
 import { SupabaseAuthClient } from '../../src/lib/SupabaseAuthClient'
 import SupabaseClient from '../../src/SupabaseClient'
 import { DEFAULT_HEADERS } from '../../src/lib/constants'
@@ -55,4 +56,37 @@ test('createClient should accept auth.throwOnError and wire it to auth client', 
 test('createClient gates passkey methods when auth.experimental.passkey is not set', async () => {
   const supa = new SupabaseClient('https://example.supabase.com', 'supabaseKey')
   await expect(supa.auth.passkey.list()).rejects.toThrow(/experimental.*passkey/)
+})
+
+test('_initSupabaseAuthClient should pass through lockAcquireTimeout option', () => {
+  const client = new SupabaseClient('https://example.supabase.com', 'supabaseKey')
+  const authClient = client['_initSupabaseAuthClient'](
+    { ...authSettings, lockAcquireTimeout: 30_000 },
+    undefined,
+    undefined
+  )
+
+  expect((authClient as any).lockAcquireTimeout).toBe(30_000)
+})
+
+test('createClient should accept auth.lockAcquireTimeout and wire it to auth client', () => {
+  const supa = new SupabaseClient('https://example.supabase.com', 'supabaseKey', {
+    auth: { lockAcquireTimeout: 30_000 },
+  })
+  expect((supa.auth as any).lockAcquireTimeout).toBe(30_000)
+})
+
+test('createClient should accept auth.skipAutoInitialize and wire it to auth client', async () => {
+  const initializeSpy = jest.spyOn(GoTrueClient.prototype, 'initialize')
+  try {
+    const supa = new SupabaseClient('https://example.supabase.com', 'supabaseKey', {
+      auth: { skipAutoInitialize: true },
+    })
+    // Wait a tick to let any auto-initialization run
+    await new Promise((resolve) => setTimeout(resolve, 10))
+    expect(initializeSpy).not.toHaveBeenCalled()
+    expect(supa.auth).toBeInstanceOf(SupabaseAuthClient)
+  } finally {
+    initializeSpy.mockRestore()
+  }
 })


### PR DESCRIPTION
Fixes #2308

Forward `lockAcquireTimeout` in `_initSupabaseAuthClient` so it is not silently ignored and correctly reaches `SupabaseAuthClient`.