### PR TITLE
docs(postgrest): warn neq does not match null

### DIFF
--- a/packages/core/postgrest-js/src/PostgrestFilterBuilder.ts
+++ b/packages/core/postgrest-js/src/PostgrestFilterBuilder.ts
@@ -176,6 +176,9 @@ export default class PostgrestFilterBuilder<
   /**
    * Match only rows where `column` is not equal to `value`.
    *
+   * This filter does not include rows where `column` is `NULL`. To match null
+   * values, use `.is(column, null)` instead.
+   *
    * @param column - The column to filter on
    * @param value - The value to filter with
    *


### PR DESCRIPTION
Fixes supabase/postgrest-js#473.

Summary:
- add a TSDoc warning that `.neq()` does not match `NULL` rows
- point users to `.is(column, null)` when they need to match null values

Verification:
- git diff --check
- prettier not run locally because dependencies are not installed in this checkout