### PR TITLE
fix(auth): narrow OAuth/CustomProvider types to fix downstream consumer typecheck

### DIFF
--- a/packages/core/auth-js/src/lib/types.ts
+++ b/packages/core/auth-js/src/lib/types.ts
@@ -2025,13 +2025,13 @@ export type OAuthClientResponseType = 'code'
  * OAuth client type indicating whether the client can keep credentials confidential.
  * Only relevant when the OAuth 2.1 server is enabled in Supabase Auth.
  */
-export type OAuthClientType = 'public' | 'confidential' | (string & {})
+export type OAuthClientType = 'public' | 'confidential'
 
 /**
  * OAuth client registration type.
  * Only relevant when the OAuth 2.1 server is enabled in Supabase Auth.
  */
-export type OAuthClientRegistrationType = 'dynamic' | 'manual' | (string & {})
+export type OAuthClientRegistrationType = 'dynamic' | 'manual'
 
 /**
  * OAuth client token endpoint authentication method.
@@ -2213,7 +2213,7 @@ export interface GoTrueAdminOAuthApi {
 /**
  * Type of custom identity provider.
  */
-export type CustomProviderType = 'oauth2' | 'oidc' | (string & {})
+export type CustomProviderType = 'oauth2' | 'oidc'
 
 /**
  * OIDC discovery document fields.


### PR DESCRIPTION
Partially reverts the `(string & {})` widening from #2300 for three OAuth/CustomProvider types: `OAuthClientType`, `OAuthClientRegistrationType`, and `CustomProviderType`. These are externally closed enums tied to the OAuth 2.1 server, and the widening leaked through consumer form schemas (e.g. Studio) into strict mutation contracts, breaking typecheck on assignments like `'public' | 'confidential' | (string & {})` to `'public' | 'confidential'`. The genuinely server-extensible types from that PR (`EmailOtpType`, `MobileOtpType`, `AuthFlowType`) remain widened.