### PR TITLE
feat(realtime): allow httpSend to send binary payload

### DIFF
--- a/packages/core/realtime-js/src/RealtimeChannel.ts
+++ b/packages/core/realtime-js/src/RealtimeChannel.ts
@@ -736,6 +736,9 @@ export default class RealtimeChannel {
    * This method always uses the REST API endpoint regardless of WebSocket connection state.
    * Useful when you want to guarantee REST delivery or when gradually migrating from implicit REST fallback.
    *
+   * Payloads that are `ArrayBuffer` or `ArrayBufferView` (e.g. `Uint8Array`) are sent as
+   * `application/octet-stream`; all other payloads are JSON-encoded.
+   *
    * @param event The name of the broadcast event
    * @param payload Payload to be sent (required)
    * @param opts Options including timeout
@@ -752,32 +755,31 @@ export default class RealtimeChannel {
       return Promise.reject(new Error('Payload is required for httpSend()'))
     }
 
+    const isBinary = payload instanceof ArrayBuffer || ArrayBuffer.isView(payload)
+
     const headers: Record<string, string> = {
       apikey: this.socket.apiKey ? this.socket.apiKey : '',
-      'Content-Type': 'application/json',
+      'Content-Type': isBinary ? 'application/octet-stream' : 'application/json',
     }
 
     if (this.socket.accessTokenValue) {
       headers['Authorization'] = `Bearer ${this.socket.accessTokenValue}`
     }
 
+    const url = new URL(this.broadcastEndpointURL)
+    url.pathname += `/${encodeURIComponent(this.subTopic)}/events/${encodeURIComponent(event)}`
+    if (this.private) {
+      url.searchParams.set('private', 'true')
+    }
+
     const options = {
       method: 'POST',
       headers,
-      body: JSON.stringify({
-        messages: [
-          {
-            topic: this.subTopic,
-            event,
-            payload: payload,
-            private: this.private,
-          },
-        ],
-      }),
+      body: isBinary ? (payload as ArrayBuffer | ArrayBufferView) : JSON.stringify(payload),
     }
 
     const response = await this._fetchWithTimeout(
-      this.broadcastEndpointURL,
+      url.toString(),
       options,
       opts.timeout ?? this.timeout
     )

--- a/packages/core/realtime-js/test/RealtimeChannel.messaging.test.ts
+++ b/packages/core/realtime-js/test/RealtimeChannel.messaging.test.ts
@@ -611,11 +611,12 @@ describe('httpSend', () => {
 
         expect(result).toEqual({ success: true })
         expect(fetchStub).toHaveBeenCalledTimes(1)
-        const [, options] = fetchStub.mock.calls[0]
+        const [url, options] = fetchStub.mock.calls[0]
         expect(options.headers.Authorization).toBe(expectedAuth)
-        expect(options.body).toBe(
-          '{"messages":[{"topic":"topic","event":"test-payload","payload":{"data":"value"},"private":false}]}'
-        )
+        expect(options.headers['Content-Type']).toBe('application/json')
+        expect(url).toContain('/api/broadcast/topic/events/test-payload')
+        expect(url).not.toContain('private=true')
+        expect(options.body).toBe('{"data":"value"}')
       })
     })
   })
