### PR TITLE
fix(realtime): guard sessionStorage access in restricted-storage browsers

### DIFF
--- a/packages/core/realtime-js/src/RealtimeClient.ts
+++ b/packages/core/realtime-js/src/RealtimeClient.ts
@@ -81,6 +81,48 @@ export type RealtimeClientOptions = {
   workerUrl?: string
   accessToken?: () => Promise<string | null>
   disconnectOnEmptyChannelsAfterMs?: number
+  /**
+   * Storage compatible object used by the underlying socket for longpoll fallback history.
+   * Provide a custom implementation in environments where reading `globalThis.sessionStorage`
+   * throws (sandboxed iframes, in-app webviews, "block third-party storage" privacy modes).
+   * Defaults to `globalThis.sessionStorage` when accessible, otherwise an in-memory store.
+   */
+  sessionStorage?: Storage
+}
+
+function createMemorySessionStorage(): Storage {
+  const store = new Map<string, string>()
+  return {
+    get length() {
+      return store.size
+    },
+    clear() {
+      store.clear()
+    },
+    getItem(key: string) {
+      return store.has(key) ? (store.get(key) as string) : null
+    },
+    key(index: number) {
+      return Array.from(store.keys())[index] ?? null
+    },
+    removeItem(key: string) {
+      store.delete(key)
+    },
+    setItem(key: string, value: string) {
+      store.set(key, String(value))
+    },
+  }
+}
+
+function resolveSessionStorage(): Storage {
+  try {
+    if (typeof globalThis !== 'undefined' && globalThis.sessionStorage) {
+      return globalThis.sessionStorage
+    }
+  } catch {
+    // Property access on `sessionStorage` itself throws in restricted-storage browsers.
+  }
+  return createMemorySessionStorage()
 }
 
 const WORKER_SCRIPT = `
@@ -764,6 +806,7 @@ export default class RealtimeClient {
     result.params = options?.params
     result.logger = options?.logger
     result.heartbeatCallback = this._wrapHeartbeatCallback(options?.heartbeatCallback)
+    result.sessionStorage = options?.sessionStorage ?? resolveSessionStorage()
     result.reconnectAfterMs =
       options?.reconnectAfterMs ??
       ((tries: number) => {

--- a/packages/core/realtime-js/test/RealtimeClient.lifecycle.test.ts
+++ b/packages/core/realtime-js/test/RealtimeClient.lifecycle.test.ts
@@ -84,6 +84,93 @@ describe('constructor', () => {
 
     cleanup()
   })
+
+  describe('sessionStorage handling', () => {
+    let originalDescriptor: PropertyDescriptor | undefined
+
+    function stubSessionStorageGetter(impl: () => Storage | undefined) {
+      originalDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'sessionStorage')
+      Object.defineProperty(globalThis, 'sessionStorage', {
+        configurable: true,
+        get: impl,
+      })
+    }
+
+    function restoreSessionStorage() {
+      if (originalDescriptor) {
+        Object.defineProperty(globalThis, 'sessionStorage', originalDescriptor)
+      } else {
+        delete (globalThis as any).sessionStorage
+      }
+      originalDescriptor = undefined
+    }
+
+    test('does not throw when sessionStorage getter throws SecurityError', () => {
+      stubSessionStorageGetter(() => {
+        throw new DOMException(
+          "Failed to read the 'sessionStorage' property from 'Window'",
+          'SecurityError'
+        )
+      })
+
+      try {
+        assert.doesNotThrow(() => {
+          const { cleanup } = setupRealtimeTest()
+          cleanup()
+        })
+      } finally {
+        restoreSessionStorage()
+      }
+    })
+
+    test('falls back to in-memory storage when sessionStorage getter throws', () => {
+      stubSessionStorageGetter(() => {
+        throw new DOMException('blocked', 'SecurityError')
+      })
+
+      try {
+        const { client, cleanup } = setupRealtimeTest()
+        const sessionStore = (client.socketAdapter as any).socket.sessionStore as Storage
+
+        assert.ok(sessionStore, 'expected a sessionStore on the underlying phoenix socket')
+        sessionStore.setItem('rt-key', 'rt-value')
+        assert.equal(sessionStore.getItem('rt-key'), 'rt-value')
+        sessionStore.removeItem('rt-key')
+        assert.equal(sessionStore.getItem('rt-key'), null)
+
+        cleanup()
+      } finally {
+        restoreSessionStorage()
+      }
+    })
+
+    test('honors a consumer-provided sessionStorage', () => {
+      const stub: Storage = {
+        length: 0,
+        clear: () => {},
+        getItem: () => null,
+        key: () => null,
+        removeItem: () => {},
+        setItem: () => {},
+      }
+
+      const { client, cleanup } = setupRealtimeTest({ sessionStorage: stub })
+      const sessionStore = (client.socketAdapter as any).socket.sessionStore as Storage
+
+      assert.strictEqual(sessionStore, stub)
+
+      cleanup()
+    })
+
+    test('uses the real sessionStorage when accessible', () => {
+      const { client, cleanup } = setupRealtimeTest()
+      const sessionStore = (client.socketAdapter as any).socket.sessionStore as Storage
+
+      assert.strictEqual(sessionStore, globalThis.sessionStorage)
+
+      cleanup()
+    })
+  })
 })
 
 describe('connect with WebSocket', () => {


### PR DESCRIPTION
## Summary

Fixes #2331.

`createClient` / `createBrowserClient` crashed synchronously with `SecurityError: Failed to read the 'sessionStorage' property from 'Window'` in restricted-storage browsers — sandboxed iframes without `allow-same-origin`, in-app webviews (Facebook Messenger, Instagram, Google Performance Max), and "block third-party storage" privacy modes. The bundled phoenix `Socket` constructor reads `global.sessionStorage` via a bare property access; the getter itself throws in those contexts before the `||` short-circuit can save us, taking the whole `SupabaseClient` instantiation down with it.

This change always forwards a truthy `Storage` to phoenix from `_initializeOptions`, so the bare read is short-circuited and never reached. The probe tries `globalThis.sessionStorage` first and falls back to an in-memory shim when the access throws or returns nullish (Worker / Node).

Also adds `sessionStorage?: Storage` to `RealtimeClientOptions`, mirroring the existing `auth.storage` injection pattern, so consumers can inject their own.