### PR TITLE
feat(supabase): update X-Client-Info to structured metadata format

### DIFF
--- a/packages/core/supabase-js/src/lib/constants.ts
+++ b/packages/core/supabase-js/src/lib/constants.ts
@@ -15,7 +15,7 @@ if (typeof Deno !== 'undefined') {
   JS_ENV = 'node'
 }
 
-export const DEFAULT_HEADERS = { 'X-Client-Info': `supabase-js-${JS_ENV}/${version}` }
+export const DEFAULT_HEADERS = { 'X-Client-Info': `supabase-js/${version}; env=${JS_ENV}` }
 
 export const DEFAULT_GLOBAL_OPTIONS = {
   headers: DEFAULT_HEADERS,

--- a/packages/core/supabase-js/src/lib/constants.ts
+++ b/packages/core/supabase-js/src/lib/constants.ts
@@ -4,18 +4,30 @@ import { SupabaseAuthClientOptions } from './types'
 import { version } from './version'
 
 let JS_ENV = ''
+let JS_RUNTIME_VERSION: string | undefined
 // @ts-ignore
 if (typeof Deno !== 'undefined') {
   JS_ENV = 'deno'
+  // @ts-ignore
+  JS_RUNTIME_VERSION = Deno.version?.deno
 } else if (typeof document !== 'undefined') {
   JS_ENV = 'web'
 } else if (typeof navigator !== 'undefined' && navigator.product === 'ReactNative') {
   JS_ENV = 'react-native'
 } else {
   JS_ENV = 'node'
+  JS_RUNTIME_VERSION =
+    typeof process !== 'undefined' ? process.version?.replace(/^v/, '') : undefined
 }
 
-export const DEFAULT_HEADERS = { 'X-Client-Info': `supabase-js/${version}; env=${JS_ENV}` }
+const _runtimeMeta = [`runtime=${JS_ENV}`]
+if (JS_RUNTIME_VERSION) {
+  _runtimeMeta.push(`runtime-version=${JS_RUNTIME_VERSION}`)
+}
+
+export const DEFAULT_HEADERS = {
+  'X-Client-Info': `supabase-js/${version}; ${_runtimeMeta.join('; ')}`,
+}
 
 export const DEFAULT_GLOBAL_OPTIONS = {
   headers: DEFAULT_HEADERS,

--- a/packages/core/supabase-js/test/unit/constants.test.ts
+++ b/packages/core/supabase-js/test/unit/constants.test.ts
@@ -33,7 +33,7 @@ describe('constants', () => {
 
   test('DEFAULT_HEADERS should contain X-Client-Info', () => {
     expect(DEFAULT_HEADERS).toHaveProperty('X-Client-Info')
-    expect(DEFAULT_HEADERS['X-Client-Info']).toMatch(/^supabase-js-.*\/.*$/)
+    expect(DEFAULT_HEADERS['X-Client-Info']).toMatch(/^supabase-js\/.*; env=.*$/)
   })
 
   test('DEFAULT_GLOBAL_OPTIONS should contain headers', () => {
@@ -69,7 +69,7 @@ describe('constants', () => {
       jest.resetModules()
       const { DEFAULT_HEADERS: newHeaders } = require('../../src/lib/constants')
 
-      expect(newHeaders['X-Client-Info']).toContain('supabase-js-deno')
+      expect(newHeaders['X-Client-Info']).toContain('env=deno')
     })
 
     test('should detect web environment', () => {
@@ -79,7 +79,7 @@ describe('constants', () => {
       jest.resetModules()
       const { DEFAULT_HEADERS: newHeaders } = require('../../src/lib/constants')
 
-      expect(newHeaders['X-Client-Info']).toContain('supabase-js-web')
+      expect(newHeaders['X-Client-Info']).toContain('env=web')
     })
 
     test('should detect React Native environment', () => {
@@ -89,7 +89,7 @@ describe('constants', () => {
       jest.resetModules()
       const { DEFAULT_HEADERS: newHeaders } = require('../../src/lib/constants')
 
-      expect(newHeaders['X-Client-Info']).toContain('supabase-js-react-native')
+      expect(newHeaders['X-Client-Info']).toContain('env=react-native')
     })
 
     test('should default to node environment when no specific environment is detected', () => {
@@ -99,7 +99,7 @@ describe('constants', () => {
       jest.resetModules()
       const { DEFAULT_HEADERS: newHeaders } = require('../../src/lib/constants')
 
-      expect(newHeaders['X-Client-Info']).toContain('supabase-js-node')
+      expect(newHeaders['X-Client-Info']).toContain('env=node')
     })
   })
 })

--- a/packages/core/supabase-js/test/unit/constants.test.ts
+++ b/packages/core/supabase-js/test/unit/constants.test.ts
@@ -33,7 +33,7 @@ describe('constants', () => {
 
   test('DEFAULT_HEADERS should contain X-Client-Info', () => {
     expect(DEFAULT_HEADERS).toHaveProperty('X-Client-Info')
-    expect(DEFAULT_HEADERS['X-Client-Info']).toMatch(/^supabase-js\/.*; env=.*$/)
+    expect(DEFAULT_HEADERS['X-Client-Info']).toMatch(/^supabase-js\/.*; runtime=.*$/)
   })
 
   test('DEFAULT_GLOBAL_OPTIONS should contain headers', () => {
@@ -63,13 +63,25 @@ describe('constants', () => {
 
   describe('JS_ENV detection', () => {
     test('should detect Deno environment', () => {
+      ;(global as any).Deno = { version: { deno: '1.37.0' } }
+
+      // Re-import to trigger the detection logic
+      jest.resetModules()
+      const { DEFAULT_HEADERS: newHeaders } = require('../../src/lib/constants')
+
+      expect(newHeaders['X-Client-Info']).toContain('runtime=deno')
+      expect(newHeaders['X-Client-Info']).toContain('runtime-version=1.37.0')
+    })
+
+    test('should detect Deno environment without version', () => {
       ;(global as any).Deno = {}
 
       // Re-import to trigger the detection logic
       jest.resetModules()
       const { DEFAULT_HEADERS: newHeaders } = require('../../src/lib/constants')
 
-      expect(newHeaders['X-Client-Info']).toContain('env=deno')
+      expect(newHeaders['X-Client-Info']).toContain('runtime=deno')
+      expect(newHeaders['X-Client-Info']).not.toContain('runtime-version=')
     })
 
     test('should detect web environment', () => {
@@ -79,7 +91,8 @@ describe('constants', () => {
       jest.resetModules()
       const { DEFAULT_HEADERS: newHeaders } = require('../../src/lib/constants')
 
-      expect(newHeaders['X-Client-Info']).toContain('env=web')
+      expect(newHeaders['X-Client-Info']).toContain('runtime=web')
+      expect(newHeaders['X-Client-Info']).not.toContain('runtime-version=')
     })
 
     test('should detect React Native environment', () => {
@@ -89,17 +102,19 @@ describe('constants', () => {
       jest.resetModules()
       const { DEFAULT_HEADERS: newHeaders } = require('../../src/lib/constants')
 
-      expect(newHeaders['X-Client-Info']).toContain('env=react-native')
+      expect(newHeaders['X-Client-Info']).toContain('runtime=react-native')
+      expect(newHeaders['X-Client-Info']).not.toContain('runtime-version=')
     })
 
-    test('should default to node environment when no specific environment is detected', () => {
-      // No globals set
+    test('should default to node environment with process version', () => {
+      // No globals set - falls through to node branch
 
       // Re-import to trigger the detection logic
       jest.resetModules()
       const { DEFAULT_HEADERS: newHeaders } = require('../../src/lib/constants')
 
-      expect(newHeaders['X-Client-Info']).toContain('env=node')
+      expect(newHeaders['X-Client-Info']).toContain('runtime=node')
+      expect(newHeaders['X-Client-Info']).toMatch(/runtime-version=\d+\.\d+\.\d+/)
     })
   })
 })


### PR DESCRIPTION
Moved from: https://github.com/supabase/supabase-js/pull/2293
Author: @grdsdev 

## Summary

Changes `X-Client-Info` header from embedding the JS environment in the library identifier (`supabase-js-node/2.105.0`) to a structured semicolon-delimited `key=value` format (`supabase-js/2.105.0; env=node`).

This aligns with the cross-library structured metadata initiative (SDK-902) and allows new metadata fields to be added freely without requiring CORS config changes in Edge Functions.

## Changes

- **`packages/core/supabase-js/src/lib/constants.ts`**: Changed `X-Client-Info` value from `supabase-js-${JS_ENV}/${version}` to `supabase-js/${version}; env=${JS_ENV}`
- **`packages/core/supabase-js/test/unit/constants.test.ts`**: Updated assertions to match new header format

## Before / After

| Before | After |
|--------|-------|
| `supabase-js-node/2.105.0` | `supabase-js/2.105.0; env=node` |
| `supabase-js-web/2.105.0` | `supabase-js/2.105.0; env=web` |
| `supabase-js-deno/2.105.0` | `supabase-js/2.105.0; env=deno` |
| `supabase-js-react-native/2.105.0` | `supabase-js/2.105.0; env=react-native` |

## Motivation

Adding new standalone HTTP headers is a breaking change for `supabase-js` users running inside Edge Functions — they must explicitly allow each header in their CORS config. Since `X-Client-Info` is already in everyone's CORS allowlist, using it as an extensible structured field lets us add new metadata (platform, runtime version, etc.) safely in the future.

## Testing

All 9 `constants.test.ts` unit tests pass. The other test-suite failures are pre-existing TypeScript issues in unrelated packages.

## Acceptance Criteria

- [x] `X-Client-Info` uses `key=value` structured format
- [x] JS environment info preserved via `env=` key
- [x] All existing constants tests pass
- [x] No breaking changes to the header value semantics

## Linear Issue

Closes: [SDK-903](https://linear.app/supabase/issue/SDK-903/update-js-x-client-info-structured-metadata)
Parent: [SDK-902](https://linear.app/supabase/issue/SDK-902/update-x-client-info-header-to-include-structured-metadata)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) `/take`