### PR TITLE
fix(postgrest): then typing

### DIFF
--- a/packages/core/postgrest-js/src/PostgrestBuilder.ts
+++ b/packages/core/postgrest-js/src/PostgrestBuilder.ts
@@ -154,9 +154,9 @@ export default abstract class PostgrestBuilder<
    *
    * @category Database
    */
-  throwOnError(): this & PostgrestBuilder<ClientOptions, Result, true> {
+  throwOnError(): Omit<this, 'then'> & PostgrestBuilder<ClientOptions, Result, true> {
     this.shouldThrowOnError = true
-    return this as this & PostgrestBuilder<ClientOptions, Result, true>
+    return this as Omit<this, 'then'> & PostgrestBuilder<ClientOptions, Result, true>
   }
 
   /**

--- a/packages/core/postgrest-js/src/PostgrestBuilder.ts
+++ b/packages/core/postgrest-js/src/PostgrestBuilder.ts
@@ -154,9 +154,9 @@ export default abstract class PostgrestBuilder<
    *
    * @category Database
    */
-  throwOnError(): this & PostgrestBuilder<ClientOptions, Result, true> {
+  throwOnError(): PostgrestBuilder<ClientOptions, Result, true> {
     this.shouldThrowOnError = true
-    return this as this & PostgrestBuilder<ClientOptions, Result, true>
+    return this as PostgrestBuilder<ClientOptions, Result, true>
   }
 
   /**
@@ -253,22 +253,6 @@ export default abstract class PostgrestBuilder<
     return this
   }
 
-  then<TResult1 = PostgrestResponseSuccess<Result>, TResult2 = never>(
-    this: PostgrestBuilder<ClientOptions, Result, true>,
-    onfulfilled?:
-      | ((value: PostgrestResponseSuccess<Result>) => TResult1 | PromiseLike<TResult1>)
-      | undefined
-      | null,
-    onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null
-  ): PromiseLike<TResult1 | TResult2>
-  then<TResult1 = PostgrestSingleResponse<Result>, TResult2 = never>(
-    this: PostgrestBuilder<ClientOptions, Result, false>,
-    onfulfilled?:
-      | ((value: PostgrestSingleResponse<Result>) => TResult1 | PromiseLike<TResult1>)
-      | undefined
-      | null,
-    onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null
-  ): PromiseLike<TResult1 | TResult2>
   then<
     TResult1 = ThrowOnError extends true
       ? PostgrestResponseSuccess<Result>
@@ -276,7 +260,11 @@ export default abstract class PostgrestBuilder<
     TResult2 = never,
   >(
     onfulfilled?:
-      | ((value: any) => TResult1 | PromiseLike<TResult1>)
+      | ((
+          value: ThrowOnError extends true
+            ? PostgrestResponseSuccess<Result>
+            : PostgrestSingleResponse<Result>
+        ) => TResult1 | PromiseLike<TResult1>)
       | undefined
       | null,
     onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null

--- a/packages/core/postgrest-js/src/PostgrestBuilder.ts
+++ b/packages/core/postgrest-js/src/PostgrestBuilder.ts
@@ -154,9 +154,9 @@ export default abstract class PostgrestBuilder<
    *
    * @category Database
    */
-  throwOnError(): Omit<this, 'then'> & PostgrestBuilder<ClientOptions, Result, true> {
+  throwOnError(): this & PostgrestBuilder<ClientOptions, Result, true> {
     this.shouldThrowOnError = true
-    return this as Omit<this, 'then'> & PostgrestBuilder<ClientOptions, Result, true>
+    return this as this & PostgrestBuilder<ClientOptions, Result, true>
   }
 
   /**
@@ -253,6 +253,22 @@ export default abstract class PostgrestBuilder<
     return this
   }
 
+  then<TResult1 = PostgrestResponseSuccess<Result>, TResult2 = never>(
+    this: PostgrestBuilder<ClientOptions, Result, true>,
+    onfulfilled?:
+      | ((value: PostgrestResponseSuccess<Result>) => TResult1 | PromiseLike<TResult1>)
+      | undefined
+      | null,
+    onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null
+  ): PromiseLike<TResult1 | TResult2>
+  then<TResult1 = PostgrestSingleResponse<Result>, TResult2 = never>(
+    this: PostgrestBuilder<ClientOptions, Result, false>,
+    onfulfilled?:
+      | ((value: PostgrestSingleResponse<Result>) => TResult1 | PromiseLike<TResult1>)
+      | undefined
+      | null,
+    onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null
+  ): PromiseLike<TResult1 | TResult2>
   then<
     TResult1 = ThrowOnError extends true
       ? PostgrestResponseSuccess<Result>
@@ -260,11 +276,7 @@ export default abstract class PostgrestBuilder<
     TResult2 = never,
   >(
     onfulfilled?:
-      | ((
-          value: ThrowOnError extends true
-            ? PostgrestResponseSuccess<Result>
-            : PostgrestSingleResponse<Result>
-        ) => TResult1 | PromiseLike<TResult1>)
+      | ((value: any) => TResult1 | PromiseLike<TResult1>)
       | undefined
       | null,
     onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null

--- a/packages/core/postgrest-js/src/PostgrestFilterBuilder.ts
+++ b/packages/core/postgrest-js/src/PostgrestFilterBuilder.ts
@@ -100,6 +100,7 @@ export default class PostgrestFilterBuilder<
   RelationName = unknown,
   Relationships = unknown,
   Method = unknown,
+  ThrowOnError extends boolean = false,
 > extends PostgrestTransformBuilder<
   ClientOptions,
   Schema,
@@ -107,8 +108,31 @@ export default class PostgrestFilterBuilder<
   Result,
   RelationName,
   Relationships,
-  Method
+  Method,
+  ThrowOnError
 > {
+  throwOnError(): PostgrestFilterBuilder<
+    ClientOptions,
+    Schema,
+    Row,
+    Result,
+    RelationName,
+    Relationships,
+    Method,
+    true
+  > {
+    return super.throwOnError() as PostgrestFilterBuilder<
+      ClientOptions,
+      Schema,
+      Row,
+      Result,
+      RelationName,
+      Relationships,
+      Method,
+      true
+    >
+  }
+
   /**
    * Match only rows where `column` is equal to `value`.
    *
@@ -1770,7 +1794,8 @@ export default class PostgrestFilterBuilder<
     NarrowResultColumn<Result, ColumnName>,
     RelationName,
     Relationships,
-    Method
+    Method,
+    ThrowOnError
   > &
     this
   not<ColumnName extends string & keyof Row>(
@@ -1842,7 +1867,16 @@ export default class PostgrestFilterBuilder<
     column: string,
     operator: string,
     value: unknown
-  ): PostgrestFilterBuilder<ClientOptions, Schema, any, any, RelationName, Relationships, Method> &
+  ): PostgrestFilterBuilder<
+    ClientOptions,
+    Schema,
+    any,
+    any,
+    RelationName,
+    Relationships,
+    Method,
+    ThrowOnError
+  > &
     this {
     this.url.searchParams.append(column, `not.${operator}.${value}`)
     return this as any

--- a/packages/core/postgrest-js/src/PostgrestTransformBuilder.ts
+++ b/packages/core/postgrest-js/src/PostgrestTransformBuilder.ts
@@ -13,7 +13,30 @@ export default class PostgrestTransformBuilder<
   RelationName = unknown,
   Relationships = unknown,
   Method = unknown,
-> extends PostgrestBuilder<ClientOptions, Result> {
+  ThrowOnError extends boolean = false,
+> extends PostgrestBuilder<ClientOptions, Result, ThrowOnError> {
+  throwOnError(): PostgrestTransformBuilder<
+    ClientOptions,
+    Schema,
+    Row,
+    Result,
+    RelationName,
+    Relationships,
+    Method,
+    true
+  > {
+    return super.throwOnError() as PostgrestTransformBuilder<
+      ClientOptions,
+      Schema,
+      Row,
+      Result,
+      RelationName,
+      Relationships,
+      Method,
+      true
+    >
+  }
+
   /**
    * Perform a SELECT on the query result.
    *
@@ -75,7 +98,8 @@ export default class PostgrestTransformBuilder<
       : NewResultOne[],
     RelationName,
     Relationships,
-    Method
+    Method,
+    ThrowOnError
   > {
     // Remove whitespaces except when quoted
     let quoted = false
@@ -104,7 +128,8 @@ export default class PostgrestTransformBuilder<
         : NewResultOne[],
       RelationName,
       Relationships,
-      Method
+      Method,
+      ThrowOnError
     >
   }
 
@@ -644,10 +669,11 @@ export default class PostgrestTransformBuilder<
    */
   single<ResultOne = Result extends (infer ResultOne)[] ? ResultOne : never>(): PostgrestBuilder<
     ClientOptions,
-    ResultOne
+    ResultOne,
+    ThrowOnError
   > {
     this.headers.set('Accept', 'application/vnd.pgrst.object+json')
-    return this as unknown as PostgrestBuilder<ClientOptions, ResultOne>
+    return this as unknown as PostgrestBuilder<ClientOptions, ResultOne, ThrowOnError>
   }
 
   /**
@@ -691,11 +717,11 @@ export default class PostgrestTransformBuilder<
    */
   maybeSingle<
     ResultOne = Result extends (infer ResultOne)[] ? ResultOne : never,
-  >(): PostgrestBuilder<ClientOptions, ResultOne | null> {
+  >(): PostgrestBuilder<ClientOptions, ResultOne | null, ThrowOnError> {
     // No Accept header override — we fetch as a list and enforce cardinality client-side.
     // Fixes https://github.com/supabase/postgrest-js/issues/361 for all request methods.
     this.isMaybeSingle = true
-    return this as unknown as PostgrestBuilder<ClientOptions, ResultOne | null>
+    return this as unknown as PostgrestBuilder<ClientOptions, ResultOne | null, ThrowOnError>
   }
 
   /**
@@ -737,9 +763,9 @@ export default class PostgrestTransformBuilder<
    * }
    * ```
    */
-  csv(): PostgrestBuilder<ClientOptions, string> {
+  csv(): PostgrestBuilder<ClientOptions, string, ThrowOnError> {
     this.headers.set('Accept', 'text/csv')
-    return this as unknown as PostgrestBuilder<ClientOptions, string>
+    return this as unknown as PostgrestBuilder<ClientOptions, string, ThrowOnError>
   }
 
   /**
@@ -747,9 +773,9 @@ export default class PostgrestTransformBuilder<
    *
    * @category Database
    */
-  geojson(): PostgrestBuilder<ClientOptions, Record<string, unknown>> {
+  geojson(): PostgrestBuilder<ClientOptions, Record<string, unknown>, ThrowOnError> {
     this.headers.set('Accept', 'application/geo+json')
-    return this as unknown as PostgrestBuilder<ClientOptions, Record<string, unknown>>
+    return this as unknown as PostgrestBuilder<ClientOptions, Record<string, unknown>, ThrowOnError>
   }
 
   /**
@@ -879,9 +905,13 @@ export default class PostgrestTransformBuilder<
       `application/vnd.pgrst.plan+${format}; for="${forMediatype}"; options=${options};`
     )
     if (format === 'json') {
-      return this as unknown as PostgrestBuilder<ClientOptions, Record<string, unknown>[]>
+      return this as unknown as PostgrestBuilder<
+        ClientOptions,
+        Record<string, unknown>[],
+        ThrowOnError
+      >
     } else {
-      return this as unknown as PostgrestBuilder<ClientOptions, string>
+      return this as unknown as PostgrestBuilder<ClientOptions, string, ThrowOnError>
     }
   }
 
@@ -943,7 +973,8 @@ export default class PostgrestTransformBuilder<
     CheckMatchingArrayTypes<Result, NewResult>,
     RelationName,
     Relationships,
-    Method
+    Method,
+    ThrowOnError
   > {
     return this as unknown as PostgrestTransformBuilder<
       ClientOptions,
@@ -952,7 +983,8 @@ export default class PostgrestTransformBuilder<
       CheckMatchingArrayTypes<Result, NewResult>,
       RelationName,
       Relationships,
-      Method
+      Method,
+      ThrowOnError
     >
   }
 

--- a/packages/core/postgrest-js/test/index.test-d.ts
+++ b/packages/core/postgrest-js/test/index.test-d.ts
@@ -299,6 +299,20 @@ const postgrestWithOptions = new PostgrestClient<DatabaseWithOptions>(REST_URL)
   error
 }
 
+{
+  postgrest
+    .from('messages')
+    .select('id')
+    .eq('id', 1)
+    .single()
+    .throwOnError()
+    .then(({ data, error }) => {
+      expectType<TypeEqual<typeof data, { id: number }>>(true)
+      expectType<TypeEqual<typeof error, null>>(true)
+      return data
+    })
+}
+
 // Json Accessor with custom types overrides
 {
   const result = await postgrest

--- a/packages/core/postgrest-js/test/index.test-d.ts
+++ b/packages/core/postgrest-js/test/index.test-d.ts
@@ -1,5 +1,6 @@
 import { expectType, TypeEqual } from './types'
 import { PostgrestClient, PostgrestError } from '../src/index'
+import type { PostgrestFilterBuilder } from '../src/index'
 import { Prettify } from '../src/types/types'
 import { Json } from '../src/select-query-parser/types'
 import { Database } from './types.override'
@@ -8,6 +9,28 @@ import { Database as DatabaseWithOptions } from './types.override-with-options-p
 const REST_URL = 'http://localhost:54321/rest/v1'
 const postgrest = new PostgrestClient<Database>(REST_URL)
 const postgrestWithOptions = new PostgrestClient<DatabaseWithOptions>(REST_URL)
+
+type WithThrowOnError<T> = T extends PostgrestFilterBuilder<
+  infer ClientOptions,
+  infer Schema,
+  infer Row,
+  infer Result,
+  infer RelationName,
+  infer Relationships,
+  infer Method,
+  boolean
+>
+  ? PostgrestFilterBuilder<
+      ClientOptions,
+      Schema,
+      Row,
+      Result,
+      RelationName,
+      Relationships,
+      Method,
+      true
+    >
+  : never
 
 // table and view name type safety
 {
@@ -234,6 +257,7 @@ const postgrestWithOptions = new PostgrestClient<DatabaseWithOptions>(REST_URL)
   const y = x.throwOnError()
   const z = x.setHeader('', '')
   const w = y.eq('id', 1)
+  expectType<TypeEqual<typeof y, WithThrowOnError<typeof x>>>(true)
   expectType<typeof w extends typeof y ? true : false>(true)
   expectType<typeof z extends typeof x ? true : false>(true)
 }
@@ -309,6 +333,47 @@ const postgrestWithOptions = new PostgrestClient<DatabaseWithOptions>(REST_URL)
     .throwOnError()
     .then(({ data, error }) => {
       expectType<TypeEqual<typeof data, { id: number }>>(true)
+      expectType<TypeEqual<typeof error, null>>(true)
+      return data
+    })
+}
+
+{
+  postgrest
+    .from('messages')
+    .select('id')
+    .eq('id', 1)
+    .maybeSingle()
+    .throwOnError()
+    .then(({ data, error }) => {
+      expectType<TypeEqual<typeof data, { id: number } | null>>(true)
+      expectType<TypeEqual<typeof error, null>>(true)
+      return data
+    })
+}
+
+{
+  postgrest
+    .from('messages')
+    .select('id')
+    .eq('id', 1)
+    .throwOnError()
+    .single()
+    .then(({ data, error }) => {
+      expectType<TypeEqual<typeof data, { id: number }>>(true)
+      expectType<TypeEqual<typeof error, null>>(true)
+      return data
+    })
+}
+
+{
+  postgrest
+    .from('messages')
+    .select('id')
+    .throwOnError()
+    .eq('id', 1)
+    .then(({ data, error }) => {
+      expectType<TypeEqual<typeof data, { id: number }[]>>(true)
       expectType<TypeEqual<typeof error, null>>(true)
       return data
     })

--- a/packages/core/postgrest-js/test/index.test-d.ts
+++ b/packages/core/postgrest-js/test/index.test-d.ts
@@ -233,7 +233,8 @@ const postgrestWithOptions = new PostgrestClient<DatabaseWithOptions>(REST_URL)
   const x = postgrest.from('channels').select()
   const y = x.throwOnError()
   const z = x.setHeader('', '')
-  expectType<typeof y extends typeof x ? true : false>(true)
+  const w = y.eq('id', 1)
+  expectType<typeof w extends typeof y ? true : false>(true)
   expectType<typeof z extends typeof x ? true : false>(true)
 }
 


### PR DESCRIPTION
## TL;DR

fixes throwOnError typing in `.then()` chains so success responses no longer stay nullable after `.throwOnError()`
also added a small test for it

## ref:

- closes https://github.com/supabase/supabase-js/issues/1642