### PR TITLE
fix(release): pin workspace:* sibling deps before JSR publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -459,6 +459,9 @@ jobs:
     concurrency:
       group: release-${{ github.ref }}
       cancel-in-progress: false
+    outputs:
+      partial_failure: ${{ steps.release.outputs.partial_failure }}
+      partial_failure_reason: ${{ steps.release.outputs.partial_failure_reason }}
     # Run on master branch pushes, only if all CI jobs succeeded
     if: |
       github.event_name == 'push' &&
@@ -536,6 +539,20 @@ jobs:
       SLACK_CLIENT_LIBS_WEBHOOK: ${{ secrets.SLACK_CLIENT_LIBS_WEBHOOK }}
     with:
       title: 'Canary Release'
+      status: 'failure'
+
+  # Fires when the canary job exits green but JSR or the gotrue-js legacy mirror
+  # publish failed. release-canary.ts swallows those errors so npm canary still
+  # ships; this notification ensures the breakage doesn't go silent for weeks.
+  notify-canary-partial-failure:
+    name: Notify Slack for Canary partial failure
+    needs: release-canary
+    if: ${{ always() && github.event_name == 'push' && needs.release-canary.result == 'success' && needs.release-canary.outputs.partial_failure == 'true' }}
+    uses: ./.github/workflows/slack-notify.yml
+    secrets:
+      SLACK_CLIENT_LIBS_WEBHOOK: ${{ secrets.SLACK_CLIENT_LIBS_WEBHOOK }}
+    with:
+      title: 'Canary Release (partial failure: ${{ needs.release-canary.outputs.partial_failure_reason }})'
       status: 'failure'
 
   notify-next-failure:

--- a/scripts/publish-to-jsr.ts
+++ b/scripts/publish-to-jsr.ts
@@ -29,6 +29,35 @@ function cleanupTracingSnapshot(packagePath: string, pkg: string): void {
   rmSync(join(packagePath, TRACING_INTERNAL_SUBPATH), { recursive: true, force: true })
 }
 
+// JSR rejects pnpm's `workspace:*` protocol as an unpinned npm specifier. Before
+// publishing, swap every `workspace:<range>` entry in package.json for the
+// package's own version (fixed-release mode means all siblings share it), then
+// restore the original file in the finally block.
+function rewriteWorkspaceDeps(packagePath: string, version: string): string {
+  const pkgJsonPath = join(packagePath, 'package.json')
+  const original = readFileSync(pkgJsonPath, 'utf-8')
+  const pkgJson = JSON.parse(original)
+  let touched = false
+  for (const section of ['dependencies', 'devDependencies'] as const) {
+    const deps = pkgJson[section]
+    if (!deps) continue
+    for (const [name, value] of Object.entries(deps)) {
+      if (typeof value === 'string' && value.startsWith('workspace:')) {
+        deps[name] = version
+        touched = true
+      }
+    }
+  }
+  if (touched) {
+    writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, 2) + '\n')
+  }
+  return original
+}
+
+function restorePackageJson(packagePath: string, original: string): void {
+  writeFileSync(join(packagePath, 'package.json'), original)
+}
+
 function getArg(name: string): string | undefined {
   const idx = process.argv.findIndex((a) => a === `--${name}` || a.startsWith(`--${name}=`))
   if (idx === -1) return undefined
@@ -86,6 +115,9 @@ async function publishToJsr() {
     jsrConfig.version = version
     writeFileSync(jsrPath, JSON.stringify(jsrConfig, null, 2) + '\n')
 
+    // Pin workspace:* sibling deps so JSR sees a real version constraint.
+    const originalPackageJson = rewriteWorkspaceDeps(packagePath, version)
+
     // Snapshot any internal workspace deps that JSR would otherwise reject for
     // missing version constraints. See TRACING_SNAPSHOT_SOURCES for details.
     copyTracingSnapshot(packagePath, pkg)
@@ -113,6 +145,8 @@ async function publishToJsr() {
     } finally {
       // Restore original jsr.json to keep working directory clean
       writeFileSync(jsrPath, originalJsrContent)
+      // Restore package.json (workspace:* sibling deps)
+      restorePackageJson(packagePath, originalPackageJson)
       // Remove any internal snapshot copies created above
       cleanupTracingSnapshot(packagePath, pkg)
     }

--- a/scripts/release-canary.ts
+++ b/scripts/release-canary.ts
@@ -1,5 +1,6 @@
 import { releaseVersion, releaseChangelog, releasePublish } from 'nx/release'
 import { execSync } from 'child_process'
+import { appendFileSync } from 'fs'
 import { getLastStableTag, getArg } from './utils'
 
 // Optional CLI flags for overriding default behavior (used by develop branch for v3 prereleases):
@@ -146,6 +147,10 @@ const tagArg = getArg('tag') ?? 'canary'
     verbose: true,
   })
 
+  // Track non-fatal publish failures (legacy mirror + JSR) so the workflow can
+  // notify Slack instead of letting them disappear into a green job log.
+  const partialFailures: string[] = []
+
   // Publish gotrue-js as legacy mirror of auth-js
   console.log('\n📦 Publishing @supabase/gotrue-js (legacy mirror)...')
   try {
@@ -154,6 +159,7 @@ const tagArg = getArg('tag') ?? 'canary'
     console.error('❌ Failed to publish gotrue-js legacy package:', error)
     // Don't fail the entire release if gotrue-js fails
     console.log('⚠️  Continuing with release despite gotrue-js publish failure')
+    partialFailures.push('gotrue-js')
   }
 
   // Publish all packages to JSR
@@ -164,6 +170,14 @@ const tagArg = getArg('tag') ?? 'canary'
     console.error('❌ Failed to publish to JSR:', error)
     // Don't fail the entire release if JSR publishing fails
     console.log('⚠️  Continuing with release despite JSR publish failure')
+    partialFailures.push('jsr')
+  }
+
+  if (partialFailures.length > 0 && process.env.GITHUB_OUTPUT) {
+    appendFileSync(
+      process.env.GITHUB_OUTPUT,
+      `partial_failure=true\npartial_failure_reason=${partialFailures.join(',')}\n`
+    )
   }
 
   process.exit(Object.values(publishResult).every((result) => result.code === 0) ? 0 : 1)


### PR DESCRIPTION
Fixes JSR canary publish for `@supabase/supabase-js`, which has been silently failing since the pnpm migration with `specifier 'npm:@supabase/auth-js' is missing a version constraint`. JSR doesn't understand pnpm's `workspace:` protocol, so `publish-to-jsr.ts` now pins `workspace:<range>` entries to the package's own version before publish and restores the original in the existing `finally` block.

The PR also surfaces non-fatal publish failures from JSR and the `gotrue-js` legacy mirror, both currently swallowed by try/catch in `release-canary.ts`, via a new `partial_failure` `GITHUB_OUTPUT` and a follow-up notification workflow job. The next time one of these silently regresses, the workflow will flag it instead of letting it go unnoticed for weeks.