### PR TITLE
ci(ci): set persist-credentials to true for revert commit

### DIFF
--- a/.github/workflows/revert-commit.yml
+++ b/.github/workflows/revert-commit.yml
@@ -97,7 +97,7 @@ jobs:
           ref: master
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
-          persist-credentials: false
+          persist-credentials: true
 
       - name: Verify SHA exists and is reachable from master
         env:


### PR DESCRIPTION
Set `persist-credentials` to `true` on the revert-commit workflow, to fix permission issues ([example](https://github.com/supabase/supabase-js/actions/runs/26820485496))