### PR TITLE
fix(auth): recognize ?error= redirects in implicit grant gate

### DIFF
--- a/packages/core/auth-js/src/GoTrueClient.ts
+++ b/packages/core/auth-js/src/GoTrueClient.ts
@@ -3724,7 +3724,9 @@ export default class GoTrueClient {
     if (typeof this.detectSessionInUrl === 'function') {
       return this.detectSessionInUrl(new URL(window.location.href), params)
     }
-    return Boolean(params.access_token || params.error_description)
+    return Boolean(
+      params.access_token || params.error || params.error_description || params.error_code
+    )
   }
 
   /**

--- a/packages/core/auth-js/test/GoTrueClient.test.ts
+++ b/packages/core/auth-js/test/GoTrueClient.test.ts
@@ -3305,6 +3305,20 @@ describe('Storage adapter edge cases', () => {
     const client = getClientWithSpecificStorage(memoryLocalStorageAdapter())
     // @ts-expect-error private method
     expect(client._isImplicitGrantCallback({})).toBe(false)
+    // @ts-expect-error private method
+    expect(client._isImplicitGrantCallback({ foo: 'bar' })).toBe(false)
+  })
+
+  test('should return true for _isImplicitGrantCallback when auth params are present', () => {
+    const client = getClientWithSpecificStorage(memoryLocalStorageAdapter())
+    // @ts-expect-error private method
+    expect(client._isImplicitGrantCallback({ access_token: 'token' })).toBe(true)
+    // @ts-expect-error private method
+    expect(client._isImplicitGrantCallback({ error: 'access_denied' })).toBe(true)
+    // @ts-expect-error private method
+    expect(client._isImplicitGrantCallback({ error_description: 'expired' })).toBe(true)
+    // @ts-expect-error private method
+    expect(client._isImplicitGrantCallback({ error_code: 'otp_expired' })).toBe(true)
   })
 
   test('should return false for _isPKCECallback with missing params', async () => {


### PR DESCRIPTION
`_isImplicitGrantCallback` only checked `access_token` or `error_description`, so redirects with just `error=access_denied` (no description, no code) were silently dropped. RFC 6749 §4.1.2.1 makes `error_description` optional, and _getSessionFromURL already handles error/error_code/error_description uniformly, align the gate with the inner check.