### PR TITLE
fix(postgrest): restore non-Error abort detection in fetch catch

### DIFF
--- a/packages/core/postgrest-js/src/PostgrestBuilder.ts
+++ b/packages/core/postgrest-js/src/PostgrestBuilder.ts
@@ -322,13 +322,13 @@ export default abstract class PostgrestBuilder<
             ),
             signal: this.signal,
           })
-        } catch (fetchError) {
+          // JS allows throwing any value, and serverless or realm-crossing fetch
+          // implementations can reject with non-Error objects. `instanceof Error`
+          // is too narrow here; narrow at the use site with optional chaining.
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } catch (fetchError: any) {
           // Never retry aborted requests
-          if (
-            fetchError instanceof Error &&
-            (fetchError.name === 'AbortError' ||
-              ('code' in fetchError && (fetchError as { code?: string }).code === 'ABORT_ERR'))
-          ) {
+          if (fetchError?.name === 'AbortError' || fetchError?.code === 'ABORT_ERR') {
             throw fetchError
           }
 

--- a/packages/core/postgrest-js/test/retry.test.ts
+++ b/packages/core/postgrest-js/test/retry.test.ts
@@ -427,6 +427,31 @@ describe('Automatic Retries', () => {
       expect(result.error?.message).toContain('AbortError')
       expect(fetchMock).toHaveBeenCalledTimes(1) // No retries
     })
+
+    // Serverless / realm-crossing runtimes (Netlify Functions, AWS Lambda)
+    // can reject native fetch with values that do not pass `instanceof Error`
+    // against the consumer realm. The abort branch must still recognise them by
+    // their `name`/`code` shape.
+    it('should rethrow plain-object AbortError-shaped rejections without retrying', async () => {
+      fetchMock.mockRejectedValue({ name: 'AbortError', message: 'aborted' })
+
+      const client = new PostgrestClient('http://localhost:3000', { fetch: fetchMock })
+      const result = await runWithTimers(client.from('users').select())
+
+      expect(result.error).not.toBeNull()
+      expect(result.error?.message).toContain('AbortError')
+      expect(fetchMock).toHaveBeenCalledTimes(1) // No retries
+    })
+
+    it('should rethrow plain-object ABORT_ERR-coded rejections without retrying', async () => {
+      fetchMock.mockRejectedValue({ code: 'ABORT_ERR', message: 'aborted' })
+
+      const client = new PostgrestClient('http://localhost:3000', { fetch: fetchMock })
+      const result = await runWithTimers(client.from('users').select())
+
+      expect(result.error).not.toBeNull()
+      expect(fetchMock).toHaveBeenCalledTimes(1) // No retries
+    })
   })
 
   describe('shouldThrowOnError interaction', () => {


### PR DESCRIPTION
The 2.105.2 narrowing to `instanceof Error` skipped the abort branch when serverless or realm-crossing fetch implementations reject with non-Error values, sending GETs into the retry loop and surfacing as silent `data: null` from `.maybeSingle()` (#2327).

Revert this catch to the 2.105.1 pattern (`: any` + optional chaining). JS allows throwing any value, so the binding here cannot be narrower than `any`. Add regression tests for plain-object rejections.

Closes https://github.com/supabase/supabase-js/issues/2327
                                                                  