### PR TITLE
fix(auth): do not console.error AuthApiError already returned through contract

### DIFF
--- a/packages/core/auth-js/src/GoTrueClient.ts
+++ b/packages/core/auth-js/src/GoTrueClient.ts
@@ -4711,7 +4711,7 @@ export default class GoTrueClient {
             if (isAuthRefreshDiscardedError(error)) {
               this._debug(debugName, 'refresh discarded by commit guard', error)
             } else {
-              console.error(error)
+              this._debug(debugName, 'refresh failed', error)
 
               if (!isAuthRetryableFetchError(error)) {
                 this._debug(

--- a/packages/core/auth-js/test/GoTrueClient.test.ts
+++ b/packages/core/auth-js/test/GoTrueClient.test.ts
@@ -2979,6 +2979,35 @@ describe('Auto Refresh', () => {
       // Verify we got a new token
       expect(session?.access_token).not.toEqual(signUpData.session?.access_token)
     })
+
+    test('does not call console.error when refresh fails with an invalid token', async () => {
+      const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+
+      const storageKey = 'test-no-console-error-on-failed-refresh'
+      const staleSession = {
+        access_token: 'invalid-access-token',
+        refresh_token: 'invalid-refresh-token',
+        expires_at: Math.floor(Date.now() / 1000) - 3600,
+        expires_in: 3600,
+        token_type: 'bearer',
+        user: null,
+      }
+      const storage = memoryLocalStorageAdapter({
+        [storageKey]: JSON.stringify(staleSession),
+      })
+      const client = new GoTrueClient({
+        url: GOTRUE_URL_SIGNUP_ENABLED_AUTO_CONFIRM_ON,
+        autoRefreshToken: true,
+        persistSession: true,
+        storage,
+        storageKey,
+      })
+
+      await client.getUser()
+
+      expect(errorSpy).not.toHaveBeenCalled()
+      errorSpy.mockRestore()
+    })
   })
 
   test('should handle auto refresh start/stop multiple times', async () => {


### PR DESCRIPTION
## Description

In SSR/Edge environments (Next.js middleware on Vercel Edge Runtime), every `supabase.auth.getUser()` call against a session with a stale refresh token produces a noisy `[AuthApiError]: Invalid Refresh Token` line in server logs.

### What changed?

In `_recoverAndRefresh` inside `GoTrueClient.ts`, the `else` branch after the discarded-error guard was calling `console.error(error)` unconditionally. This error is already returned through the public API contract via `_callRefreshToken`'s return value — the caller receives `{ data: null, error }` correctly. The bare `console.error` adds no diagnostic value and duplicates the error surface.

The fix replaces `console.error(error)` with `this._debug(debugName, 'refresh failed', error)`, matching the pattern of the `isAuthRefreshDiscardedError` branch immediately above it.


Closes #2416

## Type of Change

- [x] Bug fix (fix)
## Testing

- [x] Unit tests added — new test in `GoTrueClient.test.ts` asserts `console.error` is not called when `_recoverAndRefresh` encounters a stale refresh token
- [ ] - [x] All tests passing locally (441 passed, 15 suites)
## Checklist

- [x] Code formatted (`pnpm nx format`)
- [ ] - [x] Tests passing (`pnpm nx test:auth auth-js`)
- [ ] - [x] Build passing (`pnpm nx affected --target=build`)
- [ ] - [x] Used conventional commits (`pnpm commit`)
- [ ] - [x] Documentation updated (no public API change)