### PR TITLE
docs(misc): clarifications, grouping of modifier methods

### DIFF
--- a/packages/core/auth-js/src/GoTrueClient.ts
+++ b/packages/core/auth-js/src/GoTrueClient.ts
@@ -535,9 +535,20 @@ export default class GoTrueClient {
   }
 
   /**
-   * Initializes the client session either from the url or from storage.
-   * This method is automatically called when instantiating the client, but should also be called
-   * manually when checking for an error from an auth redirect (oauth, magiclink, password recovery, etc).
+   * Initialize the auth client by loading the session from storage or
+   * detecting it from the URL after an OAuth, magic-link, or password-recovery
+   * redirect.
+   *
+   * **Most callers do not need to invoke this directly.** The client calls it
+   * automatically during construction, and to react to sign-in events (including
+   * post-redirect events) you should subscribe to `onAuthStateChange` rather
+   * than awaiting `initialize()`.
+   *
+   * You only need to call it manually when you have opted out of the automatic
+   * call by passing `skipAutoInitialize: true` — for example, in an SSR context
+   * where you need to control initialization timing. In that case, awaiting
+   * `initialize()` returns the resolved session result (or any error encountered
+   * while detecting it from the URL).
    *
    * @category Auth
    */

--- a/packages/core/postgrest-js/src/PostgrestBuilder.ts
+++ b/packages/core/postgrest-js/src/PostgrestBuilder.ts
@@ -151,6 +151,7 @@ export default abstract class PostgrestBuilder<
    * {@link https://github.com/supabase/supabase-js/issues/92}
    *
    * @category Database
+   * @subcategory Using modifiers
    */
   throwOnError(): PostgrestBuilder<ClientOptions, Result, true> {
     this.shouldThrowOnError = true
@@ -219,6 +220,7 @@ export default abstract class PostgrestBuilder<
    * Set an HTTP header for the request.
    *
    * @category Database
+   * @subcategory Using modifiers
    */
   setHeader(name: string, value: string): this {
     this.headers = new Headers(this.headers)
@@ -228,6 +230,7 @@ export default abstract class PostgrestBuilder<
 
   /**
    * @category Database
+   * @subcategory Using modifiers
    *
    * Configure retry behavior for this request.
    *
@@ -569,6 +572,7 @@ export default abstract class PostgrestBuilder<
    * @deprecated Use overrideTypes<yourType, { merge: false }>() method at the end of your call chain instead
    *
    * @category Database
+   * @subcategory Using modifiers
    */
   returns<NewResult>(): PostgrestBuilder<
     ClientOptions,

--- a/packages/core/postgrest-js/src/PostgrestBuilder.ts
+++ b/packages/core/postgrest-js/src/PostgrestBuilder.ts
@@ -217,7 +217,17 @@ export default abstract class PostgrestBuilder<
   }
 
   /**
-   * Set an HTTP header for the request.
+   * Set an HTTP header on this single PostgREST request, overriding any header
+   * with the same name set on the client.
+   *
+   * This is an advanced escape hatch for one-off needs (passing a custom
+   * `Authorization` for a single query, attaching a tracing header, etc.).
+   * Most callers do not need it: configure client-wide headers via the
+   * `headers` option when constructing the client, and authentication via
+   * Supabase Auth.
+   *
+   * @param name - HTTP header name
+   * @param value - HTTP header value
    *
    * @category Database
    * @subcategory Using modifiers

--- a/packages/core/postgrest-js/src/PostgrestTransformBuilder.ts
+++ b/packages/core/postgrest-js/src/PostgrestTransformBuilder.ts
@@ -916,11 +916,32 @@ export default class PostgrestTransformBuilder<
   }
 
   /**
-   * Rollback the query.
+   * Dry-run this request: execute the query but discard the changes.
    *
-   * `data` will still be returned, but the query is not committed.
+   * Server-side, PostgREST runs the query inside a transaction and rolls it back
+   * instead of committing. The response still contains the data that *would* have
+   * been returned — `RETURNING` clauses execute and RLS, triggers, and constraints
+   * are all evaluated — but no row is actually inserted, updated, or deleted.
+   *
+   * This affects only the single request it is chained to. The JS caller has no
+   * handle on the transaction: supabase-js does not group multiple queries into
+   * one transaction. For multi-statement transactional logic, use a database
+   * function (`supabase.rpc(...)`).
+   *
+   * Sets the `Prefer: tx=rollback` header. See PostgREST's docs on transaction
+   * preferences for the underlying mechanism.
    *
    * @category Database
+   *
+   * @example Validate an insert without persisting
+   * ```ts
+   * const { data, error } = await supabase
+   *   .from('countries')
+   *   .insert({ name: 'France' })
+   *   .select()
+   *   .rollback()
+   * // `data` shows what would have been inserted; nothing is saved.
+   * ```
    */
   rollback(): this {
     this.headers.append('Prefer', 'tx=rollback')

--- a/packages/core/postgrest-js/src/PostgrestTransformBuilder.ts
+++ b/packages/core/postgrest-js/src/PostgrestTransformBuilder.ts
@@ -772,6 +772,7 @@ export default class PostgrestTransformBuilder<
    * Return `data` as an object in [GeoJSON](https://geojson.org) format.
    *
    * @category Database
+   * @subcategory Using modifiers
    */
   geojson(): PostgrestBuilder<ClientOptions, Record<string, unknown>, ThrowOnError> {
     this.headers.set('Accept', 'application/geo+json')
@@ -932,6 +933,7 @@ export default class PostgrestTransformBuilder<
    * preferences for the underlying mechanism.
    *
    * @category Database
+   * @subcategory Using modifiers
    *
    * @example Validate an insert without persisting
    * ```ts
@@ -1016,6 +1018,7 @@ export default class PostgrestTransformBuilder<
    * @param rows - The maximum number of rows that can be affected
    *
    * @category Database
+   * @subcategory Using modifiers
    */
   maxAffected(rows: number): MaxAffectedEnabled<ClientOptions['PostgrestVersion']> extends true
     ? // TODO: update the RPC case to only work on RPC that returns SETOF rows


### PR DESCRIPTION
Three adjustments to the auto-generated reference docs, prompted by feedback in `#help` about methods that read confusingly after the recent docs rendering rework surfaced them.

### `rollback()` (postgrest)

Was appearing as a standalone command in the reference even though it is a modifier, and its terse JSDoc ("Rollback the query") made it look like a JS-side transaction primitive — which supabase-js does not have. The JSDoc now leads with "dry-run", explains the rollback happens server-side via `Prefer: tx=rollback` (RETURNING/RLS/triggers still evaluate, nothing is persisted), and explicitly states that supabase-js does not group multiple queries into one transaction.

### Modifier method categorization (postgrest)

Mapping `@category Database` against `@subcategory Using modifiers` showed seven modifier methods missing the subcategory tag, so they did not group under the sidebar's "Using modifiers" section. All seven now have the tag:

- `geojson()`, `maxAffected()`, `rollback()` in `PostgrestTransformBuilder`
- `throwOnError()`, `setHeader()`, `retry()`, deprecated `returns()` in `PostgrestBuilder`

Top-level CRUD verbs in `PostgrestQueryBuilder` and `PostgrestClient` are intentionally left without a subcategory because they render as their own sections in the sidebar.

### `setHeader()` (postgrest)

Its previous one-line JSDoc ("Set an HTTP header for the request.") made it read like a normal step in setup. Rewrote to make clear it is an advanced escape hatch for one-off requests, and to point readers at the `headers` option on the client constructor for client-wide headers and at Supabase Auth for authentication.

### `initialize()` (auth)

Was reading as a normal setup step in the auth reference, when in practice the client calls it automatically during construction. Users who reach for `initialize()` to react to OAuth/magic-link redirects almost always want `onAuthStateChange` instead. The JSDoc now states this directly and explains the one case where calling it manually is legitimate (`skipAutoInitialize: true` for SSR or similar timing control).

### Out of scope

No behavior changes. No test changes — categorization tags and JSDoc only.