### PR TITLE
test(auth): add deepClone regression tests for React Native / Hermes environments

### DIFF
--- a/packages/core/auth-js/test/helpers.test.ts
+++ b/packages/core/auth-js/test/helpers.test.ts
@@ -1,6 +1,7 @@
 import { AuthInvalidJwtError } from '../src'
 import {
   decodeJWT,
+  deepClone,
   generateCallbackId,
   getAlgorithm,
   getItemAsync,
@@ -383,5 +384,44 @@ describe('getItemAsync', () => {
     // valid behavior. We are only guarding against parse failures here.
     const storage = makeStorage({ session: '"hello"' })
     expect(await getItemAsync(storage, 'session')).toEqual('hello')
+  })
+})
+
+describe('deepClone', () => {
+  it('returns a deep copy with no shared references', () => {
+    const original = { a: 1, b: { c: 2 } }
+    const clone = deepClone(original)
+    expect(clone).toEqual(original)
+    clone.b.c = 99
+    expect(original.b.c).toBe(2)
+  })
+
+  it('clones arrays correctly', () => {
+    const original = [1, [2, 3], { d: 4 }]
+    const clone = deepClone(original)
+    expect(clone).toEqual(original)
+    ;(clone[1] as number[])[0] = 99
+    expect((original[1] as number[])[0]).toBe(2)
+  })
+
+  it('works when globalThis.structuredClone is undefined (React Native / Hermes)', () => {
+    // Simulate the React Native / Hermes environment where structuredClone does not exist.
+    // Regression guard for https://github.com/supabase/supabase-js/issues/1615
+    const saved = (globalThis as any).structuredClone
+    delete (globalThis as any).structuredClone
+
+    try {
+      const session = {
+        access_token: 'token',
+        refresh_token: 'refresh',
+        user: { id: 'user-id', role: 'authenticated' },
+      }
+      const clone = deepClone(session)
+      expect(clone).toEqual(session)
+      expect(clone).not.toBe(session)
+      expect(clone.user).not.toBe(session.user)
+    } finally {
+      ;(globalThis as any).structuredClone = saved
+    }
   })
 })


### PR DESCRIPTION
## Background

In React Native / Hermes, `structuredClone` is not a global. Starting with
`@supabase/auth-js` v2.71.0, `GoTrueClient` called `structuredClone` directly
when persisting session data. This made `signInWithPassword` throw an unhandled
`ReferenceError: Property 'structuredClone' doesn't exist` on Hermes, even
inside a `try/catch` block (since the error was thrown synchronously in the
async function body before the first `await`).

Root issue: supabase/supabase-js#1615  
Original user report: supabase-js v2.51.0 / auth-js v2.71.0

## Code fix (already merged)

The code fix landed in commit `9a6edb9` (PR #1084 in the now-archived
`supabase/auth-js` repo) and was released as `@supabase/auth-js v2.71.1` /
`@supabase/supabase-js v2.51.1`. It introduced a `deepClone` helper in
`packages/core/auth-js/src/lib/helpers.ts` that uses
`JSON.parse(JSON.stringify(obj))` — safe in all JS runtimes — and replaced both
`structuredClone` call sites in `GoTrueClient.ts`.

## What this PR adds

The `deepClone` helper has no unit tests. This PR adds a `deepClone` describe
block to `packages/core/auth-js/test/helpers.test.ts` with three cases:

| Test | Purpose |
|---|---|
| Returns a deep copy with no shared references | Core correctness |
| Clones arrays correctly | Nested array support |
| Works when `globalThis.structuredClone` is undefined | Regression guard for the RN/Hermes scenario |

The third test deletes `globalThis.structuredClone` before calling `deepClone`
and restores it in a `finally` block. It would have caught the original bug if
it had existed before v2.71.0 shipped.

All 49 tests in `helpers.test.ts` pass locally (jest 30 / ts-jest 29 / Node 26).

🤖 Generated with [Claude Code](https://claude.com/claude-code)