### PR TITLE
docs(repo): document error.hint as the most useful field on errors

### DIFF
--- a/packages/core/auth-js/src/GoTrueClient.ts
+++ b/packages/core/auth-js/src/GoTrueClient.ts
@@ -1116,6 +1116,21 @@ export default class GoTrueClient {
    *   password: 'some-password',
    * })
    * ```
+   *
+   * @exampleDescription Handling errors
+   * Log the full `error` object so fields like `code`, `status`, and `name` aren't hidden. The `error.code` (e.g. `'invalid_credentials'`, `'email_not_confirmed'`) is often more useful for branching than `error.message`, and the full object surfaces both.
+   *
+   * @example Handling errors
+   * ```js
+   * const { data, error } = await supabase.auth.signInWithPassword({
+   *   email: 'example@email.com',
+   *   password: 'example-password',
+   * })
+   * if (error) {
+   *   console.error(error)
+   *   return
+   * }
+   * ```
    */
   async signInWithPassword(
     credentials: SignInWithPasswordCredentials

--- a/packages/core/functions-js/src/FunctionsClient.ts
+++ b/packages/core/functions-js/src/FunctionsClient.ts
@@ -101,7 +101,7 @@ export class FunctionsClient {
    * ```
    *
    * @exampleDescription Error handling
-   * A `FunctionsHttpError` error is returned if your function throws an error, `FunctionsRelayError` if the Supabase Relay has an error processing your function and `FunctionsFetchError` if there is a network error in calling your function.
+   * A `FunctionsHttpError` error is returned if your function throws an error, `FunctionsRelayError` if the Supabase Relay has an error processing your function and `FunctionsFetchError` if there is a network error in calling your function. Log the full error object so fields like `name`, `context`, and any structured body aren't hidden.
    *
    * @example Error handling
    * ```js
@@ -116,11 +116,11 @@ export class FunctionsClient {
    *
    * if (error instanceof FunctionsHttpError) {
    *   const errorMessage = await error.context.json()
-   *   console.log('Function returned an error', errorMessage)
+   *   console.error('Function returned an error', errorMessage)
    * } else if (error instanceof FunctionsRelayError) {
-   *   console.log('Relay error:', error.message)
+   *   console.error('Relay error:', error)
    * } else if (error instanceof FunctionsFetchError) {
-   *   console.log('Fetch error:', error.message)
+   *   console.error('Fetch error:', error)
    * }
    * ```
    *

--- a/packages/core/postgrest-js/src/PostgrestError.ts
+++ b/packages/core/postgrest-js/src/PostgrestError.ts
@@ -1,17 +1,24 @@
 /**
  * Error format
  *
- * Returned by every PostgREST request that fails. When handling errors, prefer
- * logging the full object (e.g. `console.error(error)`) rather than just
- * `error.message` — the other fields often contain the actionable part.
+ * Returned by every PostgREST request that fails. When something fails, the
+ * single most useful field is usually `hint` — Postgres often returns the
+ * actionable fix there, not in `message`. Always log the full object (e.g.
+ * `console.error(error)`); logging only `error.message` hides the hint.
  *
- * - `message` — human-readable summary, usually from PostgreSQL or PostgREST.
- * - `code` — error code from PostgREST (e.g. `PGRST301`) or PostgreSQL (e.g. `42501`).
- * - `details` — extra context about what went wrong.
- * - `hint` — actionable guidance from the database when available. For example,
- *   permission-denied errors (`42501`) now arrive with hints like
- *   `"Grant the required privileges to the current role with: GRANT SELECT ON public.users TO anon;"`
- *   — the rest of the error message alone wouldn't tell you which role or grant is missing.
+ * Read the fields in roughly this order of usefulness:
+ *
+ * - `hint` — actionable guidance from the database when available. For
+ *   permission-denied errors (`42501`), this is the literal SQL to fix the
+ *   problem, e.g.
+ *   `"Grant the required privileges to the current role with: GRANT SELECT ON public.users TO anon;"`.
+ *   Missing column? `hint` suggests the column you probably meant. Whenever
+ *   Postgres knows the fix, it puts it in `hint`.
+ * - `code` — stable error code from PostgREST (e.g. `PGRST301`) or Postgres
+ *   (e.g. `42501`). Branch on this rather than on `message` text.
+ * - `details` — extra context, often the offending value, key, or row.
+ * - `message` — human-readable summary. Useful in UI strings; less useful
+ *   for debugging.
  *
  * {@link https://postgrest.org/en/stable/api.html?highlight=options#errors-and-http-status-codes}
  */

