### PR TITLE
docs(supabase): sync Jaeger tracing example with test script

### DIFF
--- a/test-tracing/README.md
+++ b/test-tracing/README.md
@@ -116,18 +116,22 @@ To see traces in a real observability backend:
      jaegertracing/all-in-one:latest
    ```
 
-2. Create `test-with-jaeger.js`:
+2. Use the included `test-with-jaeger.js` script:
 
    ```javascript
    import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http'
-   import { NodeSDK } from '@opentelemetry/sdk-node'
-   import { Resource } from '@opentelemetry/resources'
-   import { ATTR_SERVICE_NAME } from '@opentelemetry/semantic-conventions'
+   import otelSdk from '@opentelemetry/sdk-node'
+   import otelResources from '@opentelemetry/resources'
+   import otelSemconv from '@opentelemetry/semantic-conventions'
    import { createClient } from '@supabase/supabase-js'
    import { trace } from '@opentelemetry/api'
 
+   const { NodeSDK } = otelSdk
+   const { resourceFromAttributes } = otelResources
+   const { ATTR_SERVICE_NAME } = otelSemconv
+
    const sdk = new NodeSDK({
-     resource: new Resource({
+     resource: resourceFromAttributes({
        [ATTR_SERVICE_NAME]: 'supabase-trace-test',
      }),
      traceExporter: new OTLPTraceExporter({
@@ -142,7 +146,7 @@ To see traces in a real observability backend:
    const tracer = trace.getTracer('test')
 
    await tracer.startActiveSpan('database-query', async (span) => {
-     const { data, error } = await supabase.from('your_table').select('*').limit(10)
+     const { data, error } = await supabase.from('testtable').select('*').limit(10)
 
      console.log('Query completed:', data ? 'success' : 'error')
      span.end()


### PR DESCRIPTION
<!-- Your PR title should follow the conventional commit format:
<type>(<scope>): <description> -->

## 🔍 Description

This PR is intended to update the `test-tracing` Jaeger example so the README matches the included runnable `test-with-jaeger.js` script.

### What changed?

- Changed the README instruction from creating a separate `test-with-jaeger.js` file to using the included script.
- Updated the OpenTelemetry imports in the README example to match the script’s current namespace-import style.
- Replaced `new Resource(...)` with `resourceFromAttributes(...)`.
- Updated the example table name from `your_table` to `testtable`, matching `test-with-jaeger.js`.

### Why was this change needed?

The README example was no longer in sync with the runnable script in `test-tracing/test-with-jaeger.js`. Users following the README could copy stale OpenTelemetry resource setup code. The table name was also updated to reflect the name referenced in the included script.

## 📸 Screenshots/Examples

Before, the README showed:

```js
import { Resource } from '@opentelemetry/resources'

resource: new Resource({
  [ATTR_SERVICE_NAME]: 'supabase-trace-test',
})

await supabase.from('your_table').select('*').limit(10)
```

After, it matches the included script:

```js
import otelResources from '@opentelemetry/resources'

const { resourceFromAttributes } = otelResources

resource: resourceFromAttributes({
  [ATTR_SERVICE_NAME]: 'supabase-trace-test',
})

await supabase.from('testtable').select('*').limit(10)
```

## 🔄 Breaking changes

- [x] This PR contains no breaking changes

## 📋 Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/supabase/supabase-js/blob/master/CONTRIBUTING.md)
- [x] My PR title follows the [conventional commit format](https://www.conventionalcommits.org/): `<type>(<scope>): <description>`
- [x] I have run `pnpm nx format` to ensure consistent code formatting
- [x] I have added tests for new functionality (if applicable)
- [x] I have updated documentation (if applicable)

## 📝 Additional notes

Validation performed:

```bash
npx --yes pnpm@11.1.2 nx format:check
npx --yes pnpm@11.1.2 nx affected --target=build
npx --yes pnpm@11.1.2 nx affected --target=docs:json
git diff --check
```

Runtime validation of the documented Jaeger path:

```bash
docker run -d --name compair-supabase-js-jaeger-test \
  -e COLLECTOR_OTLP_ENABLED=true \
  -p 16686:16686 \
  -p 4318:4318 \
  jaegertracing/all-in-one:latest

cd test-tracing
SUPABASE_URL=http://127.0.0.1:54329 SUPABASE_KEY=test-key npm run test:jaeger
```

The script completed successfully, and Jaeger reported the supabase-trace-test service via:

```bash
curl -s http://127.0.0.1:16686/api/services
```