### PR TITLE
feat(realtime): support new select field for postgres changes

### DIFF
--- a/packages/core/realtime-js/src/RealtimeChannel.ts
+++ b/packages/core/realtime-js/src/RealtimeChannel.ts
@@ -123,6 +123,11 @@ export type RealtimePostgresChangesFilter<T extends `${REALTIME_POSTGRES_CHANGES
    * Receive database changes when filter is matched.
    */
   filter?: string
+  /**
+   * Receive only the specified columns in the change payload.
+   * Primary key columns are always included.
+   */
+  select?: string[]
 }
 
 export type RealtimeChannelSendResponse = 'ok' | 'timed out' | 'error' | (string & {})
@@ -157,6 +162,7 @@ type PostgresChangesFilters = {
     schema?: string
     table?: string
     filter?: string
+    select?: string[]
   }[]
 }
 
@@ -286,7 +292,11 @@ export default class RealtimeChannel {
         config: { broadcast, presence, private: isPrivate },
       } = this.params
 
-      const postgres_changes = this.bindings.postgres_changes?.map((r) => r.filter) ?? []
+      const postgres_changes =
+        this.bindings.postgres_changes?.map((r) => {
+          const { select, ...rest } = r.filter
+          return select?.length ? { ...rest, select } : rest
+        }) ?? []
 
       const presence_enabled =
         (!!this.bindings[REALTIME_LISTEN_TYPES.PRESENCE] &&
@@ -351,7 +361,7 @@ export default class RealtimeChannel {
     for (let i = 0; i < bindingsLen; i++) {
       const clientPostgresBinding = clientPostgresBindings[i]
       const {
-        filter: { event, schema, table, filter },
+        filter: { event, schema, table, filter, select },
       } = clientPostgresBinding
       const serverPostgresFilter = postgres_changes && postgres_changes[i]
 
@@ -360,7 +370,8 @@ export default class RealtimeChannel {
         serverPostgresFilter.event === event &&
         RealtimeChannel.isFilterValueEqual(serverPostgresFilter.schema, schema) &&
         RealtimeChannel.isFilterValueEqual(serverPostgresFilter.table, table) &&
-        RealtimeChannel.isFilterValueEqual(serverPostgresFilter.filter, filter)
+        RealtimeChannel.isFilterValueEqual(serverPostgresFilter.filter, filter) &&
+        RealtimeChannel.isSelectValueEqual(serverPostgresFilter.select, select)
       ) {
         newPostgresBindings.push({
           ...clientPostgresBinding,
@@ -714,7 +725,7 @@ export default class RealtimeChannel {
    */
   on(
     type: `${REALTIME_LISTEN_TYPES}`,
-    filter: { event: string; [key: string]: string },
+    filter: { event: string; [key: string]: string | string[] | undefined },
     callback: (payload: any) => void
   ): RealtimeChannel {
     const stateCheck = this.channelAdapter.isJoined() || this.channelAdapter.isJoining()
@@ -1102,6 +1113,25 @@ export default class RealtimeChannel {
     const normalizedServer = serverValue ?? undefined
     const normalizedClient = clientValue ?? undefined
     return normalizedServer === normalizedClient
+  }
+
+  /**
+   * Compares two optional select column arrays for equality (order-independent).
+   * Treats undefined, null, and empty arrays as equivalent empty values.
+   * @internal
+   */
+  private static isSelectValueEqual(
+    serverValue: string[] | undefined | null,
+    clientValue: string[] | undefined
+  ): boolean {
+    if (!Array.isArray(serverValue)) serverValue = undefined
+    const normalizedServer = serverValue?.length ? serverValue : undefined
+    const normalizedClient = clientValue?.length ? clientValue : undefined
+    if (normalizedServer === undefined && normalizedClient === undefined) return true
+    if (normalizedServer === undefined || normalizedClient === undefined) return false
+    return (
+      JSON.stringify([...normalizedServer].sort()) === JSON.stringify([...normalizedClient].sort())
+    )
   }
 
   /** @internal */

--- a/packages/core/realtime-js/test/RealtimeChannel.postgres.test.ts
+++ b/packages/core/realtime-js/test/RealtimeChannel.postgres.test.ts
@@ -646,3 +646,137 @@ describe('PostgreSQL payload transformation', () => {
     expect(deletePayload.old).toStrictEqual({ id: 2, name: 'deleted' })
   })
 })
+
+describe('PostgreSQL select column filtering', () => {
+  test('should include select in subscription payload sent to server', () => {
+    channel.on(
+      'postgres_changes',
+      { event: 'INSERT', schema: 'public', table: 'users', select: ['id', 'name'] },
+      vi.fn()
+    )
+
+    expect(channel.bindings.postgres_changes[0].filter.select).toStrictEqual(['id', 'name'])
+  })
+
+  test('should successfully subscribe when server echoes back matching select', async () => {
+    const callbackSpy = vi.fn()
+
+    channel.on(
+      'postgres_changes',
+      { event: 'INSERT', schema: 'public', table: 'users', select: ['id', 'name'] },
+      callbackSpy
+    )
+
+    channel.subscribe()
+
+    const serverResponse = {
+      postgres_changes: [
+        { event: 'INSERT', schema: 'public', table: 'users', select: ['id', 'name'], id: 'srv-1' },
+      ],
+    }
+
+    testSetup.mockServer.emit('message', phxJoinReply(channel, serverResponse))
+
+    await waitForChannelSubscribed(channel)
+    expect(channel.bindings.postgres_changes[0].id).toBe('srv-1')
+  })
+
+  test('should match select regardless of column order', async () => {
+    const callbackSpy = vi.fn()
+
+    channel.on(
+      'postgres_changes',
+      { event: 'INSERT', schema: 'public', table: 'users', select: ['name', 'id'] },
+      callbackSpy
+    )
+
+    channel.subscribe()
+
+    const serverResponse = {
+      postgres_changes: [
+        { event: 'INSERT', schema: 'public', table: 'users', select: ['id', 'name'], id: 'srv-1' },
+      ],
+    }
+
+    testSetup.mockServer.emit('message', phxJoinReply(channel, serverResponse))
+
+    await waitForChannelSubscribed(channel)
+    expect(channel.bindings.postgres_changes[0].id).toBe('srv-1')
+  })
+
+  test('should error when server rejects join due to invalid select column', async () => {
+    const errorCallbackSpy = vi.fn()
+
+    channel.on(
+      'postgres_changes',
+      { event: 'INSERT', schema: 'public', table: 'users', select: ['nonexistent_column'] },
+      vi.fn()
+    )
+
+    channel.subscribe(errorCallbackSpy)
+
+    testSetup.mockServer.emit(
+      'message',
+      phxJoinReply(channel, 'column nonexistent_column does not exist', 'error')
+    )
+
+    expect(errorCallbackSpy).toHaveBeenCalledWith('CHANNEL_ERROR', expect.any(Error))
+    expect(channel.state).toBe(CHANNEL_STATES.errored)
+  })
+
+  test('should match when both client and server omit select', async () => {
+    const callbackSpy = vi.fn()
+
+    channel.on(
+      'postgres_changes',
+      { event: 'INSERT', schema: 'public', table: 'users' },
+      callbackSpy
+    )
+
+    channel.subscribe()
+
+    const serverResponse = {
+      postgres_changes: [{ event: 'INSERT', schema: 'public', table: 'users', id: 'srv-1' }],
+    }
+
+    testSetup.mockServer.emit('message', phxJoinReply(channel, serverResponse))
+
+    await waitForChannelSubscribed(channel)
+    expect(channel.bindings.postgres_changes[0].id).toBe('srv-1')
+  })
+
+  test('should receive only selected columns in payload', () => {
+    const callbackSpy = vi.fn()
+
+    channel.on(
+      'postgres_changes',
+      { event: 'INSERT', schema: 'public', table: 'users', select: ['id', 'name'] },
+      callbackSpy
+    )
+    channel.bindings.postgres_changes[0].id = 'srv-1'
+
+    channel.channelAdapter.getChannel().trigger(
+      'postgres_changes',
+      {
+        ids: ['srv-1'],
+        data: {
+          type: 'INSERT',
+          schema: 'public',
+          table: 'users',
+          commit_timestamp: '2023-01-01T00:00:00Z',
+          errors: [],
+          columns: [
+            { name: 'id', type: 'int4' },
+            { name: 'name', type: 'text' },
+          ],
+          record: { id: 1, name: 'Alice' },
+        },
+      },
+      '1'
+    )
+
+    expect(callbackSpy).toHaveBeenCalledTimes(1)
+    const payload = callbackSpy.mock.calls[0][0]
+    expect(payload.new).toStrictEqual({ id: 1, name: 'Alice' })
+  })
+})


### PR DESCRIPTION

## 🔍 Description

Support new `select` to limit the columns sent by Realtime Postgres Changes to connected channels 

### What changed?

* Added new field to the payload for `phx_join`

### Why was this change needed?

Supporting a new feature from Realtime that allows users to send less data over the wire

## 📋 Checklist

<!-- Ensure all items are checked before submitting -->

- [X] I have read the [Contributing Guidelines](https://github.com/supabase/supabase-js/blob/master/CONTRIBUTING.md)
- [X] My PR title follows the [conventional commit format](https://www.conventionalcommits.org/): `<type>(<scope>): <description>`
- [X] I have run `pnpm nx format` to ensure consistent code formatting
- [X] I have added tests for new functionality (if applicable)
- [x] I have updated documentation (if applicable)

