### PR TITLE
feat(supabase): rename env to runtime and add runtime-version in X-Client-Info

### DIFF
--- a/packages/core/supabase-js/src/lib/constants.ts
+++ b/packages/core/supabase-js/src/lib/constants.ts
@@ -4,18 +4,30 @@ import { SupabaseAuthClientOptions } from './types'
 import { version } from './version'
 
 let JS_ENV = ''
+let JS_RUNTIME_VERSION: string | undefined
 // @ts-ignore
 if (typeof Deno !== 'undefined') {
   JS_ENV = 'deno'
+  // @ts-ignore
+  JS_RUNTIME_VERSION = Deno.version?.deno
 } else if (typeof document !== 'undefined') {
   JS_ENV = 'web'
 } else if (typeof navigator !== 'undefined' && navigator.product === 'ReactNative') {
   JS_ENV = 'react-native'
 } else {
   JS_ENV = 'node'
+  JS_RUNTIME_VERSION =
+    typeof process !== 'undefined' ? process.version?.replace(/^v/, '') : undefined
 }
 
-export const DEFAULT_HEADERS = { 'X-Client-Info': `supabase-js/${version}; env=${JS_ENV}` }
+const _runtimeMeta = [`runtime=${JS_ENV}`]
+if (JS_RUNTIME_VERSION) {
+  _runtimeMeta.push(`runtime-version=${JS_RUNTIME_VERSION}`)
+}
+
+export const DEFAULT_HEADERS = {
+  'X-Client-Info': `supabase-js/${version}; ${_runtimeMeta.join('; ')}`,
+}
 
 export const DEFAULT_GLOBAL_OPTIONS = {
   headers: DEFAULT_HEADERS,

--- a/packages/core/supabase-js/test/unit/constants.test.ts
+++ b/packages/core/supabase-js/test/unit/constants.test.ts
@@ -33,7 +33,7 @@ describe('constants', () => {
 
   test('DEFAULT_HEADERS should contain X-Client-Info', () => {
     expect(DEFAULT_HEADERS).toHaveProperty('X-Client-Info')
-    expect(DEFAULT_HEADERS['X-Client-Info']).toMatch(/^supabase-js\/.*; env=.*$/)
+    expect(DEFAULT_HEADERS['X-Client-Info']).toMatch(/^supabase-js\/.*; runtime=.*$/)
   })
 
   test('DEFAULT_GLOBAL_OPTIONS should contain headers', () => {
@@ -63,13 +63,25 @@ describe('constants', () => {
 
   describe('JS_ENV detection', () => {
     test('should detect Deno environment', () => {
+      ;(global as any).Deno = { version: { deno: '1.37.0' } }
+
+      // Re-import to trigger the detection logic
+      jest.resetModules()
+      const { DEFAULT_HEADERS: newHeaders } = require('../../src/lib/constants')
+
+      expect(newHeaders['X-Client-Info']).toContain('runtime=deno')
+      expect(newHeaders['X-Client-Info']).toContain('runtime-version=1.37.0')
+    })
+
+    test('should detect Deno environment without version', () => {
       ;(global as any).Deno = {}
 
       // Re-import to trigger the detection logic
       jest.resetModules()
       const { DEFAULT_HEADERS: newHeaders } = require('../../src/lib/constants')
 
-      expect(newHeaders['X-Client-Info']).toContain('env=deno')
+      expect(newHeaders['X-Client-Info']).toContain('runtime=deno')
+      expect(newHeaders['X-Client-Info']).not.toContain('runtime-version=')
     })
 
     test('should detect web environment', () => {
@@ -79,7 +91,8 @@ describe('constants', () => {
       jest.resetModules()
       const { DEFAULT_HEADERS: newHeaders } = require('../../src/lib/constants')
 
-      expect(newHeaders['X-Client-Info']).toContain('env=web')
+      expect(newHeaders['X-Client-Info']).toContain('runtime=web')
+      expect(newHeaders['X-Client-Info']).not.toContain('runtime-version=')
     })
 
     test('should detect React Native environment', () => {
@@ -89,17 +102,19 @@ describe('constants', () => {
       jest.resetModules()
       const { DEFAULT_HEADERS: newHeaders } = require('../../src/lib/constants')
 
-      expect(newHeaders['X-Client-Info']).toContain('env=react-native')
+      expect(newHeaders['X-Client-Info']).toContain('runtime=react-native')
+      expect(newHeaders['X-Client-Info']).not.toContain('runtime-version=')
     })
 
-    test('should default to node environment when no specific environment is detected', () => {
-      // No globals set
+    test('should default to node environment with process version', () => {
+      // No globals set - falls through to node branch
 
       // Re-import to trigger the detection logic
       jest.resetModules()
       const { DEFAULT_HEADERS: newHeaders } = require('../../src/lib/constants')
 
-      expect(newHeaders['X-Client-Info']).toContain('env=node')
+      expect(newHeaders['X-Client-Info']).toContain('runtime=node')
+      expect(newHeaders['X-Client-Info']).toMatch(/runtime-version=\d+\.\d+\.\d+/)
     })
   })
 })


### PR DESCRIPTION
## Summary

Builds on top of #2359 (the structured `X-Client-Info` metadata initiative, SDK-902/903).

Two changes:
1. Renames the `env` key to `runtime` per the updated spec
2. Adds a `runtime-version` field where the version can be deterministically extracted at module load time

## Before / After

| Environment | Before (#2359) | After (this PR) |
|---|---|---|
| Node 22 | `supabase-js/2.x.x; env=node` | `supabase-js/2.x.x; runtime=node; runtime-version=22.13.1` |
| Deno 1.37 | `supabase-js/2.x.x; env=deno` | `supabase-js/2.x.x; runtime=deno; runtime-version=1.37.0` |
| Browser | `supabase-js/2.x.x; env=web` | `supabase-js/2.x.x; runtime=web` |
| React Native | `supabase-js/2.x.x; env=react-native` | `supabase-js/2.x.x; runtime=react-native` |

## Runtime version extraction

- **Node.js**: `process.version` with the leading `v` stripped (e.g. `22.13.1`)
- **Deno**: `Deno.version.deno` (e.g. `1.37.0`)
- **Web / React Native**: omitted — no deterministic version available

## Changes

- **`packages/core/supabase-js/src/lib/constants.ts`**: renamed `env` → `runtime`, added `JS_RUNTIME_VERSION` extraction for Node and Deno
- **`packages/core/supabase-js/test/unit/constants.test.ts`**: updated all assertions; added Deno-with-version test and negative `runtime-version` assertions for web and React Native

## Type of Change

- [x] New feature (feat)

## Testing

- [x] Unit tests added/updated
- [ ] All tests pass locally — the `jest-runtime@30.4.2` / `clearMocksOnScope` error is pre-existing and unrelated to this change (reproduced on master before any edits)

## Checklist

- [x] Code formatted
- [x] TypeScript type-check passes (`tsc --noEmit`)
- [x] Uses conventional commits

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)