### PR TITLE
fix(storage): make StreamDownloadBuilder implement Promise and memoize executor

### DIFF
--- a/packages/core/storage-js/src/packages/StreamDownloadBuilder.ts
+++ b/packages/core/storage-js/src/packages/StreamDownloadBuilder.ts
@@ -1,7 +1,10 @@
 import { isStorageError } from '../lib/common/errors'
 import { DownloadResult } from '../lib/types'
 
-export default class StreamDownloadBuilder implements PromiseLike<DownloadResult<ReadableStream>> {
+export default class StreamDownloadBuilder implements Promise<DownloadResult<ReadableStream>> {
+  readonly [Symbol.toStringTag]: string = 'StreamDownloadBuilder'
+  private promise: Promise<DownloadResult<ReadableStream>> | null = null
+
   constructor(
     private downloadFn: () => Promise<Response>,
     private shouldThrowOnError: boolean
@@ -13,7 +16,24 @@ export default class StreamDownloadBuilder implements PromiseLike<DownloadResult
       | null,
     onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null
   ): Promise<TResult1 | TResult2> {
-    return this.execute().then(onfulfilled, onrejected)
+    return this.getPromise().then(onfulfilled, onrejected)
+  }
+
+  catch<TResult = never>(
+    onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | null
+  ): Promise<DownloadResult<ReadableStream> | TResult> {
+    return this.getPromise().catch(onrejected)
+  }
+
+  finally(onfinally?: (() => void) | null): Promise<DownloadResult<ReadableStream>> {
+    return this.getPromise().finally(onfinally)
+  }
+
+  private getPromise(): Promise<DownloadResult<ReadableStream>> {
+    if (!this.promise) {
+      this.promise = this.execute()
+    }
+    return this.promise
   }
 
   private async execute(): Promise<DownloadResult<ReadableStream>> {

--- a/packages/core/storage-js/test/downloadBuilders.test.ts
+++ b/packages/core/storage-js/test/downloadBuilders.test.ts
@@ -1,0 +1,78 @@
+import BlobDownloadBuilder from '../src/packages/BlobDownloadBuilder'
+import StreamDownloadBuilder from '../src/packages/StreamDownloadBuilder'
+import { StorageApiError } from '../src/lib/common/errors'
+
+const makeOkResponse = () =>
+  new Response('hello', { status: 200, headers: { 'content-type': 'text/plain' } })
+
+describe('StreamDownloadBuilder Promise interface', () => {
+  test('invokes downloadFn once across multiple awaits', async () => {
+    const downloadFn = jest.fn(async () => makeOkResponse())
+    const builder = new StreamDownloadBuilder(downloadFn, false)
+
+    const a = await builder
+    const b = await builder
+    const c = await builder
+
+    expect(downloadFn).toHaveBeenCalledTimes(1)
+    expect(a.error).toBeNull()
+    expect(b.error).toBeNull()
+    expect(c.error).toBeNull()
+  })
+
+  test('.catch() handles a rejected execute when shouldThrowOnError is true', async () => {
+    const downloadFn = jest.fn(async () => {
+      throw new StorageApiError('Object not found', 404, 'Not found')
+    })
+    const builder = new StreamDownloadBuilder(downloadFn, true)
+
+    const handler = jest.fn(() => 'caught')
+    const result = await builder.catch(handler)
+
+    expect(handler).toHaveBeenCalledTimes(1)
+    expect(result).toBe('caught')
+  })
+
+  test('.finally() runs after the underlying promise settles', async () => {
+    const downloadFn = jest.fn(async () => makeOkResponse())
+    const builder = new StreamDownloadBuilder(downloadFn, false)
+
+    const onFinally = jest.fn()
+    const result = await builder.finally(onFinally)
+
+    expect(onFinally).toHaveBeenCalledTimes(1)
+    expect(result.error).toBeNull()
+  })
+
+  test('[Symbol.toStringTag] returns "StreamDownloadBuilder"', () => {
+    const builder = new StreamDownloadBuilder(async () => makeOkResponse(), false)
+    expect(builder[Symbol.toStringTag]).toBe('StreamDownloadBuilder')
+    expect(Object.prototype.toString.call(builder)).toBe('[object StreamDownloadBuilder]')
+  })
+
+  test('is assignable to Promise<DownloadResult<ReadableStream>>', () => {
+    // Type-level check: the builder must satisfy Promise, not just PromiseLike.
+    // If this file compiles, the assertion holds. Mirrors BlobDownloadBuilder.
+    const builder = new StreamDownloadBuilder(async () => makeOkResponse(), false)
+    const asPromise: Promise<Awaited<typeof builder>> = builder
+    expect(asPromise).toBe(builder)
+  })
+})
+
+describe('BlobDownloadBuilder Promise interface (regression baseline)', () => {
+  test('invokes downloadFn once across multiple awaits', async () => {
+    const downloadFn = jest.fn(async () => makeOkResponse())
+    const builder = new BlobDownloadBuilder(downloadFn, false)
+
+    await builder
+    await builder
+    await builder
+
+    expect(downloadFn).toHaveBeenCalledTimes(1)
+  })
+
+  test('[Symbol.toStringTag] returns "BlobDownloadBuilder"', () => {
+    const builder = new BlobDownloadBuilder(async () => makeOkResponse(), false)
+    expect(builder[Symbol.toStringTag]).toBe('BlobDownloadBuilder')
+  })
+})


### PR DESCRIPTION
Closes #2366.

## Summary

`StreamDownloadBuilder` declared `PromiseLike` instead of `Promise`, so it lacked `catch`, `finally`, and `[Symbol.toStringTag]`. Its `then` also ran `execute()` on every call, which meant each `await` re-issued the underlying fetch.

This change rewrites the class to mirror the sibling `BlobDownloadBuilder`: it now implements `Promise<DownloadResult<ReadableStream>>`, caches the in-flight promise in a private `getPromise()`, and adds the missing `catch`, `finally`, and `Symbol.toStringTag` members. The constructor signature, exports, and `execute()` body are unchanged.

## Test plan

Added `test/downloadBuilders.test.ts` covering five behaviors on the stream builder (single executor call across multiple awaits, `.catch()`, `.finally()`, `Symbol.toStringTag`, `Promise` assignability), plus two regression checks on `BlobDownloadBuilder`. All seven pass.