--- a/packages/core/postgrest-js/src/PostgrestError.ts
+++ b/packages/core/postgrest-js/src/PostgrestError.ts
@@ -1,6 +1,18 @@
 /**
  * Error format
  *
+ * Returned by every PostgREST request that fails. When handling errors, prefer
+ * logging the full object (e.g. `console.error(error)`) rather than just
+ * `error.message` — the other fields often contain the actionable part.
+ *
+ * - `message` — human-readable summary, usually from PostgreSQL or PostgREST.
+ * - `code` — error code from PostgREST (e.g. `PGRST301`) or PostgreSQL (e.g. `42501`).
+ * - `details` — extra context about what went wrong.
+ * - `hint` — actionable guidance from the database when available. For example,
+ *   permission-denied errors (`42501`) now arrive with hints like
+ *   `"Grant the required privileges to the current role with: GRANT SELECT ON public.users TO anon;"`
+ *   — the rest of the error message alone wouldn't tell you which role or grant is missing.
+ *
  * {@link https://postgrest.org/en/stable/api.html?highlight=options#errors-and-http-status-codes}
  */
 export default class PostgrestError extends Error {

--- a/packages/core/postgrest-js/src/PostgrestQueryBuilder.ts
+++ b/packages/core/postgrest-js/src/PostgrestQueryBuilder.ts
@@ -169,6 +169,33 @@ export default class PostgrestQueryBuilder<
      * }
      * ```
      *
+     * @exampleDescription Handling errors
+     * Log the full `error` object so fields like `hint` and `code` aren't hidden — `error.message` alone often omits the actionable part. For example, a permission-denied error (`code: '42501'`) arrives with a `hint` like `"Grant the required privileges to the current role with: GRANT SELECT ON public.characters TO anon;"` that tells you exactly which grant is missing.
+     *
+     * @example Handling errors
+     * ```js
+     * const { data, error } = await supabase.from('characters').select()
+     * if (error) {
+     *   // Logs the full error: message, code, details, and hint.
+     *   console.error(error)
+     *   return
+     * }
+     * ```
+     *
+     * @exampleResponse Handling errors
+     * ```json
+     * {
+     *   "error": {
+     *     "code": "42501",
+     *     "details": null,
+     *     "hint": "Grant the required privileges to the current role with: GRANT SELECT ON public.characters TO anon;",
+     *     "message": "permission denied for table characters"
+     *   },
+     *   "status": 401,
+     *   "statusText": "Unauthorized"
+     * }
+     * ```
+     *
      * @example Selecting specific columns
      * ```js
      * const { data, error } = await supabase
@@ -985,6 +1012,15 @@ export default class PostgrestQueryBuilder<
    * }
    * ```
    *
+   * @exampleDescription Handling errors
+   * Log the full `error` object — `error.hint` from the database often contains the actionable next step (e.g. `"Grant the required privileges to the current role with: GRANT INSERT ON public.countries TO anon;"` for a `42501` permission-denied error). Logging only `error.message` hides that.
+   *
+   * @example Handling errors
+   * ```js
+   * const { error } = await supabase.from('countries').insert({ id: 1, name: 'Mordor' })
+   * if (error) console.error(error)
+   * ```
+   *
    * @example Create a record and return it
    * ```ts
    * const { data, error } = await supabase
@@ -1226,6 +1262,15 @@ export default class PostgrestQueryBuilder<
    * }
    * ```
    *
+   * @exampleDescription Handling errors
+   * Log the full `error` object — `error.hint` from the database often contains the actionable next step (e.g. `"Grant the required privileges to the current role with: GRANT INSERT, UPDATE ON public.instruments TO anon;"` for a `42501` permission-denied error). Logging only `error.message` hides that.
+   *
+   * @example Handling errors
+   * ```js
+   * const { data, error } = await supabase.from('instruments').upsert({ id: 1, name: 'piano' }).select()
+   * if (error) console.error(error)
+   * ```
+   *
    * @example Bulk Upsert your data
    * ```ts
    * const { data, error } = await supabase
