### PR TITLE
ci(ci): pin windows runner and migrate github app token to client-id

### DIFF
--- a/.github/workflows/ci-supabase-js.yml
+++ b/.github/workflows/ci-supabase-js.yml
@@ -58,7 +58,7 @@ jobs:
     strategy:
       matrix:
         node: [22]
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-2025-vs2026]
       fail-fast: false
     steps:
       - name: Checkout code

--- a/.github/workflows/deprecate-version.yml
+++ b/.github/workflows/deprecate-version.yml
@@ -27,7 +27,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.APP_CLIENT_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
 
       - name: Check if actor is member of admin or sdk team

--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -46,14 +46,14 @@ jobs:
         id: app-token-member-check
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.APP_CLIENT_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
 
       - name: Generate token for dogfood
         id: app-token-dogfood
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.DOGFOOD_APP_ID }}
+          client-id: ${{ secrets.DOGFOOD_APP_CLIENT_ID }}
           private-key: ${{ secrets.DOGFOOD_APP_PRIVATE_KEY }}
           owner: supabase
           repositories: supabase,multiplayer.dev,platform,tests,realtime,ssr,helper-scripts,dbdev

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,7 +48,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.APP_CLIENT_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
       - name: Check if actor is member of admin or sdk team
         id: team-check
@@ -185,7 +185,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.APP_CLIENT_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
           owner: supabase
           repositories: supabase, supabase-js
@@ -219,7 +219,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.APP_CLIENT_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
 
       - name: Check if actor is member of admin or sdk team
@@ -331,7 +331,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.APP_CLIENT_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
 
       - name: Check if actor is member of admin or sdk team
@@ -468,7 +468,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.APP_CLIENT_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
 
       - name: Checkout code

--- a/.github/workflows/revert-commit.yml
+++ b/.github/workflows/revert-commit.yml
@@ -53,7 +53,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.APP_CLIENT_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
           repositories: ${{ github.event.repository.name }}
 


### PR DESCRIPTION
Address two GitHub Actions deprecation notices surfaced on recent runs, and document why the upcoming GitHub App installation token format change is a no-op for this repo.

- Pin the Windows runner: `windows-latest` is being redirected to `windows-2025-vs2026` on June 15, 2026. Pinning explicitly in `ci-supabase-js.yml` avoids a silent image flip on the redirect date.
- Migrate `actions/create-github-app-token` from the deprecated `app-id` input to `client-id` across 9 call sites in 4 workflows (`deprecate-version`, `dogfood`, `publish`, `revert-commit`).
- New secrets `APP_CLIENT_ID` and `DOGFOOD_APP_CLIENT_ID` must be added in repo settings before merge. They hold each GitHub App's Client ID (string like `Iv23...`), which is a different value than the numeric App ID. `PRIVATE_KEY` / `DOGFOOD_APP_PRIVATE_KEY` are unchanged. Old `APP_ID` / `DOGFOOD_APP_ID` can be removed after one green canary run.
- Upcoming `ghs_...` installation token format (~520 chars): checked all workflows and scripts. No length assumptions or string slicing on tokens, so no code change is required.