### PR TITLE
chore(ci): correct detection of actor

### DIFF
--- a/.github/workflows/deprecate-version.yml
+++ b/.github/workflows/deprecate-version.yml
@@ -36,7 +36,7 @@ jobs:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const org = 'supabase'
-            const { actor } = context
+            const actor = process.env.GITHUB_TRIGGERING_ACTOR
 
             async function isTeamMember(team_slug) {
               try {

--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -66,7 +66,7 @@ jobs:
           github-token: ${{ steps.app-token-member-check.outputs.token }}
           script: |
             const org = 'supabase'
-            const { actor } = context
+            const actor = process.env.GITHUB_TRIGGERING_ACTOR
 
             async function isTeamMember(team_slug) {
               try {

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,7 +56,7 @@ jobs:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const org = 'supabase'
-            const actor = context.triggering_actor
+            const actor = process.env.GITHUB_TRIGGERING_ACTOR
 
             async function isTeamMember(team_slug) {
               try {
@@ -227,7 +227,7 @@ jobs:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const org = 'supabase'
-            const actor = context.triggering_actor
+            const actor = process.env.GITHUB_TRIGGERING_ACTOR
 
             async function isTeamMember(team_slug) {
               try {
@@ -338,7 +338,7 @@ jobs:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const org = 'supabase'
-            const actor = context.triggering_actor
+            const actor = process.env.GITHUB_TRIGGERING_ACTOR
 
             async function isTeamMember(team_slug) {
               try {


### PR DESCRIPTION
Team-membership checks in `publish.yml`, `dogfood.yml`, and `deprecate-version.yml` were resolving the actor incorrectly, causing every authorized dispatch to fail the gate. `context.triggering_actor` is not a property on `@actions/github`'s `Context`, and `context.actor` (= `GITHUB_ACTOR`) keeps the original dispatcher on re-runs, which lets a non-team user re-execute under prior authorization.

Switches all five team-check sites to `process.env.GITHUB_TRIGGERING_ACTOR`, which reflects who actually triggered (or re-triggered) the run. The bug surfaced after the `actions/github-script@v9` bump in #2363, whose stricter Octokit no longer masked the malformed `getMembershipForUserInOrg` URL produced by the undefined username.

docs ref: https://docs.github.com/en/actions/reference/workflows-and-actions/variables