@@ -1428,6 +1473,15 @@ export default class PostgrestQueryBuilder<
    * }
    * ```
    *
+   * @exampleDescription Handling errors
+   * Log the full `error` object — `error.hint` from the database often contains the actionable next step (e.g. `"Grant the required privileges to the current role with: GRANT UPDATE ON public.instruments TO anon;"` for a `42501` permission-denied error). Logging only `error.message` hides that.
+   *
+   * @example Handling errors
+   * ```js
+   * const { error } = await supabase.from('instruments').update({ name: 'piano' }).eq('id', 1)
+   * if (error) console.error(error)
+   * ```
+   *
    * @example Update a record and return it
    * ```ts
    * const { data, error } = await supabase
@@ -1607,6 +1661,15 @@ export default class PostgrestQueryBuilder<
    *   "status": 204,
    *   "statusText": "No Content"
    * }
+   * ```
+   *
+   * @exampleDescription Handling errors
+   * Log the full `error` object — `error.hint` from the database often contains the actionable next step (e.g. `"Grant the required privileges to the current role with: GRANT DELETE ON public.countries TO anon;"` for a `42501` permission-denied error). Logging only `error.message` hides that.
+   *
+   * @example Handling errors
+   * ```js
+   * const { error } = await supabase.from('countries').delete().eq('id', 1)
+   * if (error) console.error(error)
    * ```
    *
    * @example Delete a record and return it

--- a/packages/core/postgrest-js/src/PostgrestQueryBuilder.ts
+++ b/packages/core/postgrest-js/src/PostgrestQueryBuilder.ts
@@ -170,7 +170,7 @@ export default class PostgrestQueryBuilder<
      * ```
      *
      * @exampleDescription Handling errors
-     * Log the full `error` object so fields like `hint` and `code` aren't hidden — `error.message` alone often omits the actionable part. For example, a permission-denied error (`code: '42501'`) arrives with a `hint` like `"Grant the required privileges to the current role with: GRANT SELECT ON public.characters TO anon;"` that tells you exactly which grant is missing.
+     * The most useful field on a Postgres error is usually `hint` — when the database knows the fix, it puts the literal SQL there. For example, a permission-denied error (`code: '42501'`) arrives with a `hint` like `"Grant the required privileges to the current role with: GRANT SELECT ON public.characters TO anon;"`. Log the full `error` object so the hint isn't hidden behind `error.message`.
      *
      * @example Handling errors
      * ```js
@@ -1013,7 +1013,7 @@ export default class PostgrestQueryBuilder<
    * ```
    *
    * @exampleDescription Handling errors
-   * Log the full `error` object — `error.hint` from the database often contains the actionable next step (e.g. `"Grant the required privileges to the current role with: GRANT INSERT ON public.countries TO anon;"` for a `42501` permission-denied error). Logging only `error.message` hides that.
+   * `error.hint` from Postgres often contains the actionable fix (e.g. `"Grant the required privileges to the current role with: GRANT INSERT ON public.countries TO anon;"` for a `42501` permission-denied error). Log the full `error` object so it isn't hidden behind `error.message`.
    *
    * @example Handling errors
    * ```js
@@ -1263,7 +1263,7 @@ export default class PostgrestQueryBuilder<
    * ```
    *
    * @exampleDescription Handling errors
-   * Log the full `error` object — `error.hint` from the database often contains the actionable next step (e.g. `"Grant the required privileges to the current role with: GRANT INSERT, UPDATE ON public.instruments TO anon;"` for a `42501` permission-denied error). Logging only `error.message` hides that.
+   * `error.hint` from Postgres often contains the actionable fix (e.g. `"Grant the required privileges to the current role with: GRANT INSERT, UPDATE ON public.instruments TO anon;"` for a `42501` permission-denied error). Log the full `error` object so it isn't hidden behind `error.message`.
    *
    * @example Handling errors
    * ```js
@@ -1474,7 +1474,7 @@ export default class PostgrestQueryBuilder<
    * ```
    *
    * @exampleDescription Handling errors
