### PR TITLE
fix: prevent navigator.locks deadlock by enforcing a maximum acquire timeout

### DIFF
--- a/packages/core/auth-js/src/GoTrueClient.ts
+++ b/packages/core/auth-js/src/GoTrueClient.ts
@@ -2676,6 +2676,11 @@ export default class GoTrueClient {
   private async _acquireLock<R>(acquireTimeout: number, fn: () => Promise<R>): Promise<R> {
     this._debug('#_acquireLock', 'begin', acquireTimeout)
 
+    // Safety mechanism: Prevent infinite deadlocks by capping the wait time to 15 seconds.
+    // If the lock cannot be acquired, it will throw a LockAcquireTimeoutError, allowing 
+    // the application to catch the error and recover gracefully instead of hanging forever.
+    const safeTimeout = acquireTimeout === -1 ? 15000 : acquireTimeout
+
     try {
       if (this.lockAcquired) {
         const last = this.pendingInLock.length
@@ -2700,7 +2705,7 @@ export default class GoTrueClient {
         return result
       }
 
-      return await this.lock(`lock:${this.storageKey}`, acquireTimeout, async () => {
+      return await this.lock(`lock:${this.storageKey}`, safeTimeout, async () => {
         this._debug('#_acquireLock', 'lock acquired for storage key', this.storageKey)
 
         try {


### PR DESCRIPTION
## What does this PR do?

Resolves #2013.

Currently, the \GoTrueClient\ utilizes \_acquireLock(-1, ...)\ for several core authentication methods, passing \-1\ to instruct the lock manager (\
avigator.locks\) to wait indefinitely. Under certain conditions—such as severe storage contention, reentrancy conflicts, or cross-tab lock anomalies—the lock acquisition never completes. This results in the authentication promise hanging completely silently, freezing the user interface and preventing any recovery without throwing an error.

This PR introduces a **safety mechanism** inside \_acquireLock\. Instead of allowing infinite deadlocks, we now enforce a default \safeTimeout\ of \15000\ ms (15 seconds) whenever an infinite timeout (\-1\) is requested.

## Why is this important?

* **Eliminates Infinite Hangs:** If the lock cannot be acquired within 15 seconds, the lock manager's \AbortController\ will fire.
* **Graceful Failure:** The promise will now cleanly reject with a \LockAcquireTimeoutError\ instead of freezing the browser. This allows the host application (e.g., React, Vue) to catch the exception, stop loading spinners, and prompt the user to retry or refresh the page.
* **Backwards Compatible:** Still gives \
avigator.locks\ a massive 15-second window to resolve cross-tab syncing, which is more than enough time for any legitimate storage operation to complete.

## Implementation Details
- Injected \const safeTimeout = acquireTimeout === -1 ? 15000 : acquireTimeout;\ in \_acquireLock\.
- Updated the \	his.lock\ call to utilize \safeTimeout\, ensuring \
avigatorLock\'s abort controller is active and armed to prevent indefinite blocking.

### Assistance Disclosure
Just wanted to mention that I used Antigravity (a Gemini-based AI coding assistant) to help untangle the \
avigator.locks\ logic and prevent this deadlock. I've fully reviewed and tested the resulting code to make sure it is correct.