### PR TITLE
perf(postgrest): optimize select column normalization

### DIFF
--- a/packages/core/postgrest-js/src/PostgrestQueryBuilder.ts
+++ b/packages/core/postgrest-js/src/PostgrestQueryBuilder.ts
@@ -9,6 +9,33 @@ import {
 } from './types/common/common'
 import { RejectExcessProperties } from './types/types'
 
+const WHITESPACE_REGEX = /\s/
+
+function removeWhitespaceExceptQuoted(columns: string) {
+  let quoted = false
+  let cleanedColumns = ''
+  let lastKeptIndex = 0
+
+  for (let i = 0; i < columns.length; i++) {
+    const character = columns[i]
+
+    if (character === '"') {
+      quoted = !quoted
+    }
+
+    if (!quoted && WHITESPACE_REGEX.test(character)) {
+      cleanedColumns += columns.slice(lastKeptIndex, i)
+      lastKeptIndex = i + 1
+    }
+  }
+
+  if (lastKeptIndex === 0) {
+    return columns
+  }
+
+  return cleanedColumns + columns.slice(lastKeptIndex)
+}
+
 export default class PostgrestQueryBuilder<
   ClientOptions extends ClientServerOptions,
   Schema extends GenericSchema,
@@ -904,19 +931,7 @@ export default class PostgrestQueryBuilder<
 
     const method = head ? 'HEAD' : 'GET'
     // Remove whitespaces except when quoted
-    let quoted = false
-    const cleanedColumns = (columns ?? '*')
-      .split('')
-      .map((c) => {
-        if (/\s/.test(c) && !quoted) {
-          return ''
-        }
-        if (c === '"') {
-          quoted = !quoted
-        }
-        return c
-      })
-      .join('')
+    const cleanedColumns = removeWhitespaceExceptQuoted(columns ?? '*')
 
     const { url, headers } = this.cloneRequestState()
     url.searchParams.set('select', cleanedColumns)

--- a/packages/core/postgrest-js/test/query-builder.test.ts
+++ b/packages/core/postgrest-js/test/query-builder.test.ts
@@ -1,0 +1,20 @@
+import { PostgrestClient } from '../src/index'
+
+describe('PostgrestQueryBuilder', () => {
+  test('removes whitespace from select columns while preserving quoted identifiers', async () => {
+    const fetch = jest.fn().mockResolvedValue(
+      new Response('[]', {
+        headers: { 'Content-Type': 'application/json' },
+        status: 200,
+      })
+    )
+    const postgrest = new PostgrestClient('https://example.supabase.co/rest/v1', {
+      fetch: fetch as any,
+    })
+
+    await postgrest.from('users').select(' id,\n "column whitespace",\tname ')
+
+    const requestUrl = new URL(fetch.mock.calls[0][0])
+    expect(requestUrl.searchParams.get('select')).toBe('id,"column whitespace",name')
+  })
+})


### PR DESCRIPTION
## Summary

- Replaces `select()` column cleanup with a single-pass implementation that avoids `split`/`map`/`join` allocations.
- Preserves quoted identifier whitespace behavior and returns the original column string when no cleanup is needed.
- Adds a focused PostgREST query-builder test for whitespace removal and quoted identifiers.

## Performance

Local microbenchmark on Node v23.7.0, 1,000,000 iterations per case:

- `*`: 68.1ms -> 12.9ms, 5.27x faster
- `id,name,email,created_at`: 679.8ms -> 285.7ms, 2.38x faster
- formatted select with quoted identifier: 1324.9ms -> 486.1ms, 2.73x faster
- nested select: 2018.3ms -> 942.5ms, 2.14x faster

## Validation

- `npx jest test/query-builder.test.ts --runInBand`
- `npm run type-check --workspace=@supabase/postgrest-js`
- `npx prettier --check packages/core/postgrest-js/src/PostgrestQueryBuilder.ts packages/core/postgrest-js/test/query-builder.test.ts`

Note: full `npm run format:check --workspace=@supabase/postgrest-js` currently reports an unrelated existing formatting issue in `packages/core/postgrest-js/test/rpc.test.ts`.
