### PR TITLE
fix(ci): forward DOGFOOD_APP_CLIENT_ID to dogfood workflow

### DIFF
--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -30,7 +30,7 @@ on:
         required: true
       PRIVATE_KEY:
         required: true
-      DOGFOOD_APP_ID:
+      DOGFOOD_APP_CLIENT_ID:
         required: true
       DOGFOOD_APP_PRIVATE_KEY:
         required: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -169,7 +169,7 @@ jobs:
     secrets:
       APP_CLIENT_ID: ${{ secrets.APP_CLIENT_ID }}
       PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
-      DOGFOOD_APP_ID: ${{ secrets.DOGFOOD_APP_ID }}
+      DOGFOOD_APP_CLIENT_ID: ${{ secrets.DOGFOOD_APP_CLIENT_ID }}
       DOGFOOD_APP_PRIVATE_KEY: ${{ secrets.DOGFOOD_APP_PRIVATE_KEY }}
     with:
       version: ${{ needs.release-stable.outputs.released_version }}


### PR DESCRIPTION
The dogfood reusable workflow declared DOGFOOD_APP_ID but its create-github-app-token step reads DOGFOOD_APP_CLIENT_ID, so the client-id input resolved to empty and the job failed.