### PR TITLE
ci(repo): cancel superseded workflow runs via concurrency groups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,10 @@ on:
       - '**/.gitignore'
       - '**/.gitattributes'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ci-core:
     name: Core Packages CI

--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -20,6 +20,10 @@ on:
       - '!packages/core/**/.prettierrc'
       - '!packages/core/**/*ignore'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   preview:
     if: github.repository == 'supabase/supabase-js'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,10 @@ on:
         required: false
         type: string
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: ${{ github.event_name == 'push' }}
+
 env:
   NODE_VERSION: '22'
 


### PR DESCRIPTION
Add top-level `concurrency:` to ci.yml, preview-release.yml, and publish.yml so newer runs supersede older in-progress ones for the same ref. Prevents multiple release publishes when multiple commits land on master/develop in quick succession, and stops PR force-pushes from running CI / preview-release in parallel with the previous run.
                                                                                                                           
`publish.yml` keys its group on `event_name` and only enables `cancel-in-progress` for `push`, so manual stable/beta `workflow_dispatch` runs are never cancelled by concurrent pushes. 