### PR TITLE
docs(repo): ship per-package AGENTS.md and migrations via npm

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -7,7 +7,7 @@ You are assisting with development in a unified Nx monorepo that consolidates al
 > - **[CONTRIBUTING.md](../CONTRIBUTING.md)** - Development guidelines, commit format, PR process
 > - **[TESTING.md](../docs/TESTING.md)** - Complete testing guide with Docker requirements
 > - **[RELEASE.md](../docs/RELEASE.md)** - Release workflows and versioning strategy
-> - **[MIGRATION.md](../docs/MIGRATION.md)** - Migration context from old repositories
+> - **[MIGRATION.md](../docs/MIGRATION.md)** - Cross-cutting migration notes (one H2 per theme). Per-package migrations live at `packages/core/<package>/migrations/`.
 > - **[SECURITY.md](../docs/SECURITY.md)** - Security policies and responsible disclosure
 
 ## Repository Architecture
@@ -745,7 +745,7 @@ nx test supabase-js --testFile=client.test.ts
 - **[CONTRIBUTING.md](../CONTRIBUTING.md)** - Complete contribution guide
 - **[TESTING.md](../docs/TESTING.md)** - Comprehensive testing documentation
 - **[RELEASE.md](../docs/RELEASE.md)** - Release workflows and automation
