### PR TITLE
fix(auth): encode client-id in oauth requests

### DIFF
--- a/packages/core/auth-js/src/GoTrueAdminApi.ts
+++ b/packages/core/auth-js/src/GoTrueAdminApi.ts
@@ -65,6 +65,14 @@ export default class GoTrueAdminApi {
   protected headers: {
     [key: string]: string
   }
+
+  private _encodePathSegment(segment: string): string {
+    if (segment === '.' || segment === '..') {
+      throw new AuthError('Invalid path segment')
+    }
+
+    return encodeURIComponent(segment)
+  }
   protected fetch: Fetch
   protected experimental: ExperimentalFeatureFlags
 
@@ -982,12 +990,18 @@ export default class GoTrueAdminApi {
    */
   private async _getOAuthClient(clientId: string): Promise<OAuthClientResponse> {
     try {
-      return await _request(this.fetch, 'GET', `${this.url}/admin/oauth/clients/${clientId}`, {
-        headers: this.headers,
-        xform: (client: any) => {
-          return { data: client, error: null }
-        },
-      })
+      const encodedClientId = this._encodePathSegment(clientId)
+      return await _request(
+        this.fetch,
+        'GET',
+        `${this.url}/admin/oauth/clients/${encodedClientId}`,
+        {
+          headers: this.headers,
+          xform: (client: any) => {
+            return { data: client, error: null }
+          },
+        }
+      )
     } catch (error) {
       if (isAuthError(error)) {
         return { data: null, error }
@@ -1008,13 +1022,19 @@ export default class GoTrueAdminApi {
     params: UpdateOAuthClientParams
   ): Promise<OAuthClientResponse> {
     try {
-      return await _request(this.fetch, 'PUT', `${this.url}/admin/oauth/clients/${clientId}`, {
-        body: params,
-        headers: this.headers,
-        xform: (client: any) => {
-          return { data: client, error: null }
-        },
-      })
+      const encodedClientId = this._encodePathSegment(clientId)
+      return await _request(
+        this.fetch,
+        'PUT',
+        `${this.url}/admin/oauth/clients/${encodedClientId}`,
+        {
+          body: params,
+          headers: this.headers,
+          xform: (client: any) => {
+            return { data: client, error: null }
+          },
+        }
+      )
     } catch (error) {
       if (isAuthError(error)) {
         return { data: null, error }
@@ -1034,7 +1054,8 @@ export default class GoTrueAdminApi {
     clientId: string
   ): Promise<{ data: null; error: AuthError | null }> {
     try {
-      await _request(this.fetch, 'DELETE', `${this.url}/admin/oauth/clients/${clientId}`, {
+      const encodedClientId = this._encodePathSegment(clientId)
+      await _request(this.fetch, 'DELETE', `${this.url}/admin/oauth/clients/${encodedClientId}`, {
         headers: this.headers,
         noResolveJson: true,
       })
@@ -1056,10 +1077,11 @@ export default class GoTrueAdminApi {
    */
   private async _regenerateOAuthClientSecret(clientId: string): Promise<OAuthClientResponse> {
     try {
+      const encodedClientId = this._encodePathSegment(clientId)
       return await _request(
         this.fetch,
         'POST',
-        `${this.url}/admin/oauth/clients/${clientId}/regenerate_secret`,
+        `${this.url}/admin/oauth/clients/${encodedClientId}/regenerate_secret`,
         {
           headers: this.headers,
           xform: (client: any) => {
@@ -1141,12 +1163,18 @@ export default class GoTrueAdminApi {
    */
   private async _getCustomProvider(identifier: string): Promise<CustomProviderResponse> {
     try {
-      return await _request(this.fetch, 'GET', `${this.url}/admin/custom-providers/${identifier}`, {
-        headers: this.headers,
-        xform: (provider: any) => {
-          return { data: provider, error: null }
-        },
-      })
+      const encodedIdentifier = this._encodePathSegment(identifier)
+      return await _request(
+        this.fetch,
+        'GET',
+        `${this.url}/admin/custom-providers/${encodedIdentifier}`,
+        {
+          headers: this.headers,
+          xform: (provider: any) => {
+            return { data: provider, error: null }
+          },
+        }
+      )
     } catch (error) {
       if (isAuthError(error)) {
         return { data: null, error }
@@ -1170,13 +1198,19 @@ export default class GoTrueAdminApi {
     params: UpdateCustomProviderParams
   ): Promise<CustomProviderResponse> {
     try {
-      return await _request(this.fetch, 'PUT', `${this.url}/admin/custom-providers/${identifier}`, {
-        body: params,
-        headers: this.headers,
-        xform: (provider: any) => {
-          return { data: provider, error: null }
-        },
-      })
+      const encodedIdentifier = this._encodePathSegment(identifier)
+      return await _request(
+        this.fetch,
+        'PUT',
+        `${this.url}/admin/custom-providers/${encodedIdentifier}`,
+        {
+          body: params,
+          headers: this.headers,
+          xform: (provider: any) => {
+            return { data: provider, error: null }
+          },
+        }
+      )
     } catch (error) {
       if (isAuthError(error)) {
         return { data: null, error }
@@ -1194,10 +1228,16 @@ export default class GoTrueAdminApi {
     identifier: string
   ): Promise<{ data: null; error: AuthError | null }> {
     try {
-      await _request(this.fetch, 'DELETE', `${this.url}/admin/custom-providers/${identifier}`, {
-        headers: this.headers,
-        noResolveJson: true,
-      })
+      const encodedIdentifier = this._encodePathSegment(identifier)
+      await _request(
+        this.fetch,
+        'DELETE',
+        `${this.url}/admin/custom-providers/${encodedIdentifier}`,
+        {
+          headers: this.headers,
+          noResolveJson: true,
+        }
+      )
       return { data: null, error: null }
     } catch (error) {
       if (isAuthError(error)) {

--- a/packages/core/auth-js/test/GoTrueAdminApiPathValidation.test.ts
+++ b/packages/core/auth-js/test/GoTrueAdminApiPathValidation.test.ts
@@ -1,0 +1,84 @@
+import GoTrueAdminApi from '../src/GoTrueAdminApi'
+import { AuthError } from '../src/lib/errors'
+
+const URL = 'https://project.supabase.co/auth/v1'
+
+const jsonResponse = () =>
+  new Response(JSON.stringify({}), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  })
+
+describe('GoTrueAdminApi admin path validation', () => {
+  it.each([
+    [
+      'oauth.getClient',
+      (api: GoTrueAdminApi) => api.oauth.getClient('../../custom-providers/google'),
+      `${URL}/admin/oauth/clients/..%2F..%2Fcustom-providers%2Fgoogle`,
+    ],
+    [
+      'oauth.updateClient',
+      (api: GoTrueAdminApi) => api.oauth.updateClient('../../custom-providers/google', {} as any),
+      `${URL}/admin/oauth/clients/..%2F..%2Fcustom-providers%2Fgoogle`,
+    ],
+    [
+      'oauth.deleteClient',
+      (api: GoTrueAdminApi) => api.oauth.deleteClient('../../custom-providers/google'),
+      `${URL}/admin/oauth/clients/..%2F..%2Fcustom-providers%2Fgoogle`,
+    ],
+    [
+      'oauth.regenerateClientSecret',
+      (api: GoTrueAdminApi) => api.oauth.regenerateClientSecret('../../custom-providers/google'),
+      `${URL}/admin/oauth/clients/..%2F..%2Fcustom-providers%2Fgoogle/regenerate_secret`,
+    ],
+    [
+      'customProviders.getProvider',
+      (api: GoTrueAdminApi) => api.customProviders.getProvider('../../oauth/clients/client-id'),
+      `${URL}/admin/custom-providers/..%2F..%2Foauth%2Fclients%2Fclient-id`,
+    ],
+    [
+      'customProviders.updateProvider',
+      (api: GoTrueAdminApi) =>
+        api.customProviders.updateProvider('../../oauth/clients/client-id', {} as any),
+      `${URL}/admin/custom-providers/..%2F..%2Foauth%2Fclients%2Fclient-id`,
+    ],
+    [
+      'customProviders.deleteProvider',
+      (api: GoTrueAdminApi) => api.customProviders.deleteProvider('../../oauth/clients/client-id'),
+      `${URL}/admin/custom-providers/..%2F..%2Foauth%2Fclients%2Fclient-id`,
+    ],
+  ])('encodes path separators in %s identifiers before fetch', async (_name, run, expectedUrl) => {
+    const observed: string[] = []
+    const fakeFetch = jest.fn(async (input: RequestInfo | URL) => {
+      observed.push(new Request(String(input)).url)
+      return jsonResponse()
+    })
+    const api = new GoTrueAdminApi({
+      url: URL,
+      headers: { Authorization: 'Bearer service-role' },
+      fetch: fakeFetch as any,
+    })
+
+    await run(api)
+
+    expect(observed).toEqual([expectedUrl])
+  })
+
+  it.each([
+    ['oauth.getClient', (api: GoTrueAdminApi) => api.oauth.getClient('..')],
+    ['customProviders.getProvider', (api: GoTrueAdminApi) => api.customProviders.getProvider('..')],
+  ])('rejects raw dot segment identifiers in %s before fetch', async (_name, run) => {
+    const fakeFetch = jest.fn(async () => jsonResponse())
+    const api = new GoTrueAdminApi({
+      url: URL,
+      headers: { Authorization: 'Bearer service-role' },
+      fetch: fakeFetch as any,
+    })
+
+    const { error } = await run(api)
+
+    expect(error).toBeInstanceOf(AuthError)
+    expect(error?.message).toBe('Invalid path segment')
+    expect(fakeFetch).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION

## 🔍 Description

ensure client-id is encoded when passed to URL creation for oauth related requests


### What changed?

The client-id is url encoded before use in forming oauth requests

### Why was this change needed?

client-id can contain URL influencing characters that are not escaped. If this is passed in an admin context, where the SDK is treated as a security boundary, there can be unintended side effects.

## 🔄 Breaking changes

<!-- If this PR contains breaking changes, describe them here -->

- [x] This PR contains no breaking changes

## 📋 Checklist

<!-- Ensure all items are checked before submitting -->

- [x] I have read the [Contributing Guidelines](https://github.com/supabase/supabase-js/blob/master/CONTRIBUTING.md)
- [x] My PR title follows the [conventional commit format](https://www.conventionalcommits.org/): `<type>(<scope>): <description>`
- [x] I have run `pnpm nx format` to ensure consistent code formatting
- [x] I have added tests for new functionality (if applicable)
- [x] I have updated documentation (if applicable)

## 📝 Additional notes

<!-- Add any additional notes, context, or concerns for reviewers -->

<!-- Thank you for contributing to Supabase! 💚 -->
