### PR TITLE
fix(auth): restore signup user response

### DIFF
--- a/packages/core/auth-js/src/lib/fetch.ts
+++ b/packages/core/auth-js/src/lib/fetch.ts
@@ -255,7 +255,7 @@ export function _sessionResponse(data: GoTrueSessionData): AuthResponse {
 
   // Some /verify responses (e.g. secure email_change first-confirmation) return
   // only `{ msg, code }` with no user and no session. Treat those as null user.
-  const user: User | null = data.user ?? null
+  const user: User | null = data.user ?? (typeof data?.id === 'string' ? (data as User) : null)
   return { data: { session, user }, error: null }
 }
 

--- a/packages/core/auth-js/test/GoTrueClient.test.ts
+++ b/packages/core/auth-js/test/GoTrueClient.test.ts
@@ -567,6 +567,38 @@ describe('GoTrueClient', () => {
       expect(data?.user?.user_metadata).toMatchObject(TEST_USER_DATA)
     })
 
+    test('signUp() returns the bare user payload when signup requires confirmation', async () => {
+      const user = {
+        id: 'user-id',
+        aud: 'authenticated',
+        role: 'authenticated',
+        email: 'user@example.com',
+        created_at: '2026-05-21T12:00:00.000Z',
+      }
+      const mockFetch = jest.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        json: () => Promise.resolve(user),
+      })
+      const client = new GoTrueClient({
+        url: GOTRUE_URL_SIGNUP_ENABLED_AUTO_CONFIRM_ON,
+        autoRefreshToken: false,
+        persistSession: false,
+        storage: memoryLocalStorageAdapter(),
+        fetch: mockFetch as unknown as typeof fetch,
+      })
+
+      const { data, error } = await client.signUp({
+        email: user.email,
+        password: 'password123',
+      })
+
+      expect(error).toBeNull()
+      expect(data.session).toBeNull()
+      expect(data.user).toEqual(user)
+    })
+
     test('fail to signUp() with invalid password', async () => {
       const { error, data } = await auth.signUp({ email: 'asd@a.aa', password: '123' })
 


### PR DESCRIPTION
## TL;DR 

fixes a regression where `signUp()` could drop a valid user response

## Prob

before this, `_sessionResponse()` used `data.user ?? (data as User)`

- #2378 changed that to `data.user ?? null` to fix the `verifyOtp({ type: 'email_change' })` case where gotrue can return `{ code, msg }` with no user or session.

that fixed `email_change`, but it also broke `signUp()` when gotrue returned a valid bare top-level user object, causing the sdk to return `data.user: null`

## Sol:

 what i did was keep the `email_change` behavior from #2378, while restoring the fallback only when the top-level payload actually looks like a user object


## ref

- closes https://github.com/supabase/supabase-js/issues/2390
- extends #2378
 which fixed: https://github.com/supabase/supabase-js/issues/2377