### PR TITLE
fix(postgrest): pass request headers as plain object for RN/custom-fetch compatibility

### DIFF
--- a/packages/core/postgrest-js/src/PostgrestBuilder.ts
+++ b/packages/core/postgrest-js/src/PostgrestBuilder.ts
@@ -305,9 +305,10 @@ export default abstract class PostgrestBuilder<
 
       while (true) {
         // Serialize headers as a plain object rather than a Headers instance.
-        // Some fetch implementations (notably React Native's whatwg-fetch polyfill)
-        // mishandle Headers instances and silently drop Content-Type, which causes
-        // PostgREST to misinterpret the request body. See supabase/supabase-js#1562.
+        // React Native's XHR-based fetch silently drops headers (notably Content-Type)
+        // when given a Headers instance, causing PGRST202 on parameter-less RPC calls.
+        // See supabase/supabase-js#1562 and facebook/react-native#33933.
+        // All sibling packages (auth-js, storage-js, functions-js) already pass plain objects.
         const headers: Record<string, string> = {}
         this.headers.forEach((value, key) => {
           headers[key] = value

--- a/packages/core/postgrest-js/src/PostgrestBuilder.ts
+++ b/packages/core/postgrest-js/src/PostgrestBuilder.ts
@@ -304,9 +304,16 @@ export default abstract class PostgrestBuilder<
       let attemptCount = 0
 
       while (true) {
-        const requestHeaders = new Headers(this.headers)
+        // Serialize headers as a plain object rather than a Headers instance.
+        // Some fetch implementations (notably React Native's whatwg-fetch polyfill)
+        // mishandle Headers instances and silently drop Content-Type, which causes
+        // PostgREST to misinterpret the request body. See supabase/supabase-js#1562.
+        const headers: Record<string, string> = {}
+        this.headers.forEach((value, key) => {
+          headers[key] = value
+        })
         if (attemptCount > 0) {
-          requestHeaders.set('X-Retry-Count', String(attemptCount))
+          headers['X-Retry-Count'] = String(attemptCount)
         }
 
         // Only wrap the fetch call itself — processResponse errors must never trigger retries
@@ -314,7 +321,7 @@ export default abstract class PostgrestBuilder<
         try {
           res = await _fetch(this.url.toString(), {
             method: this.method,
-            headers: requestHeaders,
+            headers,
             body: JSON.stringify(this.body, (_, value) =>
               typeof value === 'bigint' ? value.toString() : value
             ),

--- a/packages/core/postgrest-js/test/basic.test.ts
+++ b/packages/core/postgrest-js/test/basic.test.ts
@@ -2176,7 +2176,7 @@ test('uses native fetch when no custom fetch provided', async () => {
     expect.stringContaining(REST_URL),
     expect.objectContaining({
       method: 'GET',
-      headers: expect.any(Headers),
+      headers: expect.any(Object),
     })
   )
 

--- a/packages/core/postgrest-js/test/fetch-errors.test.ts
+++ b/packages/core/postgrest-js/test/fetch-errors.test.ts
@@ -186,7 +186,7 @@ describe('Fetch error handling', () => {
     const [_url, options] = mockFetch.mock.calls[0]
     expect(options.method).toBe('POST')
     expect(JSON.parse(options.body)).toEqual({ obj_arg: { nested: 'value' } })
-    expect(options.headers.get('Prefer')).toContain('return=minimal')
+    expect(options.headers['prefer']).toContain('return=minimal')
   })
 
   test('PostgrestError serializes message with JSON.stringify', () => {

--- a/packages/core/postgrest-js/test/headers-serialization.test.ts
+++ b/packages/core/postgrest-js/test/headers-serialization.test.ts
@@ -1,0 +1,30 @@
+import { PostgrestClient } from '../src/index'
+
+const REST_URL = 'http://localhost:3000'
+
+test('passes headers to fetch as a plain object so custom/polyfilled fetches can read them by key', async () => {
+  const mockFetch = jest.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    headers: new Headers(),
+    text: async () => '{}',
+  })
+
+  const client = new PostgrestClient(REST_URL, {
+    fetch: mockFetch as any,
+    headers: { 'X-Custom-Header': 'CustomValue' },
+  })
+
+  await client.rpc('test_func')
+
+  const [, options] = mockFetch.mock.calls[0] as [string, RequestInit]
+  const headers = options.headers as Record<string, string>
+
+  // Plain-object key access works (would require .get() on a Headers instance).
+  // This is what protects React Native's whatwg-fetch polyfill from silently
+  // dropping Content-Type and causing PGRST202 on parameter-less RPC calls.
+  expect(headers['content-type']).toBe('application/json')
+  expect(headers['x-custom-header']).toBe('CustomValue')
+  expect(options.body).toBe('{}')
+})

--- a/packages/core/postgrest-js/test/retry.test.ts
+++ b/packages/core/postgrest-js/test/retry.test.ts
@@ -74,12 +74,12 @@ describe('Automatic Retries', () => {
 
       // Verify X-Retry-Count header was sent on retries
       const [, firstRetryCall] = fetchMock.mock.calls
-      const firstRetryHeaders = firstRetryCall[1].headers as Headers
-      expect(firstRetryHeaders.get('X-Retry-Count')).toBe('1')
+      const firstRetryHeaders = firstRetryCall[1].headers as Record<string, string>
+      expect(firstRetryHeaders['X-Retry-Count']).toBe('1')
 
       const [, , secondRetryCall] = fetchMock.mock.calls
-      const secondRetryHeaders = secondRetryCall[1].headers as Headers
-      expect(secondRetryHeaders.get('X-Retry-Count')).toBe('2')
+      const secondRetryHeaders = secondRetryCall[1].headers as Record<string, string>
+      expect(secondRetryHeaders['X-Retry-Count']).toBe('2')
     })
 
     it('should NOT retry POST requests even on 520 errors', async () => {


### PR DESCRIPTION
## Summary

Passes request headers to the user-supplied `fetch` as a plain object instead of a `Headers` instance. Picks up the intent of #2017 from @dev-hari-prasad with a minimal, focused change.

## Why

React Native's XHR-based `fetch` polyfill (whatwg-fetch) silently drops headers — most notably `Content-Type` — when given a `Headers` instance. Without `Content-Type: application/json`, PostgREST cannot parse the JSON body, and a parameter-less `rpc()` call surfaces as a confusing `PGRST202` ("Searched for the function with a single unnamed text parameter").

See:

- supabase/supabase-js#1562 (the original bug report)
- facebook/react-native#33933 (upstream RN tracking issue)

## Alignment with sibling packages

The sibling clients have always handled headers as plain objects internally and at the `fetch` call site:

- `auth-js` — `src/lib/fetch.ts` spreads `{ 'Content-Type': '...', ...options?.headers }` into request params.
- `storage-js` — `BaseApiClient.headers: { [key: string]: string }`.
- `functions-js` — `FunctionsClient.headers: Record<string, string>`.

`postgrest-js` was the outlier: a previous refactor (postgrest-js#619, "chore: refactor in favor of Headers API") moved it to wrap headers in `new Headers(...)` at the fetch boundary, primarily to get ergonomic multi-value handling for the `Prefer` header.

This PR keeps that ergonomic win — the internal `this.headers` storage stays a `Headers` instance, so `Prefer` append-style construction continues to work as designed — and only flattens to a plain object **at the moment of the `_fetch()` call**. Wire-level behavior to PostgREST is unchanged on standard runtimes (native fetch normalizes either form); the change only affects what user-supplied fetch wrappers see.

## Behavior note for custom fetch consumers

Headers handed to a user-supplied `fetch` are now a plain `Record<string, string>` with lowercase keys (per `Headers.prototype.forEach` semantics). Wrappers that previously did `req.headers.get('Content-Type')` should switch to `req.headers['content-type']`.

## Tests

- New: `test/headers-serialization.test.ts` — asserts the request handed to a custom fetch has `content-type: application/json` reachable by plain-object key access (i.e. what the RN polyfill would see).
- Updated: `test/fetch-errors.test.ts`, `test/retry.test.ts`, `test/basic.test.ts` to reflect the plain-object shape on the wire.

Closes #1562.
