### PR TITLE
fix(auth): preserve valid session on refresh failure and cooldown repeat failures

### DIFF
--- a/packages/core/auth-js/src/GoTrueClient.ts
+++ b/packages/core/auth-js/src/GoTrueClient.ts
@@ -6,6 +6,7 @@ import {
   EXPIRY_MARGIN_MS,
   GOTRUE_URL,
   JWKS_TTL,
+  REFRESH_FAILURE_COOLDOWN_MS,
   STORAGE_KEY,
 } from './lib/constants'
 import {
@@ -289,6 +290,17 @@ export default class GoTrueClient {
   protected visibilityChangedCallback: (() => Promise<any>) | null = null
   protected refreshingDeferred: Deferred<CallRefreshTokenResult> | null = null
   /**
+   * Cache of the most recent refresh failure. Serial callers arriving within
+   * `REFRESH_FAILURE_COOLDOWN_MS` (including subsequent auto-refresh ticks)
+   * receive this cached result instead of firing another `/token` request.
+   * Cleared on any successful refresh (locally or via BroadcastChannel from
+   * another tab) and on `_removeSession`.
+   *
+   * Pairs with `refreshingDeferred`: concurrent callers share the in-flight
+   * promise, serial callers within the cooldown share the failure result.
+   */
+  protected lastRefreshFailure: { result: CallRefreshTokenResult; expiresAt: number } | null = null
+  /**
    * Monotonic counter incremented at the top of `_removeSession`, before any
    * `await`. The commit guard inside `_callRefreshToken` captures this value
    * before `_saveSession` and re-checks it after, so a `signOut` that
@@ -481,6 +493,13 @@ export default class GoTrueClient {
 
       this.broadcastChannel?.addEventListener('message', async (event) => {
         this._debug('received broadcast notification from other tab or client', event)
+
+        // Another tab successfully refreshed or signed in — any cached
+        // failure in this tab is stale and should not block the next
+        // refresh attempt.
+        if (event.data.event === 'TOKEN_REFRESHED' || event.data.event === 'SIGNED_IN') {
+          this.lastRefreshFailure = null
+        }
 
         try {
           await this._notifyAllSubscribers(event.data.event, event.data.session, false) // broadcast = false so we don't get an endless loop of messages
@@ -2979,6 +2998,27 @@ export default class GoTrueClient {
 
       const { data: session, error } = await this._callRefreshToken(currentSession.refresh_token)
       if (error) {
+        // Proactive-preserve mirror: `_callRefreshToken` keeps the session
+        // in storage when refresh fails non-retryably but the access token
+        // is still inside its real expiry window. Hand the caller the
+        // still-valid session instead of translating the refresh error
+        // into `session: null`. If the access token has actually expired,
+        // the session is genuinely dead and the error stands. Explicit
+        // refresh entry points (`refreshSession`, `setSession`)
+        // intentionally bypass this fallback — they want to know the
+        // refresh failed.
+        const accessTokenStillValid = !!(
+          currentSession.expires_at && currentSession.expires_at * 1000 > Date.now()
+        )
+        if (accessTokenStillValid) {
+          // Race guard: a concurrent `signOut` may have cleared storage
+          // during the refresh attempt. Don't hand back a session that no
+          // longer exists on disk.
+          const stillStored = (await getItemAsync(this.storage, this.storageKey)) as Session | null
+          if (stillStored && stillStored.refresh_token === currentSession.refresh_token) {
+            return this._returnResult({ data: { session: currentSession }, error: null })
+          }
+        }
         return this._returnResult({ data: { session: null }, error })
       }
 
@@ -4730,22 +4770,16 @@ export default class GoTrueClient {
           const { error } = await this._callRefreshToken(currentSession.refresh_token)
 
           if (error) {
-            // AuthRefreshDiscardedError means a concurrent signOut already
-            // cleared storage and fired SIGNED_OUT. Don't run _removeSession
-            // again here, or we'll emit a duplicate SIGNED_OUT.
+            // `_callRefreshToken` is the single source of truth for refresh
+            // outcomes: it removes the session itself when the access token
+            // is actually expired, and preserves it when the token is still
+            // valid (proactive-preserve). Don't second-guess that here — a
+            // local `_removeSession` would emit a duplicate `SIGNED_OUT` on
+            // genuine failures and undo the proactive-preserve at init time.
             if (isAuthRefreshDiscardedError(error)) {
               this._debug(debugName, 'refresh discarded by commit guard', error)
             } else {
               this._debug(debugName, 'refresh failed', error)
-
-              if (!isAuthRetryableFetchError(error)) {
-                this._debug(
-                  debugName,
-                  'refresh failed with a non-retryable error, removing the session',
-                  error
-                )
-                await this._removeSession()
-              }
             }
           }
         }
@@ -4796,6 +4830,18 @@ export default class GoTrueClient {
     // refreshing is already in progress
     if (this.refreshingDeferred) {
       return this.refreshingDeferred.promise
+    }
+
+    // Serial failure cooldown: callers arriving after a recent failure
+    // receive the cached result instead of firing another `/token` request.
+    // This caps the proactive-refresh storm where every `getSession()` call
+    // inside the 90s EXPIRY_MARGIN_MS window kept re-firing against the
+    // same broken refresh token during outages. Concurrent callers already
+    // share `refreshingDeferred`; this cache covers serial callers spaced
+    // across cooldown windows.
+    if (this.lastRefreshFailure && Date.now() < this.lastRefreshFailure.expiresAt) {
+      this._debug('#_callRefreshToken()', 'returning cached failure (cooldown active)')
+      return this.lastRefreshFailure.result
     }
 
     // Refresh tokens are long-lived bearer credentials; do NOT include any
@@ -4881,6 +4927,10 @@ export default class GoTrueClient {
 
       const result = { data: data.session, error: null }
 
+      // Refresh succeeded — clear any cached failure so the next caller
+      // (including the auto-refresh ticker) attempts a real refresh again.
+      this.lastRefreshFailure = null
+
       this.refreshingDeferred.resolve(result)
 
       return result
@@ -4891,7 +4941,39 @@ export default class GoTrueClient {
         const result = { data: null, error }
 
         if (!isAuthRetryableFetchError(error)) {
-          await this._removeSession()
+          // Proactive vs reactive distinction: a refresh fires whenever
+          // the access token is within EXPIRY_MARGIN_MS of expiry. If the
+          // access token is *still valid* at this moment, the refresh was
+          // proactive and the existing session is still usable until its
+          // real expiry — destroying it now would log out a user whose
+          // access token works. If the access token has actually expired,
+          // the refresh token is the only credential left and it just got
+          // rejected — the session is genuinely dead. `__loadSession`
+          // mirrors this distinction on the read path so callers see the
+          // preserved session instead of `session: null`.
+          const storedNow = (await getItemAsync(this.storage, this.storageKey)) as Session | null
+          const accessTokenStillValid = !!(
+            storedNow?.expires_at && storedNow.expires_at * 1000 > Date.now()
+          )
+
+          if (accessTokenStillValid) {
+            this._debug(
+              debugName,
+              'proactive refresh failed, access token still valid — preserving session'
+            )
+          } else {
+            await this._removeSession()
+          }
+        }
+
+        // Cache the failure so serial callers (and the next auto-refresh
+        // tick) within the cooldown window receive it synchronously
+        // instead of firing another `/token` call. Set after the optional
+        // `_removeSession` above (which clears the cache as part of
+        // teardown) so the cache survives.
+        this.lastRefreshFailure = {
+          result,
+          expiresAt: Date.now() + REFRESH_FAILURE_COOLDOWN_MS,
         }
 
         this.refreshingDeferred?.resolve(result)
@@ -4994,6 +5076,10 @@ export default class GoTrueClient {
     // `_callRefreshToken`. See `_sessionRemovalEpoch` field doc.
     this._sessionRemovalEpoch += 1
     this._debug('#_removeSession()')
+
+    // The session is gone — no point holding on to a cached refresh failure
+    // for a token that no longer exists. Synchronous, before any `await`.
+    this.lastRefreshFailure = null
 
     this.suppressGetSessionWarning = false
 

--- a/packages/core/auth-js/src/GoTrueClient.ts
+++ b/packages/core/auth-js/src/GoTrueClient.ts
@@ -290,16 +290,24 @@ export default class GoTrueClient {
   protected visibilityChangedCallback: (() => Promise<any>) | null = null
   protected refreshingDeferred: Deferred<CallRefreshTokenResult> | null = null
   /**
-   * Cache of the most recent refresh failure. Serial callers arriving within
+   * Cache of the most recent refresh failure, keyed by the refresh token
+   * that failed. Serial callers passing the *same* token within
    * `REFRESH_FAILURE_COOLDOWN_MS` (including subsequent auto-refresh ticks)
    * receive this cached result instead of firing another `/token` request.
+   * Callers passing a *different* token (token rotation pickup, explicit
+   * `setSession`/`refreshSession({ refresh_token })`, multi-account switch)
+   * bypass the cache and attempt a fresh refresh as they should.
    * Cleared on any successful refresh (locally or via BroadcastChannel from
    * another tab) and on `_removeSession`.
    *
    * Pairs with `refreshingDeferred`: concurrent callers share the in-flight
    * promise, serial callers within the cooldown share the failure result.
    */
-  protected lastRefreshFailure: { result: CallRefreshTokenResult; expiresAt: number } | null = null
+  protected lastRefreshFailure: {
+    refreshToken: string
+    result: CallRefreshTokenResult
+    expiresAt: number
+  } | null = null
   /**
    * Monotonic counter incremented at the top of `_removeSession`, before any
    * `await`. The commit guard inside `_callRefreshToken` captures this value
@@ -4832,14 +4840,22 @@ export default class GoTrueClient {
       return this.refreshingDeferred.promise
     }
 
-    // Serial failure cooldown: callers arriving after a recent failure
-    // receive the cached result instead of firing another `/token` request.
-    // This caps the proactive-refresh storm where every `getSession()` call
-    // inside the 90s EXPIRY_MARGIN_MS window kept re-firing against the
-    // same broken refresh token during outages. Concurrent callers already
-    // share `refreshingDeferred`; this cache covers serial callers spaced
-    // across cooldown windows.
-    if (this.lastRefreshFailure && Date.now() < this.lastRefreshFailure.expiresAt) {
+    // Serial failure cooldown: callers passing the *same* refresh token
+    // after a recent failure receive the cached result instead of firing
+    // another `/token` request. This caps the proactive-refresh storm
+    // where every `getSession()` call inside the 90s EXPIRY_MARGIN_MS
+    // window kept re-firing against the same broken refresh token during
+    // outages. Concurrent callers already share `refreshingDeferred`; this
+    // cache covers serial callers spaced across cooldown windows.
+    //
+    // Token-keyed so callers with a fresh refresh token (rotation pickup
+    // from another tab, explicit `setSession`/`refreshSession({ refresh_token })`,
+    // multi-account switch) bypass the cache and attempt a real refresh.
+    if (
+      this.lastRefreshFailure &&
+      this.lastRefreshFailure.refreshToken === refreshToken &&
+      Date.now() < this.lastRefreshFailure.expiresAt
+    ) {
       this._debug('#_callRefreshToken()', 'returning cached failure (cooldown active)')
       return this.lastRefreshFailure.result
     }
@@ -4967,11 +4983,12 @@ export default class GoTrueClient {
         }
 
         // Cache the failure so serial callers (and the next auto-refresh
-        // tick) within the cooldown window receive it synchronously
-        // instead of firing another `/token` call. Set after the optional
-        // `_removeSession` above (which clears the cache as part of
-        // teardown) so the cache survives.
+        // tick) passing the same refresh token within the cooldown window
+        // receive it synchronously instead of firing another `/token`
+        // call. Set after the optional `_removeSession` above (which
+        // clears the cache as part of teardown) so the cache survives.
         this.lastRefreshFailure = {
+          refreshToken,
           result,
           expiresAt: Date.now() + REFRESH_FAILURE_COOLDOWN_MS,
         }

--- a/packages/core/auth-js/src/lib/constants.ts
+++ b/packages/core/auth-js/src/lib/constants.ts
@@ -12,6 +12,15 @@ export const AUTO_REFRESH_TICK_THRESHOLD = 3
  */
 export const EXPIRY_MARGIN_MS = AUTO_REFRESH_TICK_THRESHOLD * AUTO_REFRESH_TICK_DURATION_MS
 
+/**
+ * After a refresh fails, serial callers (including the next auto-refresh
+ * tick) within this window receive the cached failure instead of firing
+ * another /token request. Two ticks: each outage burns at most one /token
+ * call per cooldown window. Cleared on any successful refresh (locally or
+ * via BroadcastChannel from another tab) and on `_removeSession`.
+ */
+export const REFRESH_FAILURE_COOLDOWN_MS = 2 * AUTO_REFRESH_TICK_DURATION_MS
+
 export const GOTRUE_URL = 'http://localhost:9999'
 export const STORAGE_KEY = 'supabase.auth.token'
 export const AUDIENCE = ''

--- a/packages/core/auth-js/src/lib/fetch.ts
+++ b/packages/core/auth-js/src/lib/fetch.ts
@@ -69,10 +69,12 @@ const _getErrorMessage = (err: unknown): string => {
   return JSON.stringify(err)
 }
 
-// 502, 503, 504: Standard server/gateway errors
-// 520-524, 530: Cloudflare-specific error codes (web server down, connection timed out, etc.)
+// 500, 501, 502, 503, 504: Standard server/gateway errors
+// 520-529, 530: Cloudflare-specific error codes (web server down, connection timed out, etc.)
 // These are infrastructure errors and should not cause session invalidation.
-const NETWORK_ERROR_CODES = [502, 503, 504, 520, 521, 522, 523, 524, 530]
+const NETWORK_ERROR_CODES = [
+  500, 501, 502, 503, 504, 520, 521, 522, 523, 524, 525, 526, 527, 528, 529, 530,
+]
 
 export async function handleError(error: unknown) {
   if (!looksLikeFetchResponse(error)) {

--- a/packages/core/auth-js/test/GoTrueClient.test.ts
+++ b/packages/core/auth-js/test/GoTrueClient.test.ts
@@ -409,6 +409,13 @@ describe('GoTrueClient', () => {
 
       expect(refreshAccessTokenSpy).toHaveBeenCalledTimes(1)
 
+      // The failure cooldown would normally short-circuit the next serial
+      // caller; clear it so this test continues to verify the deferred
+      // itself has been reset (the cooldown is exercised in its own block
+      // below).
+      // @ts-expect-error 'Allow access to private lastRefreshFailure'
+      authWithSession.lastRefreshFailure = null
+
       // verify the deferred has been reset and successive calls can be made
       // @ts-expect-error 'Allow access to private _callRefreshToken()'
       const { data: session3, error: error3 } = await authWithSession._callRefreshToken(
@@ -4564,15 +4571,22 @@ describe('Refresh-token lifecycle (proactive/reactive, cooldown)', () => {
   describe('init cleanup (no double SIGNED_OUT)', () => {
     test('_recoverAndRefresh non-retryable failure emits SIGNED_OUT exactly once', async () => {
       const storage = memoryLocalStorageAdapter()
+      // Plant the session BEFORE constructing the client so it's present
+      // when _recoverAndRefresh runs at init time.
+      await plantSession(storage, { secondsUntilExpiry: -60 })
+
       const client = new GoTrueClient({
         url: GOTRUE_URL_SIGNUP_ENABLED_AUTO_CONFIRM_ON,
         storage,
         autoRefreshToken: true,
         persistSession: true,
+        // Without this, the constructor fires `initialize()` in the
+        // background before we can stub `_refreshAccessToken` and attach
+        // the listener — the test would observe 0 events because init
+        // had already settled against the unstubbed method.
+        skipAutoInitialize: true,
       })
-      // Plant a session whose access token has already expired so the
-      // refresh failure flows through the reactive (remove) branch.
-      await plantSession(storage, { secondsUntilExpiry: -60 })
+
       stubInvalidGrant(client)
 
       const events: string[] = []

--- a/packages/core/auth-js/test/GoTrueClient.test.ts
+++ b/packages/core/auth-js/test/GoTrueClient.test.ts
@@ -2,7 +2,11 @@ import { AuthError, AuthPKCECodeVerifierMissingError } from '../src/lib/errors'
 import { JWK, Session } from '../src'
 import GoTrueClient from '../src/GoTrueClient'
 import { base64UrlToUint8Array } from '../src/lib/base64url'
-import { STORAGE_KEY } from '../src/lib/constants'
+import {
+  AUTO_REFRESH_TICK_DURATION_MS,
+  REFRESH_FAILURE_COOLDOWN_MS,
+  STORAGE_KEY,
+} from '../src/lib/constants'
 import { getItemAsync, setItemAsync } from '../src/lib/helpers'
 import { memoryLocalStorageAdapter } from '../src/lib/local-storage'
 import {
@@ -4211,5 +4215,398 @@ describe('GoTrueClient with skipAutoInitialize option', () => {
     // Should work without explicit initialize() call
     expect(error).toBeNull()
     expect(data.user).toBeDefined()
+  })
+})
+
+describe('Refresh-token lifecycle (proactive/reactive, cooldown)', () => {
+  const plantSession = async (
+    storage: ReturnType<typeof memoryLocalStorageAdapter>,
+    overrides: { secondsUntilExpiry?: number; refreshToken?: string } = {}
+  ) => {
+    const secondsUntilExpiry = overrides.secondsUntilExpiry ?? 60
+    const session: Session = {
+      access_token: 'jwt.accesstoken.signature',
+      refresh_token: overrides.refreshToken ?? 'refresh-token-r1',
+      token_type: 'bearer',
+      expires_in: secondsUntilExpiry,
+      expires_at: Math.floor(Date.now() / 1000) + secondsUntilExpiry,
+      user: { id: 'user-1', email: 'u@example.com' } as any,
+    }
+    await setItemAsync(storage, STORAGE_KEY, session)
+    return session
+  }
+
+  const buildClient = (storage: ReturnType<typeof memoryLocalStorageAdapter>) =>
+    new GoTrueClient({
+      url: GOTRUE_URL_SIGNUP_ENABLED_AUTO_CONFIRM_ON,
+      storage,
+      autoRefreshToken: false,
+      persistSession: true,
+    })
+
+  const stubInvalidGrant = (client: GoTrueClient) => {
+    const spy = jest.fn(async () => ({
+      data: { session: null, user: null },
+      error: Object.assign(new AuthError('Invalid Refresh Token: Already Used', 400), {
+        name: 'AuthApiError',
+        code: 'refresh_token_already_used',
+        __isAuthError: true,
+      }),
+    }))
+    // @ts-expect-error access protected for test
+    client._refreshAccessToken = spy
+    return spy
+  }
+
+  const stubNetworkError = (client: GoTrueClient) => {
+    const spy = jest.fn(async () => ({
+      data: { session: null, user: null },
+      error: Object.assign(new AuthError('Failed to fetch', 0), {
+        name: 'AuthRetryableFetchError',
+        __isAuthError: true,
+      }),
+    }))
+    // @ts-expect-error access protected for test
+    client._refreshAccessToken = spy
+    return spy
+  }
+
+  describe('storage preservation (Fix A)', () => {
+    test('non-retryable refresh failure + access token still valid → storage preserved', async () => {
+      const storage = memoryLocalStorageAdapter()
+      const client = buildClient(storage)
+      await client.initialize()
+      await plantSession(storage, { secondsUntilExpiry: 60 })
+      stubInvalidGrant(client)
+
+      // @ts-expect-error access protected for test
+      const result = await client._callRefreshToken('refresh-token-r1')
+
+      // _callRefreshToken itself returns the error so explicit callers
+      // know the refresh did not actually rotate the token; caller-visible
+      // preservation lives in __loadSession (see Fix B tests below).
+      expect(result.data).toBeNull()
+      expect((result.error as AuthError)?.code).toBe('refresh_token_already_used')
+
+      const stored = (await getItemAsync(storage, STORAGE_KEY)) as Session | null
+      expect(stored?.refresh_token).toBe('refresh-token-r1')
+    })
+
+    test('non-retryable refresh failure + access token already expired → storage cleared', async () => {
+      const storage = memoryLocalStorageAdapter()
+      const client = buildClient(storage)
+      await client.initialize()
+      await plantSession(storage, { secondsUntilExpiry: -60 })
+      stubInvalidGrant(client)
+
+      // @ts-expect-error access protected for test
+      const result = await client._callRefreshToken('refresh-token-r1')
+
+      expect(result.data).toBeNull()
+      expect((result.error as AuthError)?.code).toBe('refresh_token_already_used')
+
+      const stored = (await getItemAsync(storage, STORAGE_KEY)) as Session | null
+      expect(stored).toBeNull()
+    })
+
+    test('retryable (network) refresh failure → storage preserved regardless of expiry', async () => {
+      const storage = memoryLocalStorageAdapter()
+      const client = buildClient(storage)
+      await client.initialize()
+      await plantSession(storage, { secondsUntilExpiry: -60 })
+      stubNetworkError(client)
+
+      // @ts-expect-error access protected for test
+      const result = await client._callRefreshToken('refresh-token-r1')
+
+      expect((result.error as AuthError)?.name).toBe('AuthRetryableFetchError')
+
+      const stored = (await getItemAsync(storage, STORAGE_KEY)) as Session | null
+      expect(stored?.refresh_token).toBe('refresh-token-r1')
+    })
+  })
+
+  describe('caller-visible preservation in getSession (Fix B)', () => {
+    test('proactive refresh failure + access token still valid → returns preserved session', async () => {
+      const storage = memoryLocalStorageAdapter()
+      const client = buildClient(storage)
+      await client.initialize()
+      // Within EXPIRY_MARGIN_MS so __loadSession triggers a refresh, but
+      // the access token is still inside its real expiry window.
+      await plantSession(storage, { secondsUntilExpiry: 30 })
+      stubInvalidGrant(client)
+
+      const { data, error } = await client.getSession()
+
+      expect(error).toBeNull()
+      expect(data.session).not.toBeNull()
+      expect(data.session?.access_token).toBe('jwt.accesstoken.signature')
+      expect(data.session?.refresh_token).toBe('refresh-token-r1')
+    })
+
+    test('reactive refresh failure (access token already expired) → returns null + error', async () => {
+      const storage = memoryLocalStorageAdapter()
+      const client = buildClient(storage)
+      await client.initialize()
+      await plantSession(storage, { secondsUntilExpiry: -60 })
+      stubInvalidGrant(client)
+
+      const { data, error } = await client.getSession()
+
+      expect(data.session).toBeNull()
+      expect((error as AuthError)?.code).toBe('refresh_token_already_used')
+    })
+
+    test('race guard: storage cleared during refresh → returns null + error', async () => {
+      const storage = memoryLocalStorageAdapter()
+      const client = buildClient(storage)
+      await client.initialize()
+      await plantSession(storage, { secondsUntilExpiry: 30 })
+
+      // Stub refresh: simulates a concurrent signOut by wiping storage
+      // mid-refresh, then returning a non-retryable error. The race guard
+      // in __loadSession must catch the disappeared storage and return null.
+      // @ts-expect-error access protected for test
+      client._refreshAccessToken = jest.fn(async () => {
+        await storage.removeItem(STORAGE_KEY)
+        return {
+          data: { session: null, user: null },
+          error: Object.assign(new AuthError('Invalid Refresh Token', 400), {
+            name: 'AuthApiError',
+            code: 'refresh_token_already_used',
+            __isAuthError: true,
+          }),
+        }
+      })
+
+      const { data, error } = await client.getSession()
+
+      expect(data.session).toBeNull()
+      expect(error).not.toBeNull()
+    })
+  })
+
+  describe('explicit-caller contract (no semantic regression)', () => {
+    test('refreshSession() on proactive-preserve scenario still returns error', async () => {
+      const storage = memoryLocalStorageAdapter()
+      const client = buildClient(storage)
+      await client.initialize()
+      await plantSession(storage, { secondsUntilExpiry: 60 })
+      stubInvalidGrant(client)
+
+      const { data, error } = await client.refreshSession()
+
+      // Explicit caller asked for a *new* token; must surface the failure
+      // rather than hand back the old session as if freshly minted.
+      expect(data.session).toBeNull()
+      expect(data.user).toBeNull()
+      expect((error as AuthError)?.code).toBe('refresh_token_already_used')
+    })
+
+    test('setSession() whose refresh fails non-retryably still returns error', async () => {
+      const storage = memoryLocalStorageAdapter()
+      const client = buildClient(storage)
+      await client.initialize()
+      stubInvalidGrant(client)
+
+      const { data, error } = await client.setSession({
+        access_token: expiredAccessToken,
+        refresh_token: 'refresh-token-r1',
+      })
+
+      expect(data.session).toBeNull()
+      expect(error).not.toBeNull()
+    })
+  })
+
+  describe('failure cooldown (Fix C)', () => {
+    test('50 sequential _callRefreshToken calls during failure → exactly 1 /token', async () => {
+      const storage = memoryLocalStorageAdapter()
+      const client = buildClient(storage)
+      await client.initialize()
+      await plantSession(storage, { secondsUntilExpiry: 60 })
+      const spy = stubInvalidGrant(client)
+
+      // @ts-expect-error access protected for test
+      await client._callRefreshToken('refresh-token-r1')
+
+      for (let i = 0; i < 50; i++) {
+        // @ts-expect-error access protected for test
+        const result = await client._callRefreshToken('refresh-token-r1')
+        expect(result.data).toBeNull()
+        expect((result.error as AuthError)?.code).toBe('refresh_token_already_used')
+      }
+      expect(spy).toHaveBeenCalledTimes(1)
+    })
+
+    test('cooldown cleared after successful refresh', async () => {
+      const storage = memoryLocalStorageAdapter()
+      const client = buildClient(storage)
+      await client.initialize()
+      await plantSession(storage, { secondsUntilExpiry: 60 })
+
+      // @ts-expect-error access protected for test
+      client.lastRefreshFailure = {
+        result: {
+          data: null,
+          error: Object.assign(new AuthError('stale', 400), {
+            name: 'AuthApiError',
+            code: 'refresh_token_already_used',
+            __isAuthError: true,
+          }),
+        } as any,
+        expiresAt: Date.now() + 30_000,
+      }
+
+      const newSession = {
+        access_token: 'jwt.new.signature',
+        refresh_token: 'refresh-token-r2',
+        token_type: 'bearer',
+        expires_in: 3600,
+        expires_at: Math.floor(Date.now() / 1000) + 3600,
+        user: { id: 'user-1', email: 'u@example.com' },
+      }
+      // @ts-expect-error access protected for test
+      client._refreshAccessToken = jest.fn(async () => ({
+        data: { session: newSession, user: newSession.user },
+        error: null,
+      }))
+
+      // First call hits the stale cooldown.
+      // @ts-expect-error access protected for test
+      const cached = await client._callRefreshToken('refresh-token-r1')
+      expect(cached.error).not.toBeNull()
+
+      // Clear cooldown manually and confirm a fresh refresh resets it.
+      // @ts-expect-error access protected for test
+      client.lastRefreshFailure = null
+
+      // @ts-expect-error access protected for test
+      const fresh = await client._callRefreshToken('refresh-token-r1')
+      expect(fresh.error).toBeNull()
+      expect(fresh.data?.refresh_token).toBe('refresh-token-r2')
+
+      // @ts-expect-error access protected for test
+      expect(client.lastRefreshFailure).toBeNull()
+    })
+
+    test('cooldown cleared inside _removeSession', async () => {
+      const storage = memoryLocalStorageAdapter()
+      const client = buildClient(storage)
+      await client.initialize()
+      await plantSession(storage, { secondsUntilExpiry: 60 })
+
+      // @ts-expect-error access protected for test
+      client.lastRefreshFailure = {
+        result: {
+          data: null,
+          error: Object.assign(new AuthError('x', 400), {
+            name: 'AuthApiError',
+            code: 'refresh_token_already_used',
+            __isAuthError: true,
+          }),
+        } as any,
+        expiresAt: Date.now() + 30_000,
+      }
+
+      // @ts-expect-error access protected for test
+      await client._removeSession()
+
+      // @ts-expect-error access protected for test
+      expect(client.lastRefreshFailure).toBeNull()
+    })
+
+    test('cooldown cleared on BroadcastChannel TOKEN_REFRESHED', async () => {
+      const storage = memoryLocalStorageAdapter()
+      const client = buildClient(storage)
+      await client.initialize()
+
+      // @ts-expect-error access protected for test
+      client.lastRefreshFailure = {
+        result: {
+          data: null,
+          error: Object.assign(new AuthError('x', 400), {
+            name: 'AuthApiError',
+            code: 'refresh_token_already_used',
+            __isAuthError: true,
+          }),
+        } as any,
+        expiresAt: Date.now() + 30_000,
+      }
+
+      // Simulate the broadcast handler clearing the cache directly. The
+      // browser-only setup wires this in `initialize`; here we exercise the
+      // contract (clear on TOKEN_REFRESHED) by calling the same statement
+      // the handler runs.
+      const event = { data: { event: 'TOKEN_REFRESHED' as const, session: null } }
+      if (event.data.event === 'TOKEN_REFRESHED' || event.data.event === 'SIGNED_IN') {
+        // @ts-expect-error access protected for test
+        client.lastRefreshFailure = null
+      }
+
+      // @ts-expect-error access protected for test
+      expect(client.lastRefreshFailure).toBeNull()
+    })
+
+    test('cooldown expires after REFRESH_FAILURE_COOLDOWN_MS and next call fires /token', async () => {
+      jest.useFakeTimers({ doNotFake: ['setImmediate'] })
+      try {
+        const storage = memoryLocalStorageAdapter()
+        const client = buildClient(storage)
+        await client.initialize()
+        await plantSession(storage, { secondsUntilExpiry: 600 })
+        const spy = stubInvalidGrant(client)
+
+        // First call sets the cooldown.
+        // @ts-expect-error access protected for test
+        await client._callRefreshToken('refresh-token-r1')
+        expect(spy).toHaveBeenCalledTimes(1)
+
+        // Inside the cooldown — no new /token.
+        // @ts-expect-error access protected for test
+        await client._callRefreshToken('refresh-token-r1')
+        expect(spy).toHaveBeenCalledTimes(1)
+
+        // Advance past the cooldown.
+        jest.setSystemTime(Date.now() + REFRESH_FAILURE_COOLDOWN_MS + 1000)
+
+        // Now the cooldown has expired — next call fires /token again.
+        // @ts-expect-error access protected for test
+        await client._callRefreshToken('refresh-token-r1')
+        expect(spy).toHaveBeenCalledTimes(2)
+      } finally {
+        jest.useRealTimers()
+      }
+    })
+
+    test('REFRESH_FAILURE_COOLDOWN_MS is two auto-refresh ticks', () => {
+      expect(REFRESH_FAILURE_COOLDOWN_MS).toBe(2 * AUTO_REFRESH_TICK_DURATION_MS)
+    })
+  })
+
+  describe('init cleanup (no double SIGNED_OUT)', () => {
+    test('_recoverAndRefresh non-retryable failure emits SIGNED_OUT exactly once', async () => {
+      const storage = memoryLocalStorageAdapter()
+      const client = new GoTrueClient({
+        url: GOTRUE_URL_SIGNUP_ENABLED_AUTO_CONFIRM_ON,
+        storage,
+        autoRefreshToken: true,
+        persistSession: true,
+      })
+      // Plant a session whose access token has already expired so the
+      // refresh failure flows through the reactive (remove) branch.
+      await plantSession(storage, { secondsUntilExpiry: -60 })
+      stubInvalidGrant(client)
+
+      const events: string[] = []
+      client.onAuthStateChange((event) => {
+        events.push(event)
+      })
+
+      await client.initialize()
+
+      const signedOutCount = events.filter((e) => e === 'SIGNED_OUT').length
+      expect(signedOutCount).toBe(1)
+    })
   })
 })

--- a/packages/core/auth-js/test/GoTrueClient.test.ts
+++ b/packages/core/auth-js/test/GoTrueClient.test.ts
@@ -4454,6 +4454,7 @@ describe('Refresh-token lifecycle (proactive/reactive, cooldown)', () => {
 
       // @ts-expect-error access protected for test
       client.lastRefreshFailure = {
+        refreshToken: 'refresh-token-r1',
         result: {
           data: null,
           error: Object.assign(new AuthError('stale', 400), {
@@ -4505,6 +4506,7 @@ describe('Refresh-token lifecycle (proactive/reactive, cooldown)', () => {
 
       // @ts-expect-error access protected for test
       client.lastRefreshFailure = {
+        refreshToken: 'refresh-token-r1',
         result: {
           data: null,
           error: Object.assign(new AuthError('x', 400), {
@@ -4565,6 +4567,33 @@ describe('Refresh-token lifecycle (proactive/reactive, cooldown)', () => {
 
     test('REFRESH_FAILURE_COOLDOWN_MS is two auto-refresh ticks', () => {
       expect(REFRESH_FAILURE_COOLDOWN_MS).toBe(2 * AUTO_REFRESH_TICK_DURATION_MS)
+    })
+
+    test('cooldown is keyed by refresh token — different token bypasses the cache', async () => {
+      const storage = memoryLocalStorageAdapter()
+      const client = buildClient(storage)
+      await client.initialize()
+      await plantSession(storage, { secondsUntilExpiry: 60 })
+      const spy = stubInvalidGrant(client)
+
+      // First call fails and caches the failure under token A.
+      // @ts-expect-error access protected for test
+      await client._callRefreshToken('refresh-token-A')
+      expect(spy).toHaveBeenCalledTimes(1)
+
+      // A second call with the *same* token is short-circuited by the
+      // cache (no new /token).
+      // @ts-expect-error access protected for test
+      await client._callRefreshToken('refresh-token-A')
+      expect(spy).toHaveBeenCalledTimes(1)
+
+      // A call with a *different* refresh token (e.g. picked up from a
+      // sibling tab's rotation, or hydrated via setSession / refreshSession)
+      // must NOT return token A's cached failure — it must attempt a fresh
+      // refresh of token B. This is the regression spydon flagged.
+      // @ts-expect-error access protected for test
+      await client._callRefreshToken('refresh-token-B')
+      expect(spy).toHaveBeenCalledTimes(2)
     })
   })
 

--- a/packages/core/auth-js/test/GoTrueClient.test.ts
+++ b/packages/core/auth-js/test/GoTrueClient.test.ts
@@ -4516,37 +4516,14 @@ describe('Refresh-token lifecycle (proactive/reactive, cooldown)', () => {
       expect(client.lastRefreshFailure).toBeNull()
     })
 
-    test('cooldown cleared on BroadcastChannel TOKEN_REFRESHED', async () => {
-      const storage = memoryLocalStorageAdapter()
-      const client = buildClient(storage)
-      await client.initialize()
-
-      // @ts-expect-error access protected for test
-      client.lastRefreshFailure = {
-        result: {
-          data: null,
-          error: Object.assign(new AuthError('x', 400), {
-            name: 'AuthApiError',
-            code: 'refresh_token_already_used',
-            __isAuthError: true,
-          }),
-        } as any,
-        expiresAt: Date.now() + 30_000,
-      }
-
-      // Simulate the broadcast handler clearing the cache directly. The
-      // browser-only setup wires this in `initialize`; here we exercise the
-      // contract (clear on TOKEN_REFRESHED) by calling the same statement
-      // the handler runs.
-      const event = { data: { event: 'TOKEN_REFRESHED' as const, session: null } }
-      if (event.data.event === 'TOKEN_REFRESHED' || event.data.event === 'SIGNED_IN') {
-        // @ts-expect-error access protected for test
-        client.lastRefreshFailure = null
-      }
-
-      // @ts-expect-error access protected for test
-      expect(client.lastRefreshFailure).toBeNull()
-    })
+    // BroadcastChannel cache-clear (GoTrueClient.ts:485-492) is not unit
+    // tested here: `globalThis.BroadcastChannel` is undefined in the Jest
+    // node env, so the handler is never wired up. Properly testing it
+    // would need a BroadcastChannel stub or jsdom, both of which are
+    // out of scope for this test file. The branch is small, exercised
+    // implicitly by manual multi-tab review, and any regression here
+    // would only affect cross-tab cooldown invalidation (callers in the
+    // failing tab still get correct behavior via the same-tab cache).
 
     test('cooldown expires after REFRESH_FAILURE_COOLDOWN_MS and next call fires /token', async () => {
       jest.useFakeTimers({ doNotFake: ['setImmediate'] })

--- a/packages/core/auth-js/test/fetch.test.ts
+++ b/packages/core/auth-js/test/fetch.test.ts
@@ -47,7 +47,7 @@ describe('fetch', () => {
       expect(route).toHaveBeenCalledTimes(1)
     })
 
-    test('should not throw AuthRetryableFetchError upon internal server error', async () => {
+    test('should throw AuthRetryableFetchError upon internal server error (500)', async () => {
       const route = server
         .get('/')
         .mockImplementationOnce((ctx) => {
@@ -60,7 +60,25 @@ describe('fetch', () => {
 
       const url = server.getURL().toString()
 
-      await expect(_request(fetch, 'GET', url)).rejects.not.toBeInstanceOf(AuthRetryableFetchError)
+      await expect(_request(fetch, 'GET', url)).rejects.toBeInstanceOf(AuthRetryableFetchError)
+
+      expect(route).toHaveBeenCalledTimes(1)
+    })
+
+    test('should throw AuthRetryableFetchError upon Cloudflare edge errors (525)', async () => {
+      const route = server
+        .get('/')
+        .mockImplementationOnce((ctx) => {
+          ctx.status = 525
+          ctx.body = 'SSL Handshake Failed'
+        })
+        .mockImplementation((ctx) => {
+          ctx.status = 200
+        })
+
+      const url = server.getURL().toString()
+
+      await expect(_request(fetch, 'GET', url)).rejects.toBeInstanceOf(AuthRetryableFetchError)
 
       expect(route).toHaveBeenCalledTimes(1)
     })


### PR DESCRIPTION
## Description

Fixes the long-standing `_callRefreshToken` issue where a transient or non-retryable refresh failure destroyed a session whose access token was still valid, and the related symptom where a sustained outage had the SDK hammer `/token` with the same dead refresh token until the access token actually expired or the user wiped local storage.

This is the second attempt — see [#2430](https://github.com/supabase/supabase-js/pull/2430) for the prior approach. Key difference: that PR preserved storage in `_callRefreshToken` but `__loadSession` still translated the refresh error into `{ session: null, error }`, so `getSession()` callers stayed effectively logged out — the same failure mode that got [#2146](https://github.com/supabase/supabase-js/pull/2146) rejected. This PR closes that gap end-to-end while keeping explicit refresh entry points (`refreshSession`, `setSession`) honest about failures.

### What changed?

Five complementary changes, all in `packages/core/auth-js/`:

- **Proactive vs reactive in `_callRefreshToken`.** On non-retryable error, re-read storage and skip `_removeSession` if the access token is still inside its real expiry window. Return shape unchanged — explicit callers still see the underlying error.
- **Caller-visible preservation in `__loadSession` only.** When `_callRefreshToken` errors but the in-scope `currentSession` is still valid, hand the caller the preserved session instead of `{ session: null, error }`. Guards against a concurrent `signOut` clearing storage during the refresh attempt by re-reading storage before returning. Scoped to `__loadSession` deliberately so `refreshSession()` / `setSession()` keep their honest error semantics.
- **Serial-failure cooldown cache.** Any refresh failure is cached on the client for `REFRESH_FAILURE_COOLDOWN_MS` (60s, two auto-refresh ticks). Subsequent serial callers within that window receive the cached failure synchronously instead of firing another `/token` call. Cleared on any successful refresh, on `_removeSession`, and on a `TOKEN_REFRESHED` / `SIGNED_IN` broadcast from another tab.
- **Wider transient classification in `lib/fetch.ts`.** `NETWORK_ERROR_CODES` now includes `500`, `501`, and the Cloudflare-origin `525-529` codes. Previously these were misclassified as non-retryable, which on the old catch path triggered `_removeSession()` during outages.
- **Strip the redundant `_removeSession` in `_recoverAndRefresh`.** `_callRefreshToken`'s catch is now the single source of truth for "session is dead enough to wipe." Stops the double-`SIGNED_OUT` during init that @nathanschram flagged on #2145, and prevents the new proactive-preserve from being undone at init time.

### Why was this change needed?

Two real-world failure modes converge on the same code path:

1. **Proactive refresh destroying still-valid sessions.** `__loadSession()` triggers a refresh whenever the access token is within `EXPIRY_MARGIN_MS` (90s) of expiry. If that refresh failed with any non-retryable error (multi-tab rotation race, mobile-browser tab lifecycle, transient 400 from GoTrue), `_removeSession()` was called unconditionally, destroying a session whose access token still worked for up to 90 more seconds. The user was silently logged out with `getSession()` returning `{ session: null, error: null }` and no recovery path short of a full reload and re-login.
2. **Refresh storm during outages.** When the same `/token` call kept failing (DNS unreachable, persistent 4xx/5xx), every subsequent `getSession()` call in the 90s margin re-fired `_callRefreshToken` against the same broken refresh token. Reporters on #2145 documented hundreds to tens of thousands of `/token` requests per hour from a single client, all hitting the same failure.

The proactive/reactive distinction in `_callRefreshToken` plus the `__loadSession` mirror address (1). The cooldown cache addresses (2) by capping `/token` calls to one per 60s window during sustained failure. The widened `NETWORK_ERROR_CODES` ensures common outage status codes are classified as transient instead of dragging the session into the reactive-removal path — the [Reddit r/Supabase report](https://www.reddit.com/r/Supabase/comments/1r49epi/warning_for_mobile_apps_outage_may_have_signed/) of a real outage signing out entire mobile-app user bases was 500 + HTML body responses falling into the non-retryable branch.

Closes #2145

## Screenshots/Examples

Before:

```js
// access token still valid for 60s, refresh fails with 400 invalid_grant
await supabase.auth.getSession()
// returns { data: { session: null }, error: null }
// storage cleared, SIGNED_OUT emitted, user logged out
```

After:

```js
// access token still valid for 60s, refresh fails with 400 invalid_grant
await supabase.auth.getSession()
// returns { data: { session: <existing valid session> }, error: null }
// storage preserved, no SIGNED_OUT emitted, access token still works
// next refresh attempt deferred by REFRESH_FAILURE_COOLDOWN_MS (60s)
```

`refreshSession()` and `setSession()` are unchanged — they still surface the refresh error to their callers so they don't lie about whether the token actually rotated.

## Breaking changes

- [x] This PR contains no breaking changes

No public API changes, no exported type changes, no method signatures changed. Three observable behavior changes worth calling out:

1. **Error class for 500/525-529 from auth.** Previously `AuthApiError`, now `AuthRetryableFetchError`. Both extend `AuthError`, so `catch (e) { if (e instanceof AuthError) ... }` is unaffected. Only `instanceof AuthApiError` for those specific status codes would stop matching.
2. **Fewer spurious `SIGNED_OUT` events.** `onAuthStateChange` callbacks see strictly fewer `SIGNED_OUT` events — only when the session is genuinely dead, never extra. Init-time non-retryable refresh now fires `SIGNED_OUT` exactly once instead of twice.
3. **`getSession()` returns the preserved session** in proactive-preserve scenarios it previously returned `null` for. This is the headline bug fix.

The auto-refresh ticker cadence (`AUTO_REFRESH_TICK_DURATION_MS`) is unchanged. The commit-guard logic for mid-flight signOut races is unchanged. `refreshSession()` / `setSession()` semantics are unchanged.

## Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/supabase/supabase-js/blob/master/CONTRIBUTING.md)
- [x] My PR title follows the [conventional commit format](https://www.conventionalcommits.org/): `<type>(<scope>): <description>`
- [x] I have run `pnpm nx format` to ensure consistent code formatting
- [x] I have added tests for new functionality (if applicable)
- [ ] I have updated documentation (if applicable)

## Additional notes

The cooldown shape follows @thomaslarsson's `lastRefreshResult` sketch on #2145. Concurrent dedupe via `refreshingDeferred` is preserved; the cooldown extends the dedupe contract to serial callers spaced across short failure windows.

Tests added under a new `describe('Refresh-token lifecycle (proactive/reactive, cooldown)')` block in `GoTrueClient.test.ts`, split into five sub-describes:

- **storage preservation** — `_callRefreshToken` preserves on proactive failure, removes on reactive, preserves on retryable network failure regardless of expiry
- **caller-visible preservation in `getSession`** — returns preserved session on proactive-preserve, null on reactive, null when storage cleared concurrently (race guard)
- **explicit-caller contract** — `refreshSession()` and `setSession()` still surface the error on proactive-preserve scenarios
- **failure cooldown** — 50 serial calls collapse to 1 `/token`, cleared on success, cleared in `_removeSession`, expires after `REFRESH_FAILURE_COOLDOWN_MS` (verified with fake timers)
- **init cleanup** — `_recoverAndRefresh` emits `SIGNED_OUT` exactly once on non-retryable refresh failure

The `BroadcastChannel` cache-clear branch is not unit tested — `globalThis.BroadcastChannel` is undefined in the Jest node env and adding a stub for one small branch isn't worth the surface area. Inline comment in the test file documents this.