### PR TITLE
fix(release): mark @supabase/tracing private and snapshot it for JSR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,7 @@ packages/**/supabase/.branches/*
 .claude/worktrees
 .nx/polygraph
 .nx/self-healing
+
+# Snapshot of internal workspace deps created at JSR publish time by
+# scripts/publish-to-jsr.ts. Generated and cleaned up per release run.
+packages/core/supabase-js/src/_internal/

--- a/packages/core/supabase-js/jsr.json
+++ b/packages/core/supabase-js/jsr.json
@@ -5,5 +5,11 @@
     ".": "./src/index.ts",
     "./cors": "./src/cors.ts"
   },
-  "exclude": ["examples"]
+  "imports": {
+    "@supabase/tracing": "./src/_internal/tracing/index.ts"
+  },
+  "exclude": ["examples"],
+  "publish": {
+    "exclude": ["!src/_internal"]
+  }
 }

--- a/packages/shared/tracing/package.json
+++ b/packages/shared/tracing/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@supabase/tracing",
   "version": "0.0.0-automated",
-  "description": "W3C/OpenTelemetry trace context propagation utilities for Supabase JS SDK",
+  "private": true,
+  "description": "Internal W3C/OpenTelemetry trace context propagation utilities for the Supabase JS SDK. Not published — bundled into @supabase/supabase-js.",
   "main": "dist/main/index.js",
   "module": "dist/module/index.js",
   "types": "dist/module/index.d.ts",

--- a/scripts/publish-to-jsr.ts
+++ b/scripts/publish-to-jsr.ts
@@ -1,9 +1,33 @@
 import { execSync } from 'child_process'
-import { readFileSync, writeFileSync, existsSync } from 'fs'
-import { join } from 'path'
+import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs'
+import { dirname, join } from 'path'
 
 // Only publishing packages with explicit return types to JSR
 const packages = ['functions-js', 'supabase-js']
+
+// supabase-js imports `@supabase/tracing` (an internal, unpublished workspace
+// package). JSR rejects unpinned npm specifiers, so before publishing
+// supabase-js we copy the tracing source into the package and rely on
+// jsr.json's `imports` map to redirect `@supabase/tracing` → `./src/_internal/tracing/index.ts`.
+// The snapshot is removed in the publish loop's finally block.
+const TRACING_INTERNAL_SUBPATH = 'src/_internal'
+const TRACING_SNAPSHOT_SOURCES: Record<string, string | undefined> = {
+  'supabase-js': join('packages', 'shared', 'tracing', 'src'),
+}
+
+function copyTracingSnapshot(packagePath: string, pkg: string): void {
+  const src = TRACING_SNAPSHOT_SOURCES[pkg]
+  if (!src) return
+  const absoluteSrc = join(process.cwd(), src)
+  const dest = join(packagePath, TRACING_INTERNAL_SUBPATH, 'tracing')
+  mkdirSync(dirname(dest), { recursive: true })
+  cpSync(absoluteSrc, dest, { recursive: true })
+}
+
+function cleanupTracingSnapshot(packagePath: string, pkg: string): void {
+  if (!TRACING_SNAPSHOT_SOURCES[pkg]) return
+  rmSync(join(packagePath, TRACING_INTERNAL_SUBPATH), { recursive: true, force: true })
+}
 
 function getArg(name: string): string | undefined {
   const idx = process.argv.findIndex((a) => a === `--${name}` || a.startsWith(`--${name}=`))
@@ -62,6 +86,10 @@ async function publishToJsr() {
     jsrConfig.version = version
     writeFileSync(jsrPath, JSON.stringify(jsrConfig, null, 2) + '\n')
 
+    // Snapshot any internal workspace deps that JSR would otherwise reject for
+    // missing version constraints. See TRACING_SNAPSHOT_SOURCES for details.
+    copyTracingSnapshot(packagePath, pkg)
+
     console.log(`\n📤 Publishing @supabase/${pkg}@${version} to JSR...`)
 
     try {
@@ -85,6 +113,8 @@ async function publishToJsr() {
     } finally {
       // Restore original jsr.json to keep working directory clean
       writeFileSync(jsrPath, originalJsrContent)
+      // Remove any internal snapshot copies created above
+      cleanupTracingSnapshot(packagePath, pkg)
     }
   }
 


### PR DESCRIPTION
`@supabase/tracing` is an internal workspace package that should never be published to npm or JSR. Two cascading failures showed up on trying to release: `nx release` tried to publish `tracing` and got a `404`, which aborted the task graph and prevented `supabase-js` itself from publishing; and JSR rejected `supabase-js` because the source imports `@supabase/tracing` with no resolvable version. This PR marks tracing as `"private": true` (the canonical Nx pattern for unpublished workspace packages) and adds a JSR imports map plus a publish-time source snapshot so supabase-js's JSR artifact is self-contained. No code, runtime, or bundle changes for consumers.