### PR TITLE
fix(misc): add react-native export condition for Hermes-safe resolution

### DIFF
--- a/packages/core/supabase-js/package.json
+++ b/packages/core/supabase-js/package.json
@@ -20,6 +20,10 @@
   "types": "dist/index.d.cts",
   "exports": {
     ".": {
+      "react-native": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      },
       "import": {
         "types": "./dist/index.d.mts",
         "default": "./dist/index.mjs"
@@ -30,6 +34,10 @@
       }
     },
     "./cors": {
+      "react-native": {
+        "types": "./dist/cors.d.cts",
+        "default": "./dist/cors.cjs"
+      },
       "import": {
         "types": "./dist/cors.d.mts",
         "default": "./dist/cors.mjs"

--- a/packages/core/supabase-js/test/bundle-hermes-compat.test.cjs
+++ b/packages/core/supabase-js/test/bundle-hermes-compat.test.cjs
@@ -28,6 +28,13 @@
  *    plugin in tsdown.config.ts — source-side magic comments don't survive
  *    rolldown's printer.
  *
+ * 4. `package.json` `exports` has a `"react-native"` condition for both `.`
+ *    and `./cors`, resolving to the Hermes-safe CJS bundle. Metro (React
+ *    Native's bundler) checks `"react-native"` before `"import"`/`"require"`
+ *    by default. Without this condition, Metro with `unstable_enablePackageExports`
+ *    enabled (the default on Expo SDK 55+) resolves the ESM bundle and ships
+ *    its `import()` to hermesc, which fails at parse time. See issue #2380.
+ *
  * Run with: node test/bundle-hermes-compat.test.cjs
  */
 
@@ -87,5 +94,40 @@ console.log('   /* webpackIgnore: true */ /* turbopackIgnore: true */ /* @vite-i
 console.log(
   '   Each bundler (webpack / turbopack / vite) sees its directive in a single-purpose block\n'
 )
+
+// Check 4: package.json `exports` has a `"react-native"` condition that
+// resolves to the Hermes-safe CJS bundle. Without this, Metro on Expo SDK 55+
+// (with unstable_enablePackageExports enabled by default) resolves the ESM
+// bundle and ships its `import()` to hermesc, which fails at parse time.
+const pkg = require('../package.json')
+for (const entry of ['.', './cors']) {
+  const conds = pkg.exports[entry]
+  assert.ok(
+    conds && typeof conds === 'object',
+    `package.json exports["${entry}"] must be a conditions object`
+  )
+  assert.ok(
+    conds['react-native'],
+    `package.json exports["${entry}"] is missing the "react-native" condition — ` +
+      `Metro resolves the ESM bundle by default, which contains import() and breaks hermesc. See issue #2380.`
+  )
+  const rnKeys = Object.keys(conds)
+  const rnIdx = rnKeys.indexOf('react-native')
+  const importIdx = rnKeys.indexOf('import')
+  const requireIdx = rnKeys.indexOf('require')
+  assert.ok(
+    rnIdx < importIdx && rnIdx < requireIdx,
+    `package.json exports["${entry}"]: "react-native" must appear before "import" and "require" — ` +
+      `Node-style conditional exports resolve in key order.`
+  )
+  const rnTarget = conds['react-native'].default || conds['react-native']
+  assert.ok(
+    typeof rnTarget === 'string' && rnTarget.endsWith('.cjs'),
+    `package.json exports["${entry}"]["react-native"] must resolve to a .cjs file (Hermes-safe). ` +
+      `Got: ${JSON.stringify(rnTarget)}`
+  )
+}
+console.log('4. package.json exports has "react-native" condition for "." and "./cors"')
+console.log('   Metro resolves dist/*.cjs (Hermes-safe) instead of dist/*.mjs\n')
 
 console.log('All bundle compatibility checks passed.')

--- a/packages/core/supabase-js/tsdown.config.ts
+++ b/packages/core/supabase-js/tsdown.config.ts
@@ -69,8 +69,10 @@ export default defineConfig([
         // bundle to tsc's CJS output (dist/main/index.js), where the
         // dynamic `import()` has been lowered to a runtime `require()`.
         // dist/index.mjs intentionally keeps the native `import()` — it's
-        // valid ESM, isn't blocked by browser CSP, and Hermes never sees
-        // the ESM bundle (Metro pulls the `require` condition).
+        // valid ESM and isn't blocked by browser CSP. React Native bundlers
+        // (Metro) avoid the ESM bundle via the `react-native` export
+        // condition in supabase-js's package.json, which points to
+        // dist/index.cjs (Hermes-safe). See issue #2380.
         return {
           resolve: {
             alias: {


### PR DESCRIPTION
## Problem

`v2.106.1` (#2381) fixed the CJS bundle so it no longer contains `import('@opentelemetry/api')` — hermesc-safe. However, **Metro on Expo SDK 55+ never resolves the CJS bundle**: with `unstable_enablePackageExports` enabled by default (Metro 0.82+), the `"import"` condition wins over `"require"`, so Metro picks `dist/index.mjs`, which still contains the dynamic `import()`. Hermes rejects it at parse time:

```
error: Invalid expression encountered
...if(otelModulePromise===null)otelModulePromise=import(...)
                                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Every React Native release build on `2.106.0`/`2.106.1` fails on Expo SDK 55. Reproducible with `expo export:embed --platform android && hermesc <bundle>` — both `expo` and `hermesc` are pre-bundled with Expo SDK 55.

This is a different code path from the one #2381 addressed (Metro consuming the CJS bundle). Reports in #2380 from users still on `2.106.1` confirm Expo SDK 55 still fails.

Refs #2380.

## Fix

Add a `"react-native"` condition to `exports["."]` and `exports["./cors"]`, placed **before** `"import"` and `"require"`, pointing to the existing Hermes-safe `dist/*.cjs` bundles. Metro recognizes the `react-native` condition by default (Metro's `resolverMainFields` and `unstable_conditionNames`).

```diff
 "exports": {
   ".": {
+    "react-native": {
+      "types": "./dist/index.d.cts",
+      "default": "./dist/index.cjs"
+    },
     "import": {
       "types": "./dist/index.d.mts",
       "default": "./dist/index.mjs"
     },
     "require": {
       "types": "./dist/index.d.cts",
       "default": "./dist/index.cjs"
     }
   },
```

Effect by consumer:

| Consumer | Before | After |
| --- | --- | --- |
| Vite / webpack / Turbopack / Next.js | `import` → `dist/index.mjs` | unchanged |
| Node ESM | `import` → `dist/index.mjs` | unchanged |
| Node CJS / Bun / Deno | `require` → `dist/index.cjs` | unchanged |
| **Metro (React Native)** | `import` → `dist/index.mjs` (broken) | `react-native` → `dist/index.cjs` ✅ |

The fix does not change the build pipeline, doesn't touch `@supabase/tracing`, and doesn't introduce new code paths. It's a pure exports-map change: Metro picks the bundle that PR #2381 already made Hermes-safe.

## Verification

Reproduced and verified locally on the original failing build (`expo export:embed` + bundled `hermesc` from React Native 0.83.6, Expo SDK 55.0.26):

1. **Baseline (`2.106.1`, unchanged):** `hermesc` exits 2, `Invalid expression encountered` at the `import(OTEL_PKG)` call in `dist/index.mjs` (Metro resolved the ESM bundle).
2. **With this patch applied to `2.106.1`'s `package.json` only (no rebuild):**
   - Metro now resolves `dist/index.cjs`.
   - Bundle contains zero `import(` occurrences.
   - `hermesc` exits 0; output `.hbc` (11M) is valid.

Test artifacts available on request — happy to attach the bundle/log.

## Regression test

Extends `test/bundle-hermes-compat.test.cjs` with a 4th check on `package.json` itself:

- Both `exports["."]` and `exports["./cors"]` define a `"react-native"` condition.
- `"react-native"` appears **before** `"import"` and `"require"` (Node-style conditional exports resolve in declaration order — placement matters when bundlers also match later conditions).
- `"react-native"` resolves to a `.cjs` target (Hermes-safe by construction).

This catches future regressions where someone reorders the conditions or accidentally points `react-native` at the ESM bundle. Wired into the existing `module-resolution` CI job through `npm run test:hermes-compat`.

## Why this approach over alternatives

- **Alternative A: separate `/tracing` entrypoint.** Cleanest architecturally but requires an opt-in API change for OTel users — breaking change for `2.106.x` consumers who already wired up tracing.
- **Alternative B: rewrite `loadOtel()` to `eval('import(...)')` or similar.** Sidesteps hermesc but trips browser strict CSP (`unsafe-eval`).
- **Alternative C (this PR): `react-native` export condition.** Zero source code changes, zero consumer-facing changes, leverages the Hermes-safe CJS bundle that #2381 already produces. Metro `unstable_enablePackageExports` was added specifically to support this kind of platform-specific resolution.