### PR TITLE
docs(realtime): clean up REST broadcast channel example

### DIFF
--- a/packages/core/realtime-js/src/RealtimeChannel.ts
+++ b/packages/core/realtime-js/src/RealtimeChannel.ts
@@ -809,6 +809,8 @@ export default class RealtimeChannel {
    * @remarks
    * - When using REST you don't need to subscribe to the channel
    * - REST calls are only available from 2.37.0 onwards
+   * - If you create a channel only to send a REST broadcast, remove it from
+   *   the client when the send completes
    *
    * @example Send a message via websocket
    * ```js
@@ -832,9 +834,13 @@ export default class RealtimeChannel {
    *
    * @example Send a message via REST
    * ```js
-   * supabase
-   *   .channel('room1')
-   *   .httpSend('cursor-pos', { x: Math.random(), y: Math.random() })
+   * const channel = supabase.channel('room1')
+   *
+   * try {
+   *   await channel.httpSend('cursor-pos', { x: Math.random(), y: Math.random() })
+   * } finally {
+   *   await supabase.removeChannel(channel)
+   * }
    * ```
    */
   async send(


### PR DESCRIPTION
Fixes #1729.

Summary:
- update the REST broadcast example to keep the created channel in a variable
- call `supabase.removeChannel(channel)` in a `finally` block after `httpSend`
- add a remark that one-off REST broadcast channels should be removed after use

Verification:
- git diff --check HEAD~1..HEAD
- prettier not run locally because dependencies are not installed in this checkout