-- **[MIGRATION.md](../docs/MIGRATION.md)** - Migration context and history
+- **[MIGRATION.md](../docs/MIGRATION.md)** - Cross-cutting migration notes; per-package migrations live at `packages/core/<package>/migrations/`
 - **[SECURITY.md](../docs/SECURITY.md)** - Security policy and reporting
 - **[Supabase Documentation](https://supabase.com/docs)** - Official Supabase docs
 - **[Nx Documentation](https://nx.dev)** - Nx monorepo documentation

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,46 @@
+# Agent instructions
+
+Entry point for AI/LLM agents working in or with this repository. Pointers below; nothing canonical lives in this file.
+
+## Repository overview
+
+- [`README.md`](./README.md) — what this repo is, package list, quick start
+- [`CONTRIBUTING.md`](./CONTRIBUTING.md) — contribution guidelines, commit format, PR process
+- [`.claude/CLAUDE.md`](./.claude/CLAUDE.md) — development conventions, Nx commands, testing matrix, library-specific notes (read by Claude Code; the canonical development-conventions doc)
+- [`.cursor/.cursorrules`](./.cursor/.cursorrules) — same conventions for Cursor (read by Cursor IDE)
+
+## Agent skills
+
+Reusable agent skills for working in this Nx workspace (Nx-related: `nx-workspace`, `nx-generate`, `nx-import`, `nx-plugins`, `nx-run-tasks`, `link-workspace-packages`) live at:
+
+- [`.agents/skills/`](./.agents/skills/) — vendor-neutral location (Agent Skills spec)
+- [`.claude/skills/`](./.claude/skills/) — mirrored copy read by Claude Code by literal path
+
+Both directories currently hold the same content. Treat `.agents/skills/` as the source of truth; the `.claude/skills/` copy is kept in sync until Claude Code can discover skills from `.agents/skills/` directly.
+
+## Per-package usage
+
+Each package has its own README with usage examples and API notes:
+
+- [`packages/core/supabase-js/README.md`](./packages/core/supabase-js/README.md) — `@supabase/supabase-js` (main isomorphic client)
+- [`packages/core/auth-js/README.md`](./packages/core/auth-js/README.md) — `@supabase/auth-js`
+- [`packages/core/postgrest-js/README.md`](./packages/core/postgrest-js/README.md) — `@supabase/postgrest-js`
+- [`packages/core/realtime-js/README.md`](./packages/core/realtime-js/README.md) — `@supabase/realtime-js`
+- [`packages/core/storage-js/README.md`](./packages/core/storage-js/README.md) — `@supabase/storage-js`
+- [`packages/core/functions-js/README.md`](./packages/core/functions-js/README.md) — `@supabase/functions-js`
+
+## Migration notes
+
+Migration notes live close to the code they describe, so they ship via npm alongside the package.
+
+- **Per-package migrations**: `packages/core/<package>/migrations/<theme>.md` — one file per migration theme (e.g. `<new-feature-adoption>.md`). Each file describes what changed, who is affected, and what callers need to do.
+- **Cross-cutting migrations** (affecting the whole repo or all packages): [`docs/MIGRATION.md`](./docs/MIGRATION.md) — one H2 section per theme (e.g. Node.js version drops). Low-frequency by design; split into a directory only if the file grows past a handful of themes.
+
+When helping a user upgrade a `@supabase/*` package, check `node_modules/@supabase/<package>/migrations/` for migration notes shipped with the installed version. They are version-pinned by virtue of being inside the package.
+
+## Other documentation
+
+- [`docs/TESTING.md`](./docs/TESTING.md) — testing guide with Docker requirements per package
+- [`docs/RELEASE.md`](./docs/RELEASE.md) — release workflows and versioning strategy
+- [`docs/SECURITY.md`](./docs/SECURITY.md) — security policies and responsible disclosure
+- [`docs/JSR_PUBLISHING.md`](./docs/JSR_PUBLISHING.md) — JSR registry publishing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,14 +29,33 @@ Each package has its own README with usage examples and API notes:
 - [`packages/core/storage-js/README.md`](./packages/core/storage-js/README.md) — `@supabase/storage-js`
 - [`packages/core/functions-js/README.md`](./packages/core/functions-js/README.md) — `@supabase/functions-js`
 
+## Helping users of a published `@supabase/*` package
+
+The published npm tarball for each package ships everything an agent needs to give a correct, version-pinned answer. After `npm install @supabase/<package>`, an agent helping with that package should look inside `node_modules/@supabase/<package>/`:
+
+- `AGENTS.md` — per-package agent entry point (read this first; it points at the resources below).
+- `README.md` — usage and quick-start.
+- `src/` — full API source with TSDoc. Every public method and type has JSDoc, most have `@example` blocks. Read source here for the canonical, version-pinned answer instead of guessing from training data.
+- `migrations/` — per-theme migration notes for changes that need caller action.
+
+Source files ship via npm because every package's `files` array in `package.json` includes `"src"`. Migration notes ship via `"migrations"`. Per-package `AGENTS.md` ships via `"AGENTS.md"`. All three are version-pinned by virtue of being inside the installed package.
+
+We deliberately do NOT ship per-package skills or duplicate docs-site content. The TSDoc-in-source IS the canonical API documentation for the SDK packages.
+
+For higher-level Supabase guidance (the documentation site, MCP tools, schema management workflows, project setup), use the centralized [Supabase agent skills](https://github.com/supabase/agent-skills):
+
+```bash
+npx skills add supabase/agent-skills
+```
+
+Or use the [Supabase Plugin for AI Coding Agents](https://supabase.com/docs/guides/getting-started/plugins) to install the agent skills together with the Supabase MCP server in one step. See also: [Agent Skills documentation](https://agentskills.io/home).
+
 ## Migration notes
 
 Migration notes live close to the code they describe, so they ship via npm alongside the package.
 
 - **Per-package migrations**: `packages/core/<package>/migrations/<theme>.md` — one file per migration theme (e.g. `<new-feature-adoption>.md`). Each file describes what changed, who is affected, and what callers need to do.
 - **Cross-cutting migrations** (affecting the whole repo or all packages): [`docs/MIGRATION.md`](./docs/MIGRATION.md) — one H2 section per theme (e.g. Node.js version drops). Low-frequency by design; split into a directory only if the file grows past a handful of themes.
-
-When helping a user upgrade a `@supabase/*` package, check `node_modules/@supabase/<package>/migrations/` for migration notes shipped with the installed version. They are version-pinned by virtue of being inside the package.
 
 ## Other documentation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,12 +2,6 @@
 
 Thank you for your interest in contributing to the Supabase JavaScript SDK! This guide will help you get started with contributing to the Supabase JS monorepo.
 
-> **Repository Structure Changed:** This repository has been restructured as a monorepo. **All libraries, including `supabase-js`, are now under `packages/core/`**. If you previously contributed to `supabase-js`, `auth-js`, `postgrest-js`, `realtime-js`, `storage-js`, or `functions-js`, please read our **[Migration Guide](docs/MIGRATION.md)** to understand:
->
-> - Where your code moved (everything is now in `packages/core/<library-name>/`)
-> - How commands changed (`npm test` → `pnpm nx test <library-name>`)
-> - New workflow with Nx
-
 ## 📋 Table of Contents
 
 - [Getting Started](#getting-started)

--- a/README.md
+++ b/README.md
@@ -26,17 +26,6 @@
 
 </div>
 
-> **For contributors: Repository Structure Changed**
->
-> This repository has been restructured as a monorepo. All libraries, including `supabase-js` itself, have moved to `packages/core/`:
->
-> | What You're Looking For | Where It Is Now              |
-> | ----------------------- | ---------------------------- |
-> | Main supabase-js code   | `packages/core/supabase-js/` |
-> | Other libraries         | `packages/core/*/`           |
->
-> Read the **[Migration Guide](./docs/MIGRATION.md)** to learn more.
-
 ## 📦 Libraries
 
 This monorepo contains the complete suite of Supabase JavaScript SDK:
@@ -144,7 +133,7 @@ Testing varies per package. See the top-level [TESTING.md](docs/TESTING.md) for 
 
 - **[Contributing](./CONTRIBUTING.md)** - Development guidelines
 - **[Release Workflows](./docs/RELEASE.md)** - Release and publishing process
-- **[Migration Guide](./docs/MIGRATION.md)** - Migrating to the monorepo structure
+- **[Migration Guide](./docs/MIGRATION.md)** - Cross-cutting migration notes (per-package migrations live alongside each package under `packages/core/<package>/migrations/`)
 - **[Security Policy](./docs/SECURITY.md)** - Vulnerability reporting and disclosure policy
 - **[Securing your npm installs](./docs/NPM_PACKAGE_SECURITY.md)** - Consumer-side guide to defending your install against npm supply-chain attacks
 

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -1,555 +1,64 @@
-# Migration Guide: Transitioning to the Supabase JS Monorepo
+# Migration Guide
 
-> **This repository has been restructured.** If you contributed to `supabase-js`, `auth-js`, `postgrest-js`, or any other Supabase JS library, this guide explains what changed and how to work with the new structure.
+Cross-cutting migration notes for the Supabase JavaScript SDK. One H2 section per migration theme.
 
-> **📦 Note for Package Users:** If you install and use these packages via npm, **nothing changed**. This guide is for contributors who develop and maintain these libraries.
+> **Per-package migrations** (changes scoped to a single SDK like `@supabase/auth-js`) live alongside the package they affect, under `packages/core/<package>/migrations/`. The notes in this file cover changes that span multiple packages or the workspace as a whole.
 
----
+## Node.js 18 support dropped (v2.79.0, 2025-10-31)
 
-## 🔴 Node.js 18 Support Dropped
+Starting with version `2.79.0`, all Supabase JavaScript libraries require **Node.js 20 or later**. The `@supabase/node-fetch` polyfill has been removed and native `fetch` is now required.
 
-**Effective Date:** October 31, 2025
+### Affected packages
 
-### What Changed
+`@supabase/supabase-js`, `@supabase/auth-js`, `@supabase/postgrest-js`, `@supabase/realtime-js`, `@supabase/storage-js`, `@supabase/functions-js`.
 
-Starting with version `2.79.0`, all Supabase JavaScript libraries require **Node.js 20 or later**. The `@supabase/node-fetch` polyfill has been removed, and native fetch support is now required.
+### Why
 
-### Why?
+Node.js 18 reached end-of-life on April 30, 2025 and no longer receives security updates. Node.js 20+ ships with native `fetch`, eliminating the need for the polyfill and reducing bundle size.
 
-Node.js 18 reached end-of-life on April 30, 2025, and no longer receives security updates or critical fixes. Node.js 20+ includes native fetch support, eliminating the need for polyfills and reducing bundle size.
+### What to do
 
-### Affected Libraries
+1. **Upgrade Node.js** to version 20 or later:
 
-- `@supabase/supabase-js`
-- `@supabase/auth-js`
-- `@supabase/postgrest-js`
-- `@supabase/realtime-js`
-- `@supabase/storage-js`
-- `@supabase/functions-js`
+   ```bash
+   # Check current version
+   node --version
 
-### Migration Guide
+   # Via nvm
+   nvm install 20
+   nvm use 20
 
-**1. Upgrade Node.js** to version 20 or later:
+   # Or download from https://nodejs.org/
+   ```
 
-```bash
-# Check your current version
-node --version
+2. **Update your dependencies**:
 
-# If < 20.0.0, upgrade Node.js
-# Via nvm (recommended):
-nvm install 20
-nvm use 20
+   ```bash
+   npm install @supabase/supabase-js@latest
+   # or, per-package:
+   npm install @supabase/auth-js@latest
+   ```
 
-# Or download from https://nodejs.org/
-```
+3. **No code changes required** — APIs are unchanged.
 
-**2. Update your package.json** to use the latest version:
+### Supported runtimes
 
-```bash
-npm install @supabase/supabase-js@latest
-# Or for individual packages:
-npm install @supabase/auth-js@latest
-```
-
-**3. No code changes required** - The APIs remain unchanged. Your existing code will work as-is once you upgrade Node.js.
-
-### Supported Environments
-
-- **Node.js 20+** - Native fetch support
-- **Modern browsers** - All modern browsers
-- **Deno 2.x** - Native fetch built-in
-- **Bun 0.1+** - Native fetch built-in
-- **React Native** - With fetch polyfill provided by the framework
-- **Expo** - With fetch polyfill provided by the framework
+- Node.js 20+ (native fetch)
+- Modern browsers
+- Deno 2.x
+- Bun 0.1+
+- React Native and Expo (with the framework's bundled fetch polyfill)
 
 ### Troubleshooting
 
-**Error: `fetch is not defined`**
-
-This means you're running Node.js < 20. Solutions:
-
-1. Upgrade to Node.js 20+ (recommended)
-2. If you absolutely cannot upgrade, use an older version of the libraries (see below)
-
-**Using Node.js 18 (Not Recommended)**
-
-If you must use Node.js 18, install the last version that supported it:
+**`fetch is not defined`** — you're on Node.js < 20. Upgrade Node.js. If you absolutely cannot upgrade, pin to the last version that supported Node.js 18:
 
 ```bash
 npm install @supabase/supabase-js@2.78.0
 ```
 
-⚠️ **Warning:** Using Node.js 18 is not recommended as it no longer receives security updates.
+> ⚠️ Using Node.js 18 is not recommended — it no longer receives security updates.
 
-### Discussion
+### Reference
 
-For more details, see the [deprecation announcement](https://github.com/orgs/supabase/discussions/37217).
-
----
-
-## 🎯 Who This Guide Is For
-
-**This guide is for contributors**, including:
-
-- Contributors to the old `supabase-js` repository (even supabase-js moved)
-- Contributors to separate libraries (`auth-js`, `postgrest-js`, `realtime-js`, `storage-js`, `functions-js`)
-- Anyone with open PRs in any of the old repositories
-- New contributors who want to understand the architecture
-
-**Not a contributor?** You can skip this guide. Packages are still installed and used the same way.
-
-## ⚠️ What Changed: The Big Picture
-
-### The Repository URL Stayed the Same, But Everything Inside Changed
-
-The repository is still at `github.com/supabase/supabase-js`.
-
-**OLD Structure:**
-
-```tree
-github.com/supabase/supabase-js/
-├── src/              ← supabase-js code was here
-├── test/
-├── package.json
-└── README.md
-
-github.com/supabase/auth-js/        ← Separate repo
-github.com/supabase/postgrest-js/   ← Separate repo
-github.com/supabase/realtime-js/    ← Separate repo
-github.com/supabase/storage-js/     ← Separate repo
-github.com/supabase/functions-js/   ← Separate repo
-```
-
-**NEW Structure** (what you'll see now):
-
-```tree
-github.com/supabase/supabase-js/    ← Same URL, different structure!
-├── packages/
-│   └── core/
-│       ├── supabase-js/     ← YOUR supabase-js code is HERE now
-│       │   ├── src/
-│       │   ├── test/
-│       │   └── package.json
-│       ├── auth-js/         ← auth-js moved here
-│       ├── postgrest-js/    ← postgrest-js moved here
-│       ├── realtime-js/     ← realtime-js moved here
-│       ├── storage-js/      ← storage-js moved here
-│       └── functions-js/    ← functions-js moved here
-├── nx.json              ← New: Nx workspace config
-├── package.json         ← New: Root workspace config
-└── README.md
-```
-
-### Key Point: EVERYTHING Moved
-
-All six libraries, including `supabase-js` itself, now live under `packages/core/`. All libraries were reorganized into a shared monorepo structure.
-
-### 📦 Important: This Only Affects Contributors
-
-**If you use these packages, nothing changed.**
-
-The monorepo restructure is a **development workflow change** for maintainers and contributors. If you install these packages via npm, your experience is unchanged:
-
-```bash
-# Still works the same
-npm install @supabase/supabase-js
-npm install @supabase/auth-js
-npm install @supabase/storage-js
-```
-
-What stayed the same:
-
-- Packages are still published independently to npm
-- You can still install only what you need
-- Your existing code does not need any changes
-- Package names remain the same (`@supabase/package-name`)
-
-The only difference is that all packages now share the same version number for compatibility across the ecosystem.
-
-This guide is for contributors who need to understand where code moved and how to develop and test these packages.
-
-## 📋 Table of Contents
-
-- [Why We Migrated](#why-we-migrated)
-- [What Changed](#what-changed)
-- [Repository Mapping](#repository-mapping)
-- [Migration Steps](#migration-steps)
-- [Common Scenarios](#common-scenarios)
-- [Command Reference](#command-reference)
-- [FAQ](#faq)
-- [Getting Help](#getting-help)
-
-## Why We Migrated
-
-We converted the `supabase-js` repository into a monorepo and absorbed the other js SDKs to solve several challenges:
-
-### Problems with Separate Repos
-
-- **Version Drift**: Libraries could have incompatible versions in production
-- **Manual Dependency Updates**: Updating internal dependencies required coordinated PRs across repos
-- **Duplicated CI/CD**: Each repo maintained its own pipeline configuration
-- **Complex Testing**: Integration testing across libraries was difficult
-- **Inconsistent Tooling**: Different repos used different build and test setups
-- **Release Coordination**: Coordinating releases across dependent packages was error-prone
-
-### Benefits of the Monorepo
-
-- **Fixed Versioning**: All packages share a single version number
-- **Automatic Dependency Updates**: Internal dependencies update automatically
-- **Unified CI/CD**: Single pipeline with intelligent affected detection
-- **Simplified Testing**: Easy integration testing across all libraries
-- **Consistent Tooling**: One build system, one test runner, one format
-- **Atomic Changes**: Coordinated changes across multiple packages in one PR
-- **Better DX**: Nx provides caching, affected commands, and dependency visualization
-
-## What Changed
-
-### Repository Structure
-
-**Before:** 6 separate repositories
-
-```tree
-github.com/supabase/supabase-js
-github.com/supabase/auth-js
-github.com/supabase/postgrest-js
-github.com/supabase/realtime-js
-github.com/supabase/storage-js
-github.com/supabase/functions-js
-```
-
-**After:** The Supabase JS monorepo (absorbed all SDKs)
-
-```tree
-github.com/supabase/supabase-js
-├── packages/
-│   └── core/
-│       ├── supabase-js/
-│       ├── auth-js/
-│       ├── postgrest-js/
-│       ├── realtime-js/
-│       ├── storage-js/
-│       └── functions-js/
-```
-
-### Development Workflow
-
-| Task                     | Old Workflow                     | New Workflow                                 |
-| ------------------------ | -------------------------------- | -------------------------------------------- |
-| **Clone & Setup**        | Clone each repo individually     | Clone once: `git clone supabase/supabase-js` |
-| **Install Dependencies** | `npm install` in each repo       | Single `pnpm install` at root                |
-| **Build a Library**      | `npm run build` in specific repo | `pnpm nx build auth-js`                      |
-| **Test a Library**       | `npm test` in specific repo      | `pnpm nx test postgrest-js`                  |
-| **Format Code**          | Various tools per repo           | `pnpm nx format`                             |
-| **Release**              | Individual releases per repo     | Single coordinated release                   |
-
-### Versioning Strategy
-
-- **Before**: Each package had independent versions (e.g., auth@2.1.0, storage@1.5.3)
-- **After**: All packages share the same version (e.g., everything at 2.5.0)
-- **Benefit**: No more compatibility matrices or version conflicts
-
-Read more about the release process in [RELEASE.md](./RELEASE.md).
-
-## Repository Mapping
-
-Here's where to find your familiar code in the new structure:
-
-| Old Repository          | New Location                  | Package Name (unchanged!) |
-| ----------------------- | ----------------------------- | ------------------------- |
-| `supabase/supabase-js`  | `packages/core/supabase-js/`  | `@supabase/supabase-js`   |
-| `supabase/auth-js`      | `packages/core/auth-js/`      | `@supabase/auth-js`       |
-| `supabase/postgrest-js` | `packages/core/postgrest-js/` | `@supabase/postgrest-js`  |
-| `supabase/realtime-js`  | `packages/core/realtime-js/`  | `@supabase/realtime-js`   |
-| `supabase/storage-js`   | `packages/core/storage-js/`   | `@supabase/storage-js`    |
-| `supabase/functions-js` | `packages/core/functions-js/` | `@supabase/functions-js`  |
-
-### Important Files
-
-Each library maintains its structure, but some files are now centralized:
-
-- **Root `package.json`**: Workspace configuration and shared dev dependencies
-- **Root `nx.json`**: Nx workspace configuration
-- **Root `.github/`**: Unified CI/CD workflows
-- **Library `package.json`**: Still exists for each library with its specific dependencies
-- **Library `tsconfig.json`**: Extends from root but maintains library-specific settings
-
-## Migration Steps
-
-### For Contributors with Existing Work
-
-If you have uncommitted changes or an active branch in an old repository, you'll need to manually port your work to the new monorepo:
-
-#### Step 1: Set up the new monorepo
-
-```bash
-# Fork github.com/supabase/supabase-js on GitHub, then:
-git clone https://github.com/YOUR_USERNAME/supabase-js.git
-cd supabase-js
-corepack enable
-pnpm install
-
-# Add upstream remote
-git remote add upstream https://github.com/supabase/supabase-js.git
-git fetch upstream
-
-# Create your feature branch
-git checkout -b feature/your-feature-name
-```
-
-#### Step 2: Manually port your changes
-
-1. **Open your old repository** in another window/tab
-2. **Copy your modified files** to the new structure:
-   - Old: `auth-js/src/GoTrueClient.ts`
-   - New: `packages/core/auth-js/src/GoTrueClient.ts`
-3. **Commit using the interactive tool**:
-
-   ```bash
-   pnpm commit
-   ```
-
-### For Active Pull Requests
-
-If you have an open PR, reach out to maintainers in your existing PR. We will help you merge it quickly or assist with porting to the monorepo.
-
-### For Projects Depending on Supabase Libraries
-
-**Zero changes for package users.** If you use these packages in your project, everything works as before. The monorepo is an internal development change.
-
-Packages are still published independently.
-
-```json
-{
-  "dependencies": {
-    "@supabase/supabase-js": "^2.0.0",
-    "@supabase/auth-js": "^2.0.0",
-    "@supabase/storage-js": "^2.0.0"
-  }
-}
-```
-
-Your application code, imports, and usage patterns remain unchanged. The monorepo structure only affects how contributors develop and maintain these libraries.
-
-## Common Scenarios
-
-### Scenario 1: "I was working on a bug fix in postgrest-js"
-
-```bash
-# make changes to packages/core/postgrest-js/src/PostgrestClient.ts
-pnpm commit  # Use interactive commit tool
-# Select: fix > postgrest > "resolve filter issue"
-```
-
-### Scenario 2: "I need to update auth-js and test it with supabase-js"
-
-```bash
-# Before: required npm link or multiple PRs
-# Now: simple
-
-# Make changes to auth-js
-edit packages/core/auth-js/src/GoTrueClient.ts
-
-# Test auth-js alone
-pnpm nx test auth-js
-
-# Test with supabase-js integration
-pnpm nx test supabase-js
-
-# Build both to ensure compatibility
-pnpm nx run-many --target=build --projects=auth-js,supabase-js
-
-# Commit both changes atomically
-pnpm commit
-# feat(auth): add new auth feature with supabase-js integration
-```
-
-### Scenario 3: "I want to add a feature that touches multiple packages"
-
-```bash
-# Create your feature branch
-git checkout -b feature/multi-package-update
-
-# Make changes across packages
-edit packages/core/auth-js/src/lib/feature.ts
-edit packages/core/supabase-js/src/SupabaseClient.ts
-edit packages/core/realtime-js/src/RealtimeClient.ts
-
-# Build all affected packages
-pnpm nx affected --target=build
-
-# Commit with appropriate scope
-pnpm commit
-# feat(supabase): add cross-package feature for X functionality
-```
-
-## Command Reference
-
-### Quick Command Conversion Table
-
-| Purpose              | Old Command (in individual repo) | New Command (in monorepo)               |
-| -------------------- | -------------------------------- | --------------------------------------- |
-| **Install deps**     | `npm install`                    | `pnpm install` (at root)                |
-| **Build library**    | `npm run build`                  | `pnpm nx build [library-name]`          |
-| **Test library**     | `npm test`                       | `pnpm nx test [library-name]`           |
-| **Test with watch**  | `npm test -- --watch`            | `pnpm nx test [library-name] --watch`   |
-| **Lint**             | `npm run lint`                   | `pnpm nx lint [library-name]`           |
-| **Format code**      | Various per repo                 | `pnpm nx format`                        |
-| **Type check**       | `npm run type-check`             | `pnpm nx build [library-name]`          |
-| **Build all**        | Run in each repo                 | `pnpm nx run-many --target=build --all` |
-| **Test all**         | Run in each repo                 | `pnpm nx run-many --target=test --all`  |
-| **Test affected**    | Not available                    | `pnpm nx affected --target=test`        |
-| **See dependencies** | Manual inspection                | `pnpm nx graph`                         |
-
-### Library Name Reference
-
-Use these names with Nx commands:
-
-- `auth-js` - Auth library
-- `functions-js` - Functions library
-- `postgrest-js` - PostgREST library
-- `realtime-js` - Realtime library
-- `storage-js` - Storage library
-- `supabase-js` - Main SDK
-
-### Useful New Commands
-
-Commands that weren't available in separate repos:
-
-```bash
-# Visualize project dependencies
-pnpm nx graph
-
-# Build only what changed since master
-pnpm nx affected --target=build --base=master
-
-# Test only what changed
-pnpm nx affected --target=test
-
-# Run test/build for a specific project
-pnpm nx test auth-js
-pnpm nx build auth-js
-
-# See what would be affected by your changes
-pnpm nx show projects --affected
-
-# Run multiple targets in parallel
-pnpm nx run-many --target=build,test --all --parallel=3
-
-# Generate documentation
-pnpm nx run-many --target=docs --all
-```
-
-## FAQ
-
-### Q: I contributed to the old supabase-js repo. Where did my code go?
-
-**A:** Your code is now in `packages/core/supabase-js/`. The repository URL (`github.com/supabase/supabase-js`) stayed the same, but the internal structure changed. What used to be in the root (`src/`, `test/`, etc.) is now nested under `packages/core/supabase-js/`.
-
-Example:
-
-- **Old:** `src/SupabaseClient.ts`
-- **New:** `packages/core/supabase-js/src/SupabaseClient.ts`
-
-This structure accommodates all the libraries in one repository.
-
-### Q: Why does it say supabase-js "absorbed" other libraries if supabase-js also moved?
-
-**A:** What happened:
-
-- The `supabase-js` **repository URL** stayed the same (`github.com/supabase/supabase-js`)
-- All libraries (including supabase-js itself) moved into a `packages/core/` structure
-- Other library repositories (`auth-js`, `postgrest-js`, etc.) were archived
-- The repository now contains all libraries, but supabase-js code also relocated
-
-The **repository** absorbed other libraries. The **supabase-js package code** also moved.
-
-### Q: Why fixed versioning instead of independent versions?
-
-**A:** Fixed versioning ensures all Supabase JS libraries are compatible with each other. You do not need to worry about compatibility matrices or which version of auth-js works with which version of supabase-js.
-
-### Q: Can I still work on just one library?
-
-**A:** Yes. The monorepo structure does not mean you have to work on everything. You can focus on a single library:
-
-```bash
-pnpm nx build auth-js --watch
-pnpm nx test auth-js --watch
-```
-
-### Q: How do releases work now?
-
-**A:** All packages are released together with the same version number. When we release v2.5.0, all six packages get v2.5.0. This is automated through Nx Release and semantic-release. Read more on [`RELEASE.md`](./RELEASE.md).
-
-### Q: Will old issues and PRs be migrated?
-
-**A:** Open issues are being triaged and migrated as appropriate. For open PRs, we will work with contributors individually. Check the old repo for a migration notice.
-
-### Q: How do I know which files to edit?
-
-**A:** The structure within each package is the same as before. Examples:
-
-- **Old auth-js repo:** `src/GoTrueClient.ts` → **New:** `packages/core/auth-js/src/GoTrueClient.ts`
-- **Old supabase-js repo:** `src/SupabaseClient.ts` → **New:** `packages/core/supabase-js/src/SupabaseClient.ts`
-
-The internal structure of each library is unchanged. Only the top-level location changed.
-
-### Q: Do I need to learn Nx?
-
-**A:** No. Basic commands are enough for most contributions. Nx handles the complexity behind the scenes. The main commands you need are `nx build`, `nx test`, and `nx affected`.
-
-### Q: What about my Git history?
-
-**A:** The Git history from all individual repos has been preserved during the migration. You can still see the history of individual files:
-
-```bash
-git log --follow packages/core/auth-js/src/GoTrueClient.ts
-```
-
-### Q: Can I still install packages individually?
-
-**A:** Yes. **Nothing changed for package users.** Each package is still published independently to npm. The monorepo structure is only for contributor development.
-
-You can install any package individually:
-
-```bash
-npm install @supabase/auth-js
-npm install @supabase/supabase-js
-npm install @supabase/storage-js
-```
-
-The monorepo is an internal development tool. It makes it easier for contributors to work across packages. It does not affect package distribution or how you use them.
-
-### Q: What if I find a bug in the migration?
-
-**A:** [Open an issue](https://github.com/supabase/supabase-js/issues/new/choose) and add `[migration]` in the title. We are actively monitoring these during the transition period.
-
-## Getting Help
-
-### Migration Support
-
-- **Migration Issues**: Create a [new GitHub issue](https://github.com/supabase/supabase-js/issues/new/choose) and add `[migration]` in the title
-- **Questions**: Check out the [GitHub Discussion](https://github.com/orgs/supabase/discussions/39197) on the monorepo transition
-- **Discord**: [Supabase Discord](https://discord.supabase.com) in #contributing channel
-
-### Resources
-
-- **[CONTRIBUTING.md](../CONTRIBUTING.md)** - Detailed contribution guidelines
-- **[README.md](../README.md)** - Repository overview and quick start
-
-### Important Links
-
-- **Supabase JS Monorepo**: <https://github.com/supabase/supabase-js>
-- **Old Repos** (archived/read-only):
-  - <https://github.com/supabase/auth-js>
-  - <https://github.com/supabase/postgrest-js>
-  - <https://github.com/supabase/realtime-js>
-  - <https://github.com/supabase/storage-js>
-  - <https://github.com/supabase/functions-js>
-
----
-
-## Welcome to the Monorepo
-
-Thank you for your patience during this transition, and thank you for contributing to Supabase! 💚
-
-> **Note**: We will update this document as we learn from the migration process.
+[Deprecation announcement](https://github.com/orgs/supabase/discussions/37217).

--- a/packages/core/auth-js/AGENTS.md
+++ b/packages/core/auth-js/AGENTS.md
@@ -1,0 +1,11 @@
+# Agent instructions for `@supabase/auth-js`
+
+Supabase Auth client SDK for JavaScript. Handles sign-in, sign-up, sessions, OAuth, MFA, and related auth flows.
+
+When helping a user work with this package:
+
+- **Usage and quick start**: [`README.md`](./README.md)
+- **Full API reference**: [`src/`](./src/) — every public method and type has TSDoc with `@example` blocks. Read the source for the canonical, version-pinned answer.
+- **Migration notes**: [`migrations/`](./migrations/) — per-theme markdown files for changes that need caller action.
+
+For broader Supabase guidance (docs site, MCP tools, schema and project workflows), use the centralized [Supabase agent skills](https://github.com/supabase/agent-skills): `npx skills add supabase/agent-skills`. Or pair with the Supabase MCP server via the [Supabase Plugin for AI Coding Agents](https://supabase.com/docs/guides/getting-started/plugins).

--- a/packages/core/auth-js/migrations/README.md
+++ b/packages/core/auth-js/migrations/README.md
@@ -1,0 +1,25 @@
+# Migration notes for `@supabase/auth-js`
+
+Each file in this directory describes one migration theme — what changed in `@supabase/auth-js`, who is affected, and what callers need to do.
+
+Files are shipped with the npm package, so the migration notes you see here are pinned to the version of `@supabase/auth-js` you have installed. Upgrading the package brings the relevant migration notes along with it.
+
+## How agents should use this directory
+
+When helping a developer upgrade `@supabase/auth-js`:
+
+1. Read the migration files in `node_modules/@supabase/auth-js/migrations/` for the version they have installed.
+2. Cross-reference against the version they are upgrading to.
+3. Apply the migration steps described in each relevant file.
+
+## How humans should use this directory
+
+Browse the files for the migration theme you care about. Each file is self-contained and explains its own scope, audience, and steps.
+
+## File naming
+
+One file per migration theme, named by topic rather than version (e.g. `<theme>.md`, kebab-case). A single version can ship multiple theme files; a single theme can span multiple versions. Each file documents its own `Since` / `Will require action by` version range internally.
+
+## Cross-cutting migration notes
+
+Migrations that span multiple Supabase packages (e.g. Node.js version drops, monorepo restructures) live in [`docs/MIGRATION.md`](../../../../docs/MIGRATION.md) at the repository root, not here. This directory is scoped to `@supabase/auth-js` only.

--- a/packages/core/auth-js/package.json
+++ b/packages/core/auth-js/package.json
@@ -15,7 +15,8 @@
   "author": "Supabase",
   "files": [
     "dist",
-    "src"
+    "src",
+    "migrations"
   ],
   "main": "dist/main/index.js",
   "module": "dist/module/index.js",

--- a/packages/core/auth-js/package.json
+++ b/packages/core/auth-js/package.json
@@ -16,7 +16,8 @@
   "files": [
     "dist",
     "src",
-    "migrations"
+    "migrations",
+    "AGENTS.md"
   ],
   "main": "dist/main/index.js",
   "module": "dist/module/index.js",

--- a/packages/core/functions-js/AGENTS.md
+++ b/packages/core/functions-js/AGENTS.md
@@ -1,0 +1,11 @@
+# Agent instructions for `@supabase/functions-js`
+
+JavaScript SDK for invoking Supabase Edge Functions.
+
+When helping a user work with this package:
+
+- **Usage and quick start**: [`README.md`](./README.md)
+- **Full API reference**: [`src/`](./src/) — every public method and type has TSDoc with `@example` blocks. Read the source for the canonical, version-pinned answer.
+- **Migration notes**: [`migrations/`](./migrations/) — per-theme markdown files for changes that need caller action.
+
+For broader Supabase guidance (docs site, MCP tools, schema and project workflows), use the centralized [Supabase agent skills](https://github.com/supabase/agent-skills): `npx skills add supabase/agent-skills`. Or pair with the Supabase MCP server via the [Supabase Plugin for AI Coding Agents](https://supabase.com/docs/guides/getting-started/plugins).

--- a/packages/core/functions-js/migrations/README.md
+++ b/packages/core/functions-js/migrations/README.md
@@ -1,0 +1,25 @@
+# Migration notes for `@supabase/functions-js`
+
+Each file in this directory describes one migration theme — what changed in `@supabase/functions-js`, who is affected, and what callers need to do.
+
+Files are shipped with the npm package, so the migration notes you see here are pinned to the version of `@supabase/functions-js` you have installed. Upgrading the package brings the relevant migration notes along with it.
+
+## How agents should use this directory
+
+When helping a developer upgrade `@supabase/functions-js`:
+
+1. Read the migration files in `node_modules/@supabase/functions-js/migrations/` for the version they have installed.
+2. Cross-reference against the version they are upgrading to.
+3. Apply the migration steps described in each relevant file.
+
+## How humans should use this directory
+
+Browse the files for the migration theme you care about. Each file is self-contained and explains its own scope, audience, and steps.
+
+## File naming
+
+One file per migration theme, named by topic rather than version (e.g. `<theme>.md`, kebab-case). A single version can ship multiple theme files; a single theme can span multiple versions. Each file documents its own `Since` / `Will require action by` version range internally.
+
+## Cross-cutting migration notes
+
+Migrations that span multiple Supabase packages (e.g. Node.js version drops, monorepo restructures) live in [`docs/MIGRATION.md`](../../../../docs/MIGRATION.md) at the repository root, not here. This directory is scoped to `@supabase/functions-js` only.

--- a/packages/core/functions-js/package.json
+++ b/packages/core/functions-js/package.json
@@ -28,7 +28,8 @@
   "files": [
     "dist",
     "src",
-    "migrations"
+    "migrations",
+    "AGENTS.md"
   ],
   "license": "MIT",
   "bugs": {

--- a/packages/core/functions-js/package.json
+++ b/packages/core/functions-js/package.json
@@ -27,7 +27,8 @@
   "author": "Supabase",
   "files": [
     "dist",
-    "src"
+    "src",
+    "migrations"
   ],
   "license": "MIT",
   "bugs": {

--- a/packages/core/postgrest-js/AGENTS.md
+++ b/packages/core/postgrest-js/AGENTS.md
@@ -1,0 +1,11 @@
+# Agent instructions for `@supabase/postgrest-js`
+
+Isomorphic PostgREST client for database operations (select, insert, update, upsert, delete, filters, RPC).
+
+When helping a user work with this package:
+
+- **Usage and quick start**: [`README.md`](./README.md)
+- **Full API reference**: [`src/`](./src/) — every public method and type has TSDoc with `@example` blocks. Read the source for the canonical, version-pinned answer.
+- **Migration notes**: [`migrations/`](./migrations/) — per-theme markdown files for changes that need caller action.
+
+For broader Supabase guidance (docs site, MCP tools, schema and project workflows), use the centralized [Supabase agent skills](https://github.com/supabase/agent-skills): `npx skills add supabase/agent-skills`. Or pair with the Supabase MCP server via the [Supabase Plugin for AI Coding Agents](https://supabase.com/docs/guides/getting-started/plugins).

--- a/packages/core/postgrest-js/migrations/README.md
+++ b/packages/core/postgrest-js/migrations/README.md
@@ -1,0 +1,25 @@
+# Migration notes for `@supabase/postgrest-js`
+
+Each file in this directory describes one migration theme — what changed in `@supabase/postgrest-js`, who is affected, and what callers need to do.
+
+Files are shipped with the npm package, so the migration notes you see here are pinned to the version of `@supabase/postgrest-js` you have installed. Upgrading the package brings the relevant migration notes along with it.
+
+## How agents should use this directory
+
+When helping a developer upgrade `@supabase/postgrest-js`:
+
+1. Read the migration files in `node_modules/@supabase/postgrest-js/migrations/` for the version they have installed.
+2. Cross-reference against the version they are upgrading to.
+3. Apply the migration steps described in each relevant file.
+
+## How humans should use this directory
+
+Browse the files for the migration theme you care about. Each file is self-contained and explains its own scope, audience, and steps.
+
+## File naming
+
+One file per migration theme, named by topic rather than version (e.g. `<theme>.md`, kebab-case). A single version can ship multiple theme files; a single theme can span multiple versions. Each file documents its own `Since` / `Will require action by` version range internally.
+
+## Cross-cutting migration notes
+
+Migrations that span multiple Supabase packages (e.g. Node.js version drops, monorepo restructures) live in [`docs/MIGRATION.md`](../../../../docs/MIGRATION.md) at the repository root, not here. This directory is scoped to `@supabase/postgrest-js` only.

--- a/packages/core/postgrest-js/package.json
+++ b/packages/core/postgrest-js/package.json
@@ -13,7 +13,8 @@
   "files": [
     "dist",
     "src",
-    "migrations"
+    "migrations",
+    "AGENTS.md"
   ],
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",

--- a/packages/core/postgrest-js/package.json
+++ b/packages/core/postgrest-js/package.json
@@ -12,7 +12,8 @@
   "author": "Supabase",
   "files": [
     "dist",
-    "src"
+    "src",
+    "migrations"
   ],
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",

--- a/packages/core/realtime-js/AGENTS.md
+++ b/packages/core/realtime-js/AGENTS.md
@@ -1,0 +1,11 @@
+# Agent instructions for `@supabase/realtime-js`
+
+Listen to realtime updates from a Supabase PostgreSQL database. Handles channels, presence, broadcast, and Postgres CDC subscriptions.
+
+When helping a user work with this package:
+
+- **Usage and quick start**: [`README.md`](./README.md)
+- **Full API reference**: [`src/`](./src/) — every public method and type has TSDoc with `@example` blocks. Read the source for the canonical, version-pinned answer.
+- **Migration notes**: [`migrations/`](./migrations/) — per-theme markdown files for changes that need caller action.
+
+For broader Supabase guidance (docs site, MCP tools, schema and project workflows), use the centralized [Supabase agent skills](https://github.com/supabase/agent-skills): `npx skills add supabase/agent-skills`. Or pair with the Supabase MCP server via the [Supabase Plugin for AI Coding Agents](https://supabase.com/docs/guides/getting-started/plugins).

--- a/packages/core/realtime-js/migrations/README.md
+++ b/packages/core/realtime-js/migrations/README.md
@@ -1,0 +1,25 @@
+# Migration notes for `@supabase/realtime-js`
+
+Each file in this directory describes one migration theme — what changed in `@supabase/realtime-js`, who is affected, and what callers need to do.
+
+Files are shipped with the npm package, so the migration notes you see here are pinned to the version of `@supabase/realtime-js` you have installed. Upgrading the package brings the relevant migration notes along with it.
+
+## How agents should use this directory
+
+When helping a developer upgrade `@supabase/realtime-js`:
+
+1. Read the migration files in `node_modules/@supabase/realtime-js/migrations/` for the version they have installed.
+2. Cross-reference against the version they are upgrading to.
+3. Apply the migration steps described in each relevant file.
+
+## How humans should use this directory
+
+Browse the files for the migration theme you care about. Each file is self-contained and explains its own scope, audience, and steps.
+
+## File naming
+
+One file per migration theme, named by topic rather than version (e.g. `<theme>.md`, kebab-case). A single version can ship multiple theme files; a single theme can span multiple versions. Each file documents its own `Since` / `Will require action by` version range internally.
+
+## Cross-cutting migration notes
+
+Migrations that span multiple Supabase packages (e.g. Node.js version drops, monorepo restructures) live in [`docs/MIGRATION.md`](../../../../docs/MIGRATION.md) at the repository root, not here. This directory is scoped to `@supabase/realtime-js` only.

--- a/packages/core/realtime-js/package.json
+++ b/packages/core/realtime-js/package.json
@@ -16,7 +16,8 @@
   "files": [
     "dist",
     "src",
-    "migrations"
+    "migrations",
+    "AGENTS.md"
   ],
   "main": "dist/main/index.js",
   "module": "dist/module/index.js",

--- a/packages/core/realtime-js/package.json
+++ b/packages/core/realtime-js/package.json
@@ -15,7 +15,8 @@
   "bugs": "https://github.com/supabase/supabase-js/issues",
   "files": [
     "dist",
-    "src"
+    "src",
+    "migrations"
   ],
   "main": "dist/main/index.js",
   "module": "dist/module/index.js",

--- a/packages/core/storage-js/AGENTS.md
+++ b/packages/core/storage-js/AGENTS.md
@@ -1,0 +1,11 @@
+# Agent instructions for `@supabase/storage-js`
+
+Isomorphic storage client for Supabase. Handles bucket and object operations: upload, download, list, signed URLs, transformations.
+
+When helping a user work with this package:
+
+- **Usage and quick start**: [`README.md`](./README.md)
+- **Full API reference**: [`src/`](./src/) — every public method and type has TSDoc with `@example` blocks. Read the source for the canonical, version-pinned answer.
+- **Migration notes**: [`migrations/`](./migrations/) — per-theme markdown files for changes that need caller action.
+
+For broader Supabase guidance (docs site, MCP tools, schema and project workflows), use the centralized [Supabase agent skills](https://github.com/supabase/agent-skills): `npx skills add supabase/agent-skills`. Or pair with the Supabase MCP server via the [Supabase Plugin for AI Coding Agents](https://supabase.com/docs/guides/getting-started/plugins).

--- a/packages/core/storage-js/migrations/README.md
+++ b/packages/core/storage-js/migrations/README.md
@@ -1,0 +1,25 @@
+# Migration notes for `@supabase/storage-js`
+
+Each file in this directory describes one migration theme — what changed in `@supabase/storage-js`, who is affected, and what callers need to do.
+
+Files are shipped with the npm package, so the migration notes you see here are pinned to the version of `@supabase/storage-js` you have installed. Upgrading the package brings the relevant migration notes along with it.
+
+## How agents should use this directory
+
+When helping a developer upgrade `@supabase/storage-js`:
+
+1. Read the migration files in `node_modules/@supabase/storage-js/migrations/` for the version they have installed.
+2. Cross-reference against the version they are upgrading to.
+3. Apply the migration steps described in each relevant file.
+
+## How humans should use this directory
+
+Browse the files for the migration theme you care about. Each file is self-contained and explains its own scope, audience, and steps.
+
+## File naming
+
+One file per migration theme, named by topic rather than version (e.g. `<theme>.md`, kebab-case). A single version can ship multiple theme files; a single theme can span multiple versions. Each file documents its own `Since` / `Will require action by` version range internally.
+
+## Cross-cutting migration notes
+
+Migrations that span multiple Supabase packages (e.g. Node.js version drops, monorepo restructures) live in [`docs/MIGRATION.md`](../../../../docs/MIGRATION.md) at the repository root, not here. This directory is scoped to `@supabase/storage-js` only.

--- a/packages/core/storage-js/package.json
+++ b/packages/core/storage-js/package.json
@@ -13,7 +13,8 @@
   "author": "Supabase",
   "files": [
     "dist",
-    "src"
+    "src",
+    "migrations"
   ],
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",

--- a/packages/core/storage-js/package.json
+++ b/packages/core/storage-js/package.json
@@ -14,7 +14,8 @@
   "files": [
     "dist",
     "src",
-    "migrations"
+    "migrations",
+    "AGENTS.md"
   ],
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",

--- a/packages/core/supabase-js/AGENTS.md
+++ b/packages/core/supabase-js/AGENTS.md
@@ -1,0 +1,11 @@
+# Agent instructions for `@supabase/supabase-js`
+
+Main isomorphic Supabase client for JavaScript. Aggregates `@supabase/auth-js`, `@supabase/postgrest-js`, `@supabase/realtime-js`, `@supabase/storage-js`, and `@supabase/functions-js` into one client.
+
+When helping a user work with this package:
+
+- **Usage and quick start**: [`README.md`](./README.md)
+- **Full API reference**: [`src/`](./src/) — every public method and type has TSDoc with `@example` blocks. Read the source for the canonical, version-pinned answer.
+- **Migration notes**: [`migrations/`](./migrations/) — per-theme markdown files for changes that need caller action.
+
+For broader Supabase guidance (docs site, MCP tools, schema and project workflows), use the centralized [Supabase agent skills](https://github.com/supabase/agent-skills): `npx skills add supabase/agent-skills`. Or pair with the Supabase MCP server via the [Supabase Plugin for AI Coding Agents](https://supabase.com/docs/guides/getting-started/plugins).

--- a/packages/core/supabase-js/migrations/README.md
+++ b/packages/core/supabase-js/migrations/README.md
@@ -1,0 +1,25 @@
+# Migration notes for `@supabase/supabase-js`
+
+Each file in this directory describes one migration theme — what changed in `@supabase/supabase-js`, who is affected, and what callers need to do.
+
+Files are shipped with the npm package, so the migration notes you see here are pinned to the version of `@supabase/supabase-js` you have installed. Upgrading the package brings the relevant migration notes along with it.
+
+## How agents should use this directory
+
+When helping a developer upgrade `@supabase/supabase-js`:
+
+1. Read the migration files in `node_modules/@supabase/supabase-js/migrations/` for the version they have installed.
+2. Cross-reference against the version they are upgrading to.
+3. Apply the migration steps described in each relevant file.
+
+## How humans should use this directory
+
+Browse the files for the migration theme you care about. Each file is self-contained and explains its own scope, audience, and steps.
+
+## File naming
+
+One file per migration theme, named by topic rather than version (e.g. `<theme>.md`, kebab-case). A single version can ship multiple theme files; a single theme can span multiple versions. Each file documents its own `Since` / `Will require action by` version range internally.
+
+## Cross-cutting migration notes
+
+Migrations that span multiple Supabase packages (e.g. Node.js version drops, monorepo restructures) live in [`docs/MIGRATION.md`](../../../../docs/MIGRATION.md) at the repository root, not here. This directory is scoped to `@supabase/supabase-js` only.

--- a/packages/core/supabase-js/package.json
+++ b/packages/core/supabase-js/package.json
@@ -13,7 +13,8 @@
   "author": "Supabase",
   "files": [
     "dist",
-    "src"
+    "src",
+    "migrations"
   ],
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",

--- a/packages/core/supabase-js/package.json
+++ b/packages/core/supabase-js/package.json
@@ -14,7 +14,8 @@
   "files": [
     "dist",
     "src",
-    "migrations"
+    "migrations",
+    "AGENTS.md"
   ],
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",


### PR DESCRIPTION
Establishes a per-package agent-discoverability layer that ships via npm:

- Every `@supabase/*` core package now has `AGENTS.md` + `migrations/` at its root, included in the `files` array. After `npm install @supabase/<package>`, agents find a pointer file directing them to the package's TSDoc-annotated `src/` (canonical, version-pinned API docs) and migration notes — no duplication of docs-site content.
- Repo-root `AGENTS.md` is the vendor-neutral entry point (alongside `.claude/CLAUDE.md` and `.cursor/.cursorrules`), explaining the workspace layout and pointing agents at the centralized [Supabase agent skills](https://github.com/supabase/agent-skills) (`npx skills add supabase/agent-skills`) for higher-level guidance.
- `docs/MIGRATION.md` is stripped of ~500 lines of stale 8-month-old monorepo-restructure content; what remains is genuine cross-cutting migration notes (currently just the Node 18 → 20 drop), one H2 per theme. The matching obsolete "Repository Structure Changed" callouts in `README.md` and `CONTRIBUTING.md` are removed.

No code changes. Verified via `npm pack --dry-run` that `AGENTS.md` and `migrations/` ship in all six core package tarballs.