### PR TITLE
feat(storage): support content encoding uploads

### DIFF
--- a/packages/core/storage-js/src/lib/types.ts
+++ b/packages/core/storage-js/src/lib/types.ts
@@ -153,6 +153,10 @@ export interface FileOptions {
    */
   contentType?: string
   /**
+   * The `Content-Encoding` header value. Useful when uploading already-compressed file bodies, for example `gzip`.
+   */
+  contentEncoding?: string
+  /**
    * When upsert is set to true, the file is overwritten if it exists. When set to false, an error is thrown if the object already exists. Defaults to false.
    */
   upsert?: boolean

--- a/packages/core/storage-js/src/packages/StorageFileApi.ts
+++ b/packages/core/storage-js/src/packages/StorageFileApi.ts
@@ -97,6 +97,9 @@ export default class StorageFileApi extends BaseApiClient<StorageError> {
       if (typeof Blob !== 'undefined' && fileBody instanceof Blob) {
         body = new FormData()
         body.append('cacheControl', options.cacheControl as string)
+        if (options.contentEncoding) {
+          body.append('contentEncoding', options.contentEncoding)
+        }
         if (metadata) {
           body.append('metadata', this.encodeMetadata(metadata))
         }
@@ -107,6 +110,9 @@ export default class StorageFileApi extends BaseApiClient<StorageError> {
         if (!body.has('cacheControl')) {
           body.append('cacheControl', options.cacheControl as string)
         }
+        if (options.contentEncoding && !body.has('contentEncoding')) {
+          body.append('contentEncoding', options.contentEncoding)
+        }
         if (metadata && !body.has('metadata')) {
           body.append('metadata', this.encodeMetadata(metadata))
         }
@@ -114,6 +120,9 @@ export default class StorageFileApi extends BaseApiClient<StorageError> {
         body = fileBody
         headers['cache-control'] = `max-age=${options.cacheControl}`
         headers['content-type'] = options.contentType as string
+        if (options.contentEncoding) {
+          headers['content-encoding'] = options.contentEncoding
+        }
 
         if (metadata) {
           headers['x-metadata'] = this.toBase64(this.encodeMetadata(metadata))
@@ -279,6 +288,9 @@ export default class StorageFileApi extends BaseApiClient<StorageError> {
       if (typeof Blob !== 'undefined' && fileBody instanceof Blob) {
         body = new FormData()
         body.append('cacheControl', options.cacheControl as string)
+        if (options.contentEncoding) {
+          body.append('contentEncoding', options.contentEncoding)
+        }
         if (metadata) {
           body.append('metadata', this.encodeMetadata(metadata))
         }
@@ -288,6 +300,9 @@ export default class StorageFileApi extends BaseApiClient<StorageError> {
         if (!body.has('cacheControl')) {
           body.append('cacheControl', options.cacheControl as string)
         }
+        if (options.contentEncoding && !body.has('contentEncoding')) {
+          body.append('contentEncoding', options.contentEncoding)
+        }
         if (metadata && !body.has('metadata')) {
           body.append('metadata', this.encodeMetadata(metadata))
         }
@@ -295,6 +310,9 @@ export default class StorageFileApi extends BaseApiClient<StorageError> {
         body = fileBody
         headers['cache-control'] = `max-age=${options.cacheControl}`
         headers['content-type'] = options.contentType as string
+        if (options.contentEncoding) {
+          headers['content-encoding'] = options.contentEncoding
+        }
         if (metadata) {
           headers['x-metadata'] = this.toBase64(this.encodeMetadata(metadata))
         }

--- a/packages/core/storage-js/test/storageFileApi.test.ts
+++ b/packages/core/storage-js/test/storageFileApi.test.ts
@@ -1188,6 +1188,28 @@ describe('StorageFileApi Edge Cases', () => {
       expect(new Headers(headers).get('content-type')).toBe('image/png')
     })
 
+    test('upload passes contentEncoding for raw bodies', async () => {
+      await storage.from('test-bucket').upload('test-path', 'test content', {
+        contentEncoding: 'gzip',
+      })
+
+      expect(mockPost).toHaveBeenCalled()
+      const [, , , { headers }] = mockPost.mock.calls[0]
+      expect(headers['content-encoding']).toBe('gzip')
+    })
+
+    test('upload passes contentEncoding in multipart bodies', async () => {
+      const testBlob = new Blob(['test content'], { type: 'text/plain' })
+
+      await storage.from('test-bucket').upload('test-path', testBlob, {
+        contentEncoding: 'gzip',
+      })
+
+      expect(mockPost).toHaveBeenCalled()
+      const [, , body] = mockPost.mock.calls[0]
+      expect((body as FormData).get('contentEncoding')).toBe('gzip')
+    })
+
     test('uploadToSignedUrl prefers file content type over existing content type header', async () => {
       const clientWithContentType = new StorageClient('http://localhost:8000/storage/v1', {
         apikey: 'test-token',
@@ -1206,6 +1228,32 @@ describe('StorageFileApi Edge Cases', () => {
       expect(headers['content-type']).toBe('image/png')
       expect(headers['Content-Type']).toBeUndefined()
       expect(new Headers(headers).get('content-type')).toBe('image/png')
+    })
+
+    test('uploadToSignedUrl passes contentEncoding for raw bodies', async () => {
+      await storage
+        .from('test-bucket')
+        .uploadToSignedUrl('test-path', 'test-token', 'test content', {
+          contentEncoding: 'gzip',
+        })
+
+      expect(mockPut).toHaveBeenCalled()
+      const [, , , { headers }] = mockPut.mock.calls[0]
+      expect(headers['content-encoding']).toBe('gzip')
+    })
+
+    test('uploadToSignedUrl passes contentEncoding in multipart bodies', async () => {
+      const testBlob = new Blob(['test content'], { type: 'text/plain' })
+
+      await storage
+        .from('test-bucket')
+        .uploadToSignedUrl('test-path', 'test-token', testBlob, {
+          contentEncoding: 'gzip',
+        })
+
+      expect(mockPut).toHaveBeenCalled()
+      const [, , body] = mockPut.mock.calls[0]
+      expect((body as FormData).get('contentEncoding')).toBe('gzip')
     })
 
     test('uploadToSignedUrl with metadata (Blob body)', async () => {


### PR DESCRIPTION
This pull request adds support for specifying `contentEncoding` values, such as `gzip`, when uploading files via the storage client. The change ensures that content encoding is passed through correctly during both standard uploads and signed URL uploads.

### What changed?

- Added a new optional `contentEncoding` field to the `FileOptions` interface.
- Updated `StorageFileApi` to pass `contentEncoding` through upload requests:
  - For raw file bodies, it sets the `content-encoding` header.
  - For multipart uploads, such as `Blob`, `File`, or `FormData`, it includes `contentEncoding` as a form field.
- Added tests covering `contentEncoding` behavior for both `upload()` and `uploadToSignedUrl()`.

### Why it changed

The storage client already supports related upload metadata such as `contentType` and `cacheControl`, but did not expose a first-class way to set `Content-Encoding`.

This is useful for pre-compressed assets, such as gzip-encoded files, where callers need the stored object to preserve the correct encoding metadata.

Closes #1883

### How to test

Run the focused storage test:

```bash
cd packages/core/storage-js
../../../node_modules/.bin/jest test/storageFileApi.test.ts --runInBand --testNamePattern contentEncoding --watchman=false