-   * Log the full `error` object — `error.hint` from the database often contains the actionable next step (e.g. `"Grant the required privileges to the current role with: GRANT UPDATE ON public.instruments TO anon;"` for a `42501` permission-denied error). Logging only `error.message` hides that.
+   * `error.hint` from Postgres often contains the actionable fix (e.g. `"Grant the required privileges to the current role with: GRANT UPDATE ON public.instruments TO anon;"` for a `42501` permission-denied error). Log the full `error` object so it isn't hidden behind `error.message`.
    *
    * @example Handling errors
    * ```js
@@ -1664,7 +1664,7 @@ export default class PostgrestQueryBuilder<
    * ```
    *
    * @exampleDescription Handling errors
-   * Log the full `error` object — `error.hint` from the database often contains the actionable next step (e.g. `"Grant the required privileges to the current role with: GRANT DELETE ON public.countries TO anon;"` for a `42501` permission-denied error). Logging only `error.message` hides that.
+   * `error.hint` from Postgres often contains the actionable fix (e.g. `"Grant the required privileges to the current role with: GRANT DELETE ON public.countries TO anon;"` for a `42501` permission-denied error). Log the full `error` object so it isn't hidden behind `error.message`.
    *
    * @example Handling errors
    * ```js

--- a/packages/core/realtime-js/src/RealtimeChannel.ts
+++ b/packages/core/realtime-js/src/RealtimeChannel.ts
@@ -271,8 +271,23 @@ export default class RealtimeChannel {
   }
 
   /**
-   * Subscribe registers your client with the server
+   * Subscribe registers your client with the server.
+   *
+   * The optional `callback` receives a `status` and, on failure, an `err` argument.
+   * Log the full `err` so its `cause`, `name`, and any structured fields aren't hidden
+   * behind `err.message`.
+   *
    * @category Realtime
+   *
+   * @example Handling errors
+   * ```js
+   * supabase.channel('room1').subscribe((status, err) => {
+   *   if (status === 'CHANNEL_ERROR' || status === 'TIMED_OUT') {
+   *     // Log the full error: its `cause` often holds the underlying reason.
+   *     console.error(status, err)
+   *   }
+   * })
+   * ```
    */
   subscribe(
     callback?: (status: REALTIME_SUBSCRIBE_STATES, err?: Error) => void,

--- a/packages/core/storage-js/src/packages/StorageFileApi.ts
+++ b/packages/core/storage-js/src/packages/StorageFileApi.ts
@@ -194,6 +194,21 @@ export default class StorageFileApi extends BaseApiClient<StorageError> {
    *   })
    * ```
    *
+   * @example Handling errors
+   * ```js
+   * const { data, error } = await supabase
+   *   .storage
+   *   .from('avatars')
+   *   .upload('public/avatar1.png', avatarFile)
+   *
+   * if (error) {
+   *   // Log the full error so fields like `statusCode` and `error` (the
+   *   // Storage error name, e.g. "Duplicate") aren't hidden behind `error.message`.
+   *   console.error(error)
+   *   return
+   * }
+   * ```
+   *
    * @remarks
    * - RLS policy permissions required:
    *   - `buckets` table permissions: none


### PR DESCRIPTION
Postgres + PostgREST return the actionable fix on permission errors via `error.hint` (for example, the exact `GRANT` statement to run for a `42501`), but most of our JSDoc examples logged only `error.message` and hid it.

Updates the `PostgrestError` class doc and the `@example Handling errors` blocks on postgrest-js CRUD methods (`select`, `insert`, `update`, `upsert`, `delete`) to lead with the `hint` field, plus matching examples in auth-js (`signInWithPassword`), storage-js (`upload`), functions-js (`invoke`, rewriting the existing relay/fetch branches to use `console.error(error)`), and realtime-js (`subscribe`).

Companion docs guide: supabase/supabase#46556.