@@ -635,7 +636,9 @@ describe('httpSend', () => {
       const expectedUrl = testSetup.wssUrl
         .replace('/websocket', '')
         .replace('wss', 'https')
-        .concat(`/api/broadcast?apikey=${expectedApiKey}&vsn=${VSN_2_0_0}`)
+        .concat(
+          `/api/broadcast/topic/events/test-explicit?apikey=${expectedApiKey}&vsn=${VSN_2_0_0}&private=true`
+        )
 
       expect(fetchStub).toHaveBeenCalledTimes(1)
       const [url, options] = fetchStub.mock.calls[0]
@@ -643,9 +646,8 @@ describe('httpSend', () => {
       expect(options.method).toBe('POST')
       expect(options.headers.Authorization).toBe('Bearer token123')
       expect(options.headers.apikey).toBe(expectedApiKey)
-      expect(options.body).toBe(
-        '{"messages":[{"topic":"topic","event":"test-explicit","payload":{"data":"explicit"},"private":true}]}'
-      )
+      expect(options.headers['Content-Type']).toBe('application/json')
+      expect(options.body).toBe('{"data":"explicit"}')
     })
 
     test('uses default timeout when not specified', async () => {
@@ -700,6 +702,59 @@ describe('httpSend', () => {
       await expect(channel.httpSend('test', { data: 'test' })).rejects.toThrow(
         'Service Unavailable'
       )
+    })
+  })
+
+  describe('binary payloads', () => {
+    test('sends ArrayBuffer payload as application/octet-stream', async () => {
+      const mockResponse = createMockResponse(202)
+      const fetchStub = vi.fn().mockResolvedValue(mockResponse)
+      const testSetup = createSocket(false, fetchStub)
+      const channel = testSetup.client.channel('topic')
+
+      const buffer = new ArrayBuffer(4)
+      new Uint8Array(buffer).set([1, 2, 3, 4])
+
+      const result = await channel.httpSend('bin', buffer)
+
+      expect(result).toEqual({ success: true })
+      expect(fetchStub).toHaveBeenCalledTimes(1)
+      const [url, options] = fetchStub.mock.calls[0]
+      expect(url).toContain('/api/broadcast/topic/events/bin')
+      expect(options.headers['Content-Type']).toBe('application/octet-stream')
+      expect(options.body).toBe(buffer)
+    })
+
+    test('sends Uint8Array payload as application/octet-stream', async () => {
+      const mockResponse = createMockResponse(202)
+      const fetchStub = vi.fn().mockResolvedValue(mockResponse)
+      const testSetup = createSocket(false, fetchStub)
+      const channel = testSetup.client.channel('topic')
+
+      const bytes = new Uint8Array([10, 20, 30])
+
+      const result = await channel.httpSend('bin', bytes)
+
+      expect(result).toEqual({ success: true })
+      expect(fetchStub).toHaveBeenCalledTimes(1)
+      const [, options] = fetchStub.mock.calls[0]
+      expect(options.headers['Content-Type']).toBe('application/octet-stream')
+      expect(options.body).toBe(bytes)
+    })
+  })
+
+  describe('URL encoding', () => {
+    test('URL-encodes topic and event names with special characters', async () => {
+      const mockResponse = createMockResponse(202)
+      const fetchStub = vi.fn().mockResolvedValue(mockResponse)
+      const testSetup = createSocket(false, fetchStub)
+      const channel = testSetup.client.channel('room:42')
+
+      const result = await channel.httpSend('user/joined', { id: 1 })
+
+      expect(result).toEqual({ success: true })
+      const [url] = fetchStub.mock.calls[0]
+      expect(url).toContain('/api/broadcast/room%3A42/events/user%2Fjoined')
     })
   })
 })

--- a/packages/core/supabase-js/scripts/setup-supabase.sh
+++ b/packages/core/supabase-js/scripts/setup-supabase.sh
@@ -6,6 +6,13 @@ cd "$(dirname "$0")/.."
 echo "🚀 Stop supabase if it is running"
 npx supabase stop
 
+# Pin realtime to a version that includes the per-event broadcast endpoint
+# (supabase/realtime#1864, first released in realtime v2.97.0). The Supabase CLI
+# bundled with this repo still defaults to an older realtime image; the CLI
+# reads supabase/.temp/realtime-version and overrides the image tag from it.
+mkdir -p supabase/.temp
+echo "v2.97.3" > supabase/.temp/realtime-version
+
 echo "🚀 Starting Supabase (migrations applied, seed data skipped)..."
 npx supabase start
 

--- a/packages/core/supabase-js/test/integration.test.ts
+++ b/packages/core/supabase-js/test/integration.test.ts
@@ -449,6 +449,98 @@ describe('Supabase Integration Tests', () => {
       // removeAllChannels is an explicit teardown — no deferred timer, disconnect is immediate
       expect(supabase.realtime.isConnected()).toBe(false)
     }, 20000)
+
+    test('httpSend delivers JSON broadcast to a public channel', async () => {
+      const publicChannelName = `public-${crypto.randomUUID()}`
+      const publicChannel = supabase.channel(publicChannelName, {
+        config: { broadcast: { self: true } },
+      })
+
+      let received: any
+      await new Promise<void>((resolve, reject) => {
+        const timeout = setTimeout(() => reject(new Error('subscribe timeout')), 8000)
+        publicChannel
+          .on('broadcast', { event: 'json' }, (payload) => {
+            received = payload
+          })
+          .subscribe((status) => {
+            if (status === 'SUBSCRIBED') {
+              clearTimeout(timeout)
+              resolve()
+            }
+          })
+      })
+
+      const result = await publicChannel.httpSend('json', { hello: 'public' })
+      expect(result).toEqual({ success: true })
+
+      let attempts = 0
+      while (!received) {
+        if (attempts++ > 50) throw new Error('Timeout waiting for broadcast')
+        await new Promise((r) => setTimeout(r, 100))
+      }
+      expect(received.payload).toEqual({ hello: 'public' })
+    }, 15000)
+
+    test('httpSend delivers JSON broadcast to a private channel', async () => {
+      let received: any
+      await new Promise<void>((resolve, reject) => {
+        const timeout = setTimeout(() => reject(new Error('subscribe timeout')), 8000)
+        channel
+          .on('broadcast', { event: 'json-private' }, (payload) => {
+            received = payload
+          })
+          .subscribe((status) => {
+            if (status === 'SUBSCRIBED') {
+              clearTimeout(timeout)
+              resolve()
+            }
+          })
+      })
+
+      const result = await channel.httpSend('json-private', { hello: 'private' })
+      expect(result).toEqual({ success: true })
+
+      let attempts = 0
+      while (!received) {
+        if (attempts++ > 50) throw new Error('Timeout waiting for broadcast')
+        await new Promise((r) => setTimeout(r, 100))
+      }
+      expect(received.payload).toEqual({ hello: 'private' })
+    }, 15000)
+
+    const binaryBroadcastTest = vsn === '2.0.0' ? test : test.skip
+    binaryBroadcastTest(
+      'httpSend delivers a binary broadcast to a private channel',
+      async () => {
+        let received: any
+        await new Promise<void>((resolve, reject) => {
+          const timeout = setTimeout(() => reject(new Error('subscribe timeout')), 8000)
+          channel
+            .on('broadcast', { event: 'binary' }, (payload) => {
+              received = payload
+            })
+            .subscribe((status) => {
+              if (status === 'SUBSCRIBED') {
+                clearTimeout(timeout)
+                resolve()
+              }
+            })
+        })
+
+        const bytes = new Uint8Array([1, 2, 3, 4, 5])
+        const result = await channel.httpSend('binary', bytes)
+        expect(result).toEqual({ success: true })
+
+        let attempts = 0
+        while (!received) {
+          if (attempts++ > 50) throw new Error('Timeout waiting for broadcast')
+          await new Promise((r) => setTimeout(r, 100))
+        }
+        expect(new Uint8Array(received.payload)).toEqual(bytes)
+      },
+      15000
+    )
   })
 })
 


### PR DESCRIPTION
<!-- Your PR title should follow the conventional commit format:
<type>(<scope>): <description> -->

## 🔍 Description

<!-- Provide a clear and concise description of what this PR does -->

It uses the new single broadcast API to send JSON or binary payloads.

I had to pin the realtime version for now until CLI has updated the realtime version.

### What changed?

<!-- Describe the changes made in this PR -->

### Why was this change needed?

<!-- Explain the motivation behind this change. Link any related issues. -->

Closes #(issue_number) <!-- If applicable -->

## 📸 Screenshots/Examples

<!-- If applicable, add screenshots or code examples to help explain your changes -->

## 🔄 Breaking changes

<!-- If this PR contains breaking changes, describe them here -->

- [x] This PR contains no breaking changes

## 📋 Checklist

<!-- Ensure all items are checked before submitting -->

- [x] I have read the [Contributing Guidelines](https://github.com/supabase/supabase-js/blob/master/CONTRIBUTING.md)
- [x] My PR title follows the [conventional commit format](https://www.conventionalcommits.org/): `<type>(<scope>): <description>`
- [x] I have run `pnpm nx format` to ensure consistent code formatting
- [x] I have added tests for new functionality (if applicable)
- [x] I have updated documentation (if applicable)

## 📝 Additional notes

<!-- Add any additional notes, context, or concerns for reviewers -->

<!-- Thank you for contributing to Supabase! 💚 -->
