### PR TITLE
ci(repo): gate npm publish and deprecate workflows behind environments

### DIFF
--- a/.github/workflows/deprecate-version.yml
+++ b/.github/workflows/deprecate-version.yml
@@ -18,6 +18,7 @@ env:
 jobs:
   deprecate:
     runs-on: ubuntu-latest
+    environment: npm-deprecate
     permissions:
       contents: read
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,6 +8,9 @@ jobs:
   docs:
     name: Generate and Publish Documentation
     runs-on: ubuntu-latest
+    environment: docs-publish
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,6 +36,7 @@ jobs:
   release-stable: # stable releases can only be manually triggered
     if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.version_specifier != '' }}
     runs-on: ubuntu-latest
+    environment: npm-publish
     outputs:
       released_version: ${{ steps.extract-version.outputs.version }}
     permissions:
@@ -208,6 +209,7 @@ jobs:
   release-beta:
     if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.beta_version != '' }}
     runs-on: ubuntu-latest
+    environment: npm-publish
     permissions:
       contents: read
       id-token: write
@@ -319,6 +321,7 @@ jobs:
     # v3 next prerelease — manual dispatch only, must be run from the v3 branch.
     if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.next_prerelease == 'true' && github.ref == 'refs/heads/v3' }}
     runs-on: ubuntu-latest
+    environment: npm-publish
     permissions:
       contents: read
       id-token: write
@@ -446,6 +449,7 @@ jobs:
   release-canary:
     name: Release Prerelease
     runs-on: ubuntu-latest
+    environment: npm-publish
     needs: [ci-core, ci-supabase-js]
     permissions:
       contents: read


### PR DESCRIPTION
Add `environment: npm-publish` to all four publish jobs (release-stable, release-beta, release-next, release-canary) and `environment: npm-deprecate` to the deprecate job. Every npm-touching workflow now requires manual approval from a second reviewer before running.

Hardens against the supply-chain pattern where a single stolen maintainer credential can trigger an automated publish 