### PR TITLE
fix(release): publish gotrue-js legacy mirror via pnpm

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -552,8 +552,8 @@ jobs:
     secrets:
       SLACK_CLIENT_LIBS_WEBHOOK: ${{ secrets.SLACK_CLIENT_LIBS_WEBHOOK }}
     with:
-      title: 'Canary Release (partial failure: ${{ needs.release-canary.outputs.partial_failure_reason }})'
-      status: 'failure'
+      title: 'Canary Release: partial publish failure (${{ needs.release-canary.outputs.partial_failure_reason }})'
+      status: 'partial'
 
   notify-next-failure:
     name: Notify Slack for Next failure

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -45,21 +45,35 @@ jobs:
               STATUS_ICON="❌";
               STATUS_PREFIX="failed";
               ;;
+            partial)
+              STATUS_ICON="⚠️";
+              STATUS_PREFIX="";
+              ;;
             *)
               STATUS_ICON="ℹ️";
               STATUS_PREFIX="update";
               ;;
           esac
+          # Omit ", version …" when no version is supplied; older callers that
+          # pass a version still render unchanged.
           VERSION_VALUE=${VERSION_INPUT:-n/a}
-          VERSION_LINE=", version ${VERSION_VALUE}"
+          VERSION_LINE=""
+          if [ -n "$VERSION_INPUT" ]; then
+            VERSION_LINE=", version ${VERSION_INPUT}"
+          fi
+          # Drop the trailing status word when it would be redundant (partial).
+          TITLE_SUFFIX=""
+          if [ -n "$STATUS_PREFIX" ]; then
+            TITLE_SUFFIX=" ${STATUS_PREFIX}"
+          fi
 
           payload=$(cat <<EOF
           {
-            "text": "${STATUS_ICON} ${TITLE} ${STATUS_PREFIX}${VERSION_LINE} in ${GITHUB_REPO}",
+            "text": "${STATUS_ICON} ${TITLE}${TITLE_SUFFIX}${VERSION_LINE} in ${GITHUB_REPO}",
             "blocks": [
               {
                 "type": "header",
-                "text": { "type": "plain_text", "text": "${STATUS_ICON} ${TITLE} ${STATUS_PREFIX}", "emoji": true }
+                "text": { "type": "plain_text", "text": "${STATUS_ICON} ${TITLE}${TITLE_SUFFIX}", "emoji": true }
               },
               {
                 "type": "section",

--- a/scripts/publish-gotrue-legacy.ts
+++ b/scripts/publish-gotrue-legacy.ts
@@ -106,8 +106,11 @@ async function publishGotrueLegacy(): Promise<void> {
       process.exit(1)
     }
 
-    // Publish to npm from the auth-js directory
-    const publishCommand = `npm publish --provenance --tag ${tag}`
+    // Publish to npm from the auth-js directory. Use pnpm publish to match what
+    // nx-release-publish does for the other six packages — `npm publish` from
+    // inside a pnpm workspace can sign provenance but then 404s on the registry
+    // PUT (observed continuously since the pnpm migration).
+    const publishCommand = `pnpm publish --provenance --tag ${tag} --no-git-checks`
 
     log(`\n🚀 Publishing to npm...`)
     log(`   Command: ${publishCommand}`)


### PR DESCRIPTION
Fixes the `@supabase/gotrue-js` legacy mirror canary publish, which has been 404ing on every release since the pnpm migration with `404 Not Found - PUT /@supabase%2fgotrue-js`. The trusted-publisher config for `@supabase/gotrue-js` is correct and provenance signing succeeds; the actual issue is that `npm publish --provenance` invoked via `execSync` 404s on the registry PUT inside a pnpm-managed workspace, while `pnpm publish` (what `nx-release-publish` uses for the other six packages) works.

Switches `scripts/publish-gotrue-legacy.ts` to `pnpm publish --provenance --tag <t> --no-git-checks`, matching the command shape `nx-release-publish` generates for pnpm projects. `--no-git-checks` is required because the script renames `auth-js`'s `package.json` in place before publishing.

Also tightens the partial-failure notification wiring added in #2418. It was rendering as `Canary Release (partial failure: gotrue-js) failed, version n/a` because the reusable `slack-notify.yml` always appends a status verb and `, version n/a`. Adds a `partial` status (warning icon, no trailing verb) and makes the version suffix conditional, so the message now renders as `Canary Release: partial publish failure (gotrue-js) in supabase/supabase-js`.