### PR TITLE
ci(repo): remove pathback keyword from patchback commits

### DIFF
--- a/.github/workflows/patchback.yml
+++ b/.github/workflows/patchback.yml
@@ -61,7 +61,7 @@ jobs:
             gh pr create \
               --base master \
               --head "$BRANCH" \
-              --title "[patchback] ${PR_TITLE}" \
+              --title "${PR_TITLE}" \
               --body "$(cat <<EOF
           Cherry-pick of #${PR_NUMBER} to \`master\` for patch release.
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -211,7 +211,7 @@ flowchart TD
   B --> C["Cherry-pick merge commit"]
   C --> D{Conflict?}
   D -- No --> E["Push patchback/PR-NUMBER branch"]
-  E --> F["Open PR to master:<br/>[patchback] Original Title"]
+  E --> F["Open PR to master:<br/>Original Title (cherry-pick of #N)"]
   F --> G[Request review from original author]
   G --> H[Human reviews + merges]
   H --> I["Triggers canary on master"]


### PR DESCRIPTION
`[patchback]` keyword no longer needed. Cleanup.