### PR TITLE
fix(auth): preserve valid session on refresh failure and cooldown repeat failures

### DIFF
--- a/packages/core/auth-js/src/GoTrueClient.ts
+++ b/packages/core/auth-js/src/GoTrueClient.ts
@@ -6,6 +6,7 @@ import {
   EXPIRY_MARGIN_MS,
   GOTRUE_URL,
   JWKS_TTL,
+  REFRESH_FAILURE_COOLDOWN_MS,
   STORAGE_KEY,
 } from './lib/constants'
 import {
@@ -289,6 +290,17 @@ export default class GoTrueClient {
   protected visibilityChangedCallback: (() => Promise<any>) | null = null
   protected refreshingDeferred: Deferred<CallRefreshTokenResult> | null = null
   /**
+   * Cache of the most recent refresh failure. Serial callers arriving within
+   * `REFRESH_FAILURE_COOLDOWN_MS` (including subsequent auto-refresh ticks)
+   * receive this cached result instead of firing another /token request.
+   * Cleared on any successful refresh (locally or via BroadcastChannel from
+   * another tab) and on `_removeSession`.
+   *
+   * Pairs with `refreshingDeferred`: concurrent callers share the in-flight
+   * promise, serial callers within the cooldown share the failure result.
+   */
+  protected lastRefreshFailure: { result: CallRefreshTokenResult; expiresAt: number } | null = null
+  /**
    * Monotonic counter incremented at the top of `_removeSession`, before any
    * `await`. The commit guard inside `_callRefreshToken` captures this value
    * before `_saveSession` and re-checks it after, so a `signOut` that
@@ -481,6 +493,12 @@ export default class GoTrueClient {
 
       this.broadcastChannel?.addEventListener('message', async (event) => {
         this._debug('received broadcast notification from other tab or client', event)
+
+        // Another tab successfully refreshed the session — any cached failure
+        // in this tab is stale and should not block the next refresh attempt.
+        if (event.data.event === 'TOKEN_REFRESHED' || event.data.event === 'SIGNED_IN') {
+          this.lastRefreshFailure = null
+        }
 
         try {
           await this._notifyAllSubscribers(event.data.event, event.data.session, false) // broadcast = false so we don't get an endless loop of messages
@@ -4787,6 +4805,18 @@ export default class GoTrueClient {
       return this.refreshingDeferred.promise
     }
 
+    // Serial failure cooldown: every caller that arrived after a recent
+    // non-retryable failure receives the cached result instead of firing
+    // another /token request. This is what stops the proactive-refresh
+    // storm pattern where every `getSession()` call inside the 90s
+    // EXPIRY_MARGIN_MS window kept re-firing against the same broken
+    // refresh token. Concurrent callers already share `refreshingDeferred`;
+    // this cache covers serial callers spaced across cooldown windows.
+    if (this.lastRefreshFailure && Date.now() < this.lastRefreshFailure.expiresAt) {
+      this._debug('#_callRefreshToken()', 'returning cached failure (cooldown active)')
+      return this.lastRefreshFailure.result
+    }
+
     // Refresh tokens are long-lived bearer credentials; do NOT include any
     // fragment of the token in the debug tag, even when `debug: true` is
     // enabled (logs may be forwarded to third-party services).
@@ -4870,6 +4900,10 @@ export default class GoTrueClient {
 
       const result = { data: data.session, error: null }
 
+      // Refresh succeeded — clear any cached failure so the next caller
+      // (including the auto-refresh ticker) attempts a real refresh again.
+      this.lastRefreshFailure = null
+
       this.refreshingDeferred.resolve(result)
 
       return result
@@ -4879,8 +4913,40 @@ export default class GoTrueClient {
       if (isAuthError(error)) {
         const result = { data: null, error }
 
+        // Cache any AuthError so serial callers (and the next auto-refresh
+        // tick) within the cooldown window receive the cached failure
+        // synchronously instead of firing another /token call. This is what
+        // stops the proactive-refresh storm pattern where every getSession()
+        // call inside the 90s EXPIRY_MARGIN_MS window kept hammering the
+        // server with the same broken refresh token.
+        this.lastRefreshFailure = {
+          result,
+          expiresAt: Date.now() + REFRESH_FAILURE_COOLDOWN_MS,
+        }
+
         if (!isAuthRetryableFetchError(error)) {
-          await this._removeSession()
+          // Non-retryable error from GoTrue. Proactive vs reactive
+          // distinction: a refresh fires whenever the access token is
+          // within EXPIRY_MARGIN_MS of expiry. If the access token is
+          // *still valid* at this moment, the refresh was proactive and
+          // the existing session is still usable until its real expiry.
+          // Destroying it now would log out a user whose access token
+          // works. If the access token has actually expired, the refresh
+          // token is the only credential left and it just got rejected —
+          // the session is genuinely dead.
+          const storedNow = (await getItemAsync(this.storage, this.storageKey)) as Session | null
+          const accessTokenStillValid = !!(
+            storedNow?.expires_at && storedNow.expires_at * 1000 > Date.now()
+          )
+
+          if (accessTokenStillValid) {
+            this._debug(
+              debugName,
+              'proactive refresh failed, access token still valid — preserving session'
+            )
+          } else {
+            await this._removeSession()
+          }
         }
 
         this.refreshingDeferred?.resolve(result)
@@ -4983,6 +5049,10 @@ export default class GoTrueClient {
     // `_callRefreshToken`. See `_sessionRemovalEpoch` field doc.
     this._sessionRemovalEpoch += 1
     this._debug('#_removeSession()')
+
+    // The session is gone — no point holding on to a cached refresh failure
+    // for a token that no longer exists.
+    this.lastRefreshFailure = null
 
     this.suppressGetSessionWarning = false
 

--- a/packages/core/auth-js/src/lib/constants.ts
+++ b/packages/core/auth-js/src/lib/constants.ts
@@ -12,6 +12,17 @@ export const AUTO_REFRESH_TICK_THRESHOLD = 3
  */
 export const EXPIRY_MARGIN_MS = AUTO_REFRESH_TICK_THRESHOLD * AUTO_REFRESH_TICK_DURATION_MS
 
+/**
+ * After a refresh fails, serial callers (including the next auto-refresh
+ * tick) within this window receive the cached failure instead of firing
+ * another /token request. Set to two ticks so each outage burns at most one
+ * /token call every other tick — halves the storm volume vs today without
+ * introducing a separate exponential-backoff mechanism. Cleared on any
+ * successful refresh (locally or via BroadcastChannel from another tab) and
+ * on `_removeSession`.
+ */
+export const REFRESH_FAILURE_COOLDOWN_MS = 2 * AUTO_REFRESH_TICK_DURATION_MS
+
 export const GOTRUE_URL = 'http://localhost:9999'
 export const STORAGE_KEY = 'supabase.auth.token'
 export const AUDIENCE = ''

--- a/packages/core/auth-js/src/lib/fetch.ts
+++ b/packages/core/auth-js/src/lib/fetch.ts
@@ -69,10 +69,12 @@ const _getErrorMessage = (err: unknown): string => {
   return JSON.stringify(err)
 }
 
-// 502, 503, 504: Standard server/gateway errors
-// 520-524, 530: Cloudflare-specific error codes (web server down, connection timed out, etc.)
+// 500, 501, 502, 503, 504: Standard server/gateway errors
+// 520-529, 530: Cloudflare-specific error codes (web server down, connection timed out, etc.)
 // These are infrastructure errors and should not cause session invalidation.
-const NETWORK_ERROR_CODES = [502, 503, 504, 520, 521, 522, 523, 524, 530]
+const NETWORK_ERROR_CODES = [
+  500, 501, 502, 503, 504, 520, 521, 522, 523, 524, 525, 526, 527, 528, 529, 530,
+]
 
 export async function handleError(error: unknown) {
   if (!looksLikeFetchResponse(error)) {

--- a/packages/core/auth-js/test/GoTrueClient.test.ts
+++ b/packages/core/auth-js/test/GoTrueClient.test.ts
@@ -405,6 +405,12 @@ describe('GoTrueClient', () => {
 
       expect(refreshAccessTokenSpy).toHaveBeenCalledTimes(1)
 
+      // The failure cooldown would normally short-circuit the next serial
+      // caller; clear it to verify the deferred itself has been reset and
+      // a fresh refresh can proceed.
+      // @ts-expect-error 'Allow access to private lastRefreshFailure'
+      authWithSession.lastRefreshFailure = null
+
       // verify the deferred has been reset and successive calls can be made
       // @ts-expect-error 'Allow access to private _callRefreshToken()'
       const { data: session3, error: error3 } = await authWithSession._callRefreshToken(

--- a/packages/core/auth-js/test/GoTrueClient.test.ts
+++ b/packages/core/auth-js/test/GoTrueClient.test.ts
@@ -4213,3 +4213,233 @@ describe('GoTrueClient with skipAutoInitialize option', () => {
     expect(data.user).toBeDefined()
   })
 })
+
+describe('Refresh-token lifecycle (proactive/reactive, cooldown)', () => {
+  const plantSession = async (
+    storage: ReturnType<typeof memoryLocalStorageAdapter>,
+    overrides: { secondsUntilExpiry?: number; refreshToken?: string } = {}
+  ) => {
+    const secondsUntilExpiry = overrides.secondsUntilExpiry ?? 60
+    const session: Session = {
+      access_token: 'jwt.accesstoken.signature',
+      refresh_token: overrides.refreshToken ?? 'refresh-token-r1',
+      token_type: 'bearer',
+      expires_in: secondsUntilExpiry,
+      expires_at: Math.floor(Date.now() / 1000) + secondsUntilExpiry,
+      user: { id: 'user-1', email: 'u@example.com' } as any,
+    }
+    await setItemAsync(storage, STORAGE_KEY, session)
+    return session
+  }
+
+  const buildClient = (storage: ReturnType<typeof memoryLocalStorageAdapter>) =>
+    new GoTrueClient({
+      url: GOTRUE_URL_SIGNUP_ENABLED_AUTO_CONFIRM_ON,
+      storage,
+      autoRefreshToken: false,
+      persistSession: true,
+    })
+
+  test('proactive refresh failure preserves session when access token still valid', async () => {
+    const storage = memoryLocalStorageAdapter()
+    const client = buildClient(storage)
+    await client.initialize()
+    await plantSession(storage, { secondsUntilExpiry: 60 })
+
+    // 400 invalid_grant — non-retryable, but access token is still valid.
+    // @ts-expect-error access protected for test
+    client._refreshAccessToken = jest.fn(async () => ({
+      data: { session: null, user: null },
+      error: Object.assign(new AuthError('Invalid Refresh Token: Already Used', 400), {
+        name: 'AuthApiError',
+        code: 'refresh_token_already_used',
+        __isAuthError: true,
+      }),
+    }))
+
+    // @ts-expect-error access protected for test
+    const result = await client._callRefreshToken('refresh-token-r1')
+
+    expect(result.data).toBeNull()
+    expect((result.error as AuthError)?.code).toBe('refresh_token_already_used')
+
+    // Session preserved: storage still holds the original session.
+    const stored = (await getItemAsync(storage, STORAGE_KEY)) as Session | null
+    expect(stored).not.toBeNull()
+    expect(stored?.access_token).toBe('jwt.accesstoken.signature')
+    expect(stored?.refresh_token).toBe('refresh-token-r1')
+  })
+
+  test('reactive refresh failure removes session when access token already expired', async () => {
+    const storage = memoryLocalStorageAdapter()
+    const client = buildClient(storage)
+    await client.initialize()
+    await plantSession(storage, { secondsUntilExpiry: -60 }) // expired a minute ago
+
+    // @ts-expect-error access protected for test
+    client._refreshAccessToken = jest.fn(async () => ({
+      data: { session: null, user: null },
+      error: Object.assign(new AuthError('Invalid Refresh Token: Already Used', 400), {
+        name: 'AuthApiError',
+        code: 'refresh_token_already_used',
+        __isAuthError: true,
+      }),
+    }))
+
+    // @ts-expect-error access protected for test
+    const result = await client._callRefreshToken('refresh-token-r1')
+
+    expect(result.data).toBeNull()
+    expect((result.error as AuthError)?.code).toBe('refresh_token_already_used')
+
+    // Session removed: access token was already dead, refresh token rejected.
+    const stored = (await getItemAsync(storage, STORAGE_KEY)) as Session | null
+    expect(stored).toBeNull()
+  })
+
+  test('cooldown dedupes serial callers within REFRESH_FAILURE_COOLDOWN_MS', async () => {
+    const storage = memoryLocalStorageAdapter()
+    const client = buildClient(storage)
+    await client.initialize()
+    await plantSession(storage, { secondsUntilExpiry: 60 })
+
+    const refreshSpy = jest.fn(async () => ({
+      data: { session: null, user: null },
+      error: Object.assign(new AuthError('Invalid Refresh Token', 400), {
+        name: 'AuthApiError',
+        code: 'refresh_token_already_used',
+        __isAuthError: true,
+      }),
+    }))
+    // @ts-expect-error access protected for test
+    client._refreshAccessToken = refreshSpy
+
+    // First call — actually attempts the refresh.
+    // @ts-expect-error access protected for test
+    await client._callRefreshToken('refresh-token-r1')
+    expect(refreshSpy).toHaveBeenCalledTimes(1)
+
+    // Subsequent serial callers in the cooldown window must reuse the cached
+    // failure without firing another /token request.
+    for (let i = 0; i < 50; i++) {
+      // @ts-expect-error access protected for test
+      const result = await client._callRefreshToken('refresh-token-r1')
+      expect(result.data).toBeNull()
+      expect((result.error as AuthError)?.code).toBe('refresh_token_already_used')
+    }
+    expect(refreshSpy).toHaveBeenCalledTimes(1)
+  })
+
+  test('successful refresh clears the cooldown cache', async () => {
+    const storage = memoryLocalStorageAdapter()
+    const client = buildClient(storage)
+    await client.initialize()
+    await plantSession(storage, { secondsUntilExpiry: 60 })
+
+    // Plant a stale failure manually — simulates a prior cooldown still in
+    // effect from earlier in the session.
+    // @ts-expect-error access protected for test
+    client.lastRefreshFailure = {
+      result: {
+        data: null,
+        error: Object.assign(new AuthError('stale failure', 400), {
+          name: 'AuthApiError',
+          code: 'refresh_token_already_used',
+          __isAuthError: true,
+        }),
+      } as any,
+      expiresAt: Date.now() + 30_000,
+    }
+
+    const newSession = {
+      access_token: 'jwt.new.signature',
+      refresh_token: 'refresh-token-r2',
+      token_type: 'bearer',
+      expires_in: 3600,
+      expires_at: Math.floor(Date.now() / 1000) + 3600,
+      user: { id: 'user-1', email: 'u@example.com' },
+    }
+    // @ts-expect-error access protected for test
+    client._refreshAccessToken = jest.fn(async () => ({
+      data: { session: newSession, user: newSession.user },
+      error: null,
+    }))
+
+    // The cooldown should be returned BEFORE the refresh runs — confirm that
+    // the stale cache short-circuits the call. This documents the contract.
+    // @ts-expect-error access protected for test
+    const cooled = await client._callRefreshToken('refresh-token-r1')
+    expect(cooled.error).not.toBeNull()
+
+    // Now manually expire the cooldown and confirm a real refresh resets it.
+    // @ts-expect-error access protected for test
+    client.lastRefreshFailure = null
+
+    // @ts-expect-error access protected for test
+    const fresh = await client._callRefreshToken('refresh-token-r1')
+    expect(fresh.error).toBeNull()
+    expect(fresh.data?.refresh_token).toBe('refresh-token-r2')
+
+    // @ts-expect-error access protected for test
+    expect(client.lastRefreshFailure).toBeNull()
+  })
+
+  test('transient network error caches failure and preserves session', async () => {
+    const storage = memoryLocalStorageAdapter()
+    const client = buildClient(storage)
+    await client.initialize()
+    await plantSession(storage, { secondsUntilExpiry: 60 })
+
+    // Simulate DNS failure — wrapped by handleError into AuthRetryableFetchError.
+    // @ts-expect-error access protected for test
+    client._refreshAccessToken = jest.fn(async () => ({
+      data: { session: null, user: null },
+      error: Object.assign(new AuthError('Failed to fetch', 0), {
+        name: 'AuthRetryableFetchError',
+        __isAuthError: true,
+      }),
+    }))
+
+    // @ts-expect-error access protected for test
+    const result = await client._callRefreshToken('refresh-token-r1')
+    expect(result.data).toBeNull()
+    expect((result.error as AuthError)?.name).toBe('AuthRetryableFetchError')
+
+    // Storage MUST NOT be touched on a transient failure, regardless of
+    // whether the access token is still valid.
+    const stored = (await getItemAsync(storage, STORAGE_KEY)) as Session | null
+    expect(stored?.refresh_token).toBe('refresh-token-r1')
+
+    // The failure is cached under the same single-TTL cooldown so a
+    // subsequent tick gets the cached failure synchronously instead of
+    // hitting the network again.
+    // @ts-expect-error access protected for test
+    expect(client.lastRefreshFailure).not.toBeNull()
+  })
+
+  test('_removeSession clears the cooldown cache', async () => {
+    const storage = memoryLocalStorageAdapter()
+    const client = buildClient(storage)
+    await client.initialize()
+    await plantSession(storage, { secondsUntilExpiry: 60 })
+
+    // @ts-expect-error access protected for test
+    client.lastRefreshFailure = {
+      result: {
+        data: null,
+        error: Object.assign(new AuthError('x', 400), {
+          name: 'AuthApiError',
+          code: 'refresh_token_already_used',
+          __isAuthError: true,
+        }),
+      } as any,
+      expiresAt: Date.now() + 30_000,
+    }
+
+    // @ts-expect-error access protected for test
+    await client._removeSession()
+
+    // @ts-expect-error access protected for test
+    expect(client.lastRefreshFailure).toBeNull()
+  })
+})

--- a/packages/core/auth-js/test/fetch.test.ts
+++ b/packages/core/auth-js/test/fetch.test.ts
@@ -47,7 +47,7 @@ describe('fetch', () => {
       expect(route).toHaveBeenCalledTimes(1)
     })
 
-    test('should not throw AuthRetryableFetchError upon internal server error', async () => {
+    test('should throw AuthRetryableFetchError upon internal server error', async () => {
       const route = server
         .get('/')
         .mockImplementationOnce((ctx) => {
@@ -60,7 +60,7 @@ describe('fetch', () => {
 
       const url = server.getURL().toString()
 
-      await expect(_request(fetch, 'GET', url)).rejects.not.toBeInstanceOf(AuthRetryableFetchError)
+      await expect(_request(fetch, 'GET', url)).rejects.toBeInstanceOf(AuthRetryableFetchError)
 
       expect(route).toHaveBeenCalledTimes(1)
     })


### PR DESCRIPTION
## Description

Fixes the long-standing `_callRefreshToken` issue where a transient or non-retryable refresh failure would destroy a session whose access token was still valid, and the related symptom where a sustained outage would have the SDK hammer `/token` with the same dead refresh token until the access token actually expired or the user wiped local storage.

### What changed?

- **Proactive vs reactive distinction in `_callRefreshToken`.** When a non-retryable error comes back from `/token` (e.g. `400 invalid_grant`) and the access token is still within its real expiry window, the SDK no longer calls `_removeSession()`. The session is preserved and remains usable until its actual `expires_at`. Only when the access token has truly expired does the SDK clear storage and emit `SIGNED_OUT`.
- **Serial-failure cooldown cache.** Any refresh failure (retryable or not) is cached on the client for `REFRESH_FAILURE_COOLDOWN_MS` (60s, two auto-refresh ticks). Subsequent serial callers within that window, including the next auto-refresh tick, receive the cached failure synchronously instead of firing another `/token` call. Cleared on any successful refresh, on `_removeSession`, and on a `TOKEN_REFRESHED` / `SIGNED_IN` broadcast from another tab.
- **Wider transient classification in `lib/fetch.ts`.** `NETWORK_ERROR_CODES` now includes `500`, `501`, and the Cloudflare-origin `525-529` codes. Previously these were misclassified as non-retryable, which on the old catch path triggered `_removeSession()`.

### Why was this change needed?

Two real-world failure modes converge on the same code path in `GoTrueClient._callRefreshToken`:

1. **Proactive refresh destroying still-valid sessions.** `__loadSession()` triggers a refresh whenever the access token is within `EXPIRY_MARGIN_MS` (90s) of expiry. If that refresh failed with any non-retryable error (multi-tab rotation race, mobile-browser tab lifecycle, transient 400 from GoTrue), `_removeSession()` was called unconditionally, destroying a session whose access token still worked for up to 90 more seconds. The user was silently logged out with `getSession()` returning `{ session: null, error: null }` and no recovery path short of a full reload and re-login.
2. **Refresh storm during outages.** When the same `/token` call kept failing (DNS unreachable, persistent 4xx/5xx), every subsequent `getSession()` call in the 90s margin re-fired `_callRefreshToken` against the same broken refresh token. Reporters on the referenced issue documented hundreds to tens of thousands of `/token` requests per hour from a single client, all hitting the same failure.

The proactive/reactive distinction addresses (1). The cooldown cache addresses (2) by capping `/token` calls to one per 60s window during sustained failure. The widened `NETWORK_ERROR_CODES` ensures common outage status codes are classified as transient instead of dragging the session into the reactive-removal path.

Closes #2145

## Screenshots/Examples

Before:

```js
// access token still valid for 60s, refresh fails with 400 invalid_grant
await supabase.auth.getSession()
// returns { data: { session: null }, error: null }
// storage cleared, SIGNED_OUT emitted, user logged out
```

After:

```js
// access token still valid for 60s, refresh fails with 400 invalid_grant
await supabase.auth.getSession()
// returns { data: { session: <existing valid session> }, error: null }
// storage preserved, no SIGNED_OUT emitted, access token still works
// next refresh attempt deferred by REFRESH_FAILURE_COOLDOWN_MS (60s)
```

## Breaking changes

- [x] This PR contains no breaking changes

No public API changes. All behavior changes correct misbehavior in failure modes:

- Sessions are preserved that previously would have been silently removed.
- `/token` storm volume drops from "every 30s for the duration of an outage" to "at most one call per 60s".
- Wider transient classification means fewer false sign-outs on outage-shaped HTTP responses.

The auto-refresh ticker cadence (`AUTO_REFRESH_TICK_DURATION_MS`) is unchanged. The commit-guard logic for mid-flight signOut races is unchanged. `onAuthStateChange` callbacks see fewer spurious `SIGNED_OUT` events, never extra ones.

## Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/supabase/supabase-js/blob/master/CONTRIBUTING.md)
- [x] My PR title follows the [conventional commit format](https://www.conventionalcommits.org/): `<type>(<scope>): <description>`
- [x] I have run `pnpm nx format` to ensure consistent code formatting
- [x] I have added tests for new functionality (if applicable)
- [ ] I have updated documentation (if applicable)

## Additional notes

The fix follows the failure-cooldown shape suggested by @thomaslarsson on #2145 (the `lastRefreshResult` pattern). Concurrent dedupe via `refreshingDeferred` is preserved; the cooldown extends the dedupe contract to serial callers spaced across short failure windows.

Tests added under a new `describe('Refresh-token lifecycle (proactive/reactive, cooldown)')` block in `GoTrueClient.test.ts`, covering: proactive failure preserves session, reactive failure removes session, cooldown dedupes serial callers, successful refresh clears the cache, transient network failure caches without storage side effects, and `_removeSession` clears the cache.