### PR TITLE
fix(realtime): subscribed state

### DIFF
--- a/packages/core/realtime-js/src/RealtimeChannel.ts
+++ b/packages/core/realtime-js/src/RealtimeChannel.ts
@@ -182,6 +182,7 @@ export default class RealtimeChannel {
   private _postgresChangesSystemReady = false
   private _subscribeCallback: ((status: REALTIME_SUBSCRIBE_STATES, err?: Error) => void) | null =
     null
+  private _subscribeTimeoutId: ReturnType<typeof setTimeout> | null = null
   /** @internal */
   channelAdapter: ChannelAdapter
 
@@ -258,16 +259,33 @@ export default class RealtimeChannel {
     this.presence = new RealtimePresence(this)
     this.channelAdapter.on(REALTIME_LISTEN_TYPES.SYSTEM, (payload: unknown) => {
       if (
-        payload &&
-        typeof payload === 'object' &&
-        'extension' in payload &&
-        payload.extension === REALTIME_LISTEN_TYPES.POSTGRES_CHANGES &&
-        'status' in payload &&
-        payload.status === 'ok'
+        !payload ||
+        typeof payload !== 'object' ||
+        !('extension' in payload) ||
+        payload.extension !== REALTIME_LISTEN_TYPES.POSTGRES_CHANGES ||
+        !('status' in payload)
       ) {
-        this._postgresChangesSystemReady = true
-        this._emitSubscribed()
+        return
       }
+
+      if (payload.status !== 'ok') {
+        this._failSubscribeState(
+          REALTIME_SUBSCRIBE_STATES.CHANNEL_ERROR,
+          new Error(
+            'message' in payload && typeof payload.message === 'string'
+              ? payload.message
+              : `postgres_changes system status: ${String(payload.status)}`
+          )
+        )
+        return
+      }
+
+      this._postgresChangesSystemReady = true
+      this._emitSubscribed()
+    })
+
+    this._onError(() => {
+      this._resetSubscribeState()
     })
 
     this._onClose(() => {
@@ -342,6 +360,7 @@ export default class RealtimeChannel {
       }
 
       this._onError((reason: unknown) => {
+        this._resetSubscribeState()
         callback?.(REALTIME_SUBSCRIBE_STATES.CHANNEL_ERROR, normalizeChannelError(reason))
       })
 
@@ -363,7 +382,7 @@ export default class RealtimeChannel {
             return
           }
 
-          this._updatePostgresBindings(postgres_changes, callback)
+          this._updatePostgresBindings(postgres_changes, callback, timeout)
         })
         .receive('error', (error: { [key: string]: any }) => {
           this._resetSubscribeState()
@@ -381,7 +400,8 @@ export default class RealtimeChannel {
 
   private _updatePostgresBindings(
     postgres_changes: PostgresChangesFilters['postgres_changes'],
-    callback?: (status: REALTIME_SUBSCRIBE_STATES, err?: Error) => void
+    callback?: (status: REALTIME_SUBSCRIBE_STATES, err?: Error) => void,
+    timeout = this.timeout
   ) {
     const clientPostgresBindings = this.bindings.postgres_changes
     const bindingsLen = clientPostgresBindings?.length ?? 0
@@ -406,6 +426,7 @@ export default class RealtimeChannel {
           id: serverPostgresFilter.id,
         })
       } else {
+        this._resetSubscribeState()
         this.unsubscribe()
         this.state = CHANNEL_STATES.errored
 
@@ -420,7 +441,7 @@ export default class RealtimeChannel {
     this.bindings.postgres_changes = newPostgresBindings
 
     if (this.state != CHANNEL_STATES.errored && callback) {
-      this._onSubscribeOk(callback)
+      this._onSubscribeOk(callback, timeout)
     }
   }
 
@@ -1145,13 +1166,17 @@ export default class RealtimeChannel {
     return normalizedServer === normalizedClient
   }
 
-  private _onSubscribeOk(callback: (status: REALTIME_SUBSCRIBE_STATES, err?: Error) => void) {
+  private _onSubscribeOk(
+    callback: (status: REALTIME_SUBSCRIBE_STATES, err?: Error) => void,
+    timeout = this.timeout
+  ) {
     if (!this._shouldWaitForPostgresChangesSystem()) {
       callback(REALTIME_SUBSCRIBE_STATES.SUBSCRIBED)
       return
     }
 
     this._subscribeCallback = callback
+    this._startSubscribeTimeout(timeout)
     this._emitSubscribed()
   }
 
@@ -1161,13 +1186,38 @@ export default class RealtimeChannel {
     }
 
     const callback = this._subscribeCallback
-    this._subscribeCallback = null
-    callback(REALTIME_SUBSCRIBE_STATES.SUBSCRIBED)
+    this._resetSubscribeState()
+    callback?.(REALTIME_SUBSCRIBE_STATES.SUBSCRIBED)
+  }
+
+  private _failSubscribeState(status: REALTIME_SUBSCRIBE_STATES, err?: Error) {
+    if (!this._subscribeCallback) {
+      return
+    }
+
+    const callback = this._subscribeCallback
+    this._resetSubscribeState()
+    this.state = CHANNEL_STATES.errored
+    callback?.(status, err)
+  }
+
+  private _startSubscribeTimeout(timeout: number) {
+    if (this._subscribeTimeoutId) {
+      clearTimeout(this._subscribeTimeoutId)
+    }
+
+    this._subscribeTimeoutId = setTimeout(() => {
+      this._failSubscribeState(REALTIME_SUBSCRIBE_STATES.TIMED_OUT)
+    }, timeout)
   }
 
   private _resetSubscribeState() {
     this._postgresChangesSystemReady = false
     this._subscribeCallback = null
+    if (this._subscribeTimeoutId) {
+      clearTimeout(this._subscribeTimeoutId)
+      this._subscribeTimeoutId = null
+    }
   }
 
   private _shouldWaitForPostgresChangesSystem() {

--- a/packages/core/realtime-js/src/RealtimeChannel.ts
+++ b/packages/core/realtime-js/src/RealtimeChannel.ts
@@ -179,6 +179,9 @@ export default class RealtimeChannel {
   broadcastEndpointURL: string
   private: boolean
   presence: RealtimePresence
+  private _postgresChangesSystemReady = false
+  private _subscribeCallback: ((status: REALTIME_SUBSCRIBE_STATES, err?: Error) => void) | null =
+    null
   /** @internal */
   channelAdapter: ChannelAdapter
 
@@ -253,8 +256,22 @@ export default class RealtimeChannel {
 
     this.channelAdapter = new ChannelAdapter(this.socket.socketAdapter, topic, this.params)
     this.presence = new RealtimePresence(this)
+    this.channelAdapter.on(REALTIME_LISTEN_TYPES.SYSTEM, (payload: unknown) => {
+      if (
+        payload &&
+        typeof payload === 'object' &&
+        'extension' in payload &&
+        payload.extension === REALTIME_LISTEN_TYPES.POSTGRES_CHANGES &&
+        'status' in payload &&
+        payload.status === 'ok'
+      ) {
+        this._postgresChangesSystemReady = true
+        this._emitSubscribed()
+      }
+    })
 
     this._onClose(() => {
+      this._resetSubscribeState()
       this.socket._remove(this)
     })
 
@@ -277,6 +294,10 @@ export default class RealtimeChannel {
    * Log the full `err` so its `cause`, `name`, and any structured fields aren't hidden
    * behind `err.message`.
    *
+   * For channels that only bind `postgres_changes` callbacks, `SUBSCRIBED` is emitted after the
+   * server confirms the Postgres changefeed is ready. Channels with `broadcast` or `presence`
+   * callbacks keep the existing `SUBSCRIBED` timing.
+   *
    * @category Realtime
    *
    * @example Handling errors
@@ -297,6 +318,7 @@ export default class RealtimeChannel {
       this.socket.connect()
     }
     if (this.channelAdapter.isClosed()) {
+      this._resetSubscribeState()
       const {
         config: { broadcast, presence, private: isPrivate },
       } = this.params
@@ -344,11 +366,13 @@ export default class RealtimeChannel {
           this._updatePostgresBindings(postgres_changes, callback)
         })
         .receive('error', (error: { [key: string]: any }) => {
+          this._resetSubscribeState()
           this.state = CHANNEL_STATES.errored
           const message = Object.values(error).join(', ') || 'error'
           callback?.(REALTIME_SUBSCRIBE_STATES.CHANNEL_ERROR, new Error(message, { cause: error }))
         })
         .receive('timeout', () => {
+          this._resetSubscribeState()
           callback?.(REALTIME_SUBSCRIBE_STATES.TIMED_OUT)
         })
     }
@@ -396,7 +420,7 @@ export default class RealtimeChannel {
     this.bindings.postgres_changes = newPostgresBindings
 
     if (this.state != CHANNEL_STATES.errored && callback) {
-      callback(REALTIME_SUBSCRIBE_STATES.SUBSCRIBED)
+      this._onSubscribeOk(callback)
     }
   }
 
@@ -1119,6 +1143,39 @@ export default class RealtimeChannel {
     const normalizedServer = serverValue ?? undefined
     const normalizedClient = clientValue ?? undefined
     return normalizedServer === normalizedClient
+  }
+
+  private _onSubscribeOk(callback: (status: REALTIME_SUBSCRIBE_STATES, err?: Error) => void) {
+    if (!this._shouldWaitForPostgresChangesSystem()) {
+      callback(REALTIME_SUBSCRIBE_STATES.SUBSCRIBED)
+      return
+    }
+
+    this._subscribeCallback = callback
+    this._emitSubscribed()
+  }
+
+  private _emitSubscribed() {
+    if (!this._subscribeCallback || !this._postgresChangesSystemReady) {
+      return
+    }
+
+    const callback = this._subscribeCallback
+    this._subscribeCallback = null
+    callback(REALTIME_SUBSCRIBE_STATES.SUBSCRIBED)
+  }
+
+  private _resetSubscribeState() {
+    this._postgresChangesSystemReady = false
+    this._subscribeCallback = null
+  }
+
+  private _shouldWaitForPostgresChangesSystem() {
+    return (
+      (this.bindings.postgres_changes?.length ?? 0) > 0 &&
+      (this.bindings.broadcast?.length ?? 0) === 0 &&
+      (this.bindings.presence?.length ?? 0) === 0
+    )
   }
 
   /** @internal */

--- a/packages/core/realtime-js/test/RealtimeChannel.lifecycle.test.ts
+++ b/packages/core/realtime-js/test/RealtimeChannel.lifecycle.test.ts
@@ -283,6 +283,13 @@ describe('Channel Lifecycle Management', () => {
     })
 
     describe('socket push operations', () => {
+      const singlePostgresChangeReply = {
+        status: 'ok',
+        response: {
+          postgres_changes: [{ id: 'abc', event: '*', schema: '*' }],
+        },
+      }
+
       test('triggers socket push with default channel params', async () => {
         const joinSpy = vi.fn()
         testSetup.cleanup()
@@ -420,6 +427,13 @@ describe('Channel Lifecycle Management', () => {
             defaultRef
           )
         })
+        expect(cbSpy).not.toHaveBeenCalledWith('SUBSCRIBED')
+
+        channel.channelAdapter.getChannel().trigger('system', {
+          extension: 'postgres_changes',
+          status: 'ok',
+        })
+
         expect(cbSpy).toHaveBeenCalledWith('SUBSCRIBED')
 
         expect(channel.bindings.postgres_changes).toStrictEqual([
@@ -450,6 +464,72 @@ describe('Channel Lifecycle Management', () => {
             callback: func,
           },
         ])
+      })
+
+      test.each([
+        ['broadcast', { event: '*' }],
+        ['presence', { event: 'join' }],
+      ])('does not wait for system ready when %s bindings are present', async (type, filter) => {
+        testSetup.cleanup()
+        testSetup = setupRealtimeTest({
+          useFakeTimers: true,
+          timeout: defaultTimeout,
+          socketHandlers: {
+            phx_join: (socket, message) => {
+              socket.send(phxReply(message as string, singlePostgresChangeReply))
+            },
+          },
+        })
+
+        channel = testSetup.client.channel('topic')
+        const cbSpy = vi.fn()
+        const func = () => {}
+
+        channel.on('postgres_changes', { event: '*', schema: '*' }, func)
+        channel.on(type, filter, func)
+
+        channel.subscribe(cbSpy)
+
+        await vi.waitFor(() => {
+          expect(cbSpy).toHaveBeenCalledWith('SUBSCRIBED')
+        })
+      })
+
+      test('still waits for system ready when presence is enabled without presence callbacks', async () => {
+        testSetup.cleanup()
+        testSetup = setupRealtimeTest({
+          useFakeTimers: true,
+          timeout: defaultTimeout,
+          socketHandlers: {
+            phx_join: (socket, message) => {
+              socket.send(phxReply(message as string, singlePostgresChangeReply))
+            },
+          },
+        })
+
+        channel = testSetup.client.channel('topic', {
+          config: {
+            presence: {
+              enabled: true,
+            },
+          },
+        })
+        const cbSpy = vi.fn()
+        const func = () => {}
+
+        channel.on('postgres_changes', { event: '*', schema: '*' }, func)
+        channel.subscribe(cbSpy)
+
+        expect(cbSpy).not.toHaveBeenCalledWith('SUBSCRIBED')
+
+        channel.channelAdapter.getChannel().trigger('system', {
+          extension: 'postgres_changes',
+          status: 'ok',
+        })
+
+        await vi.waitFor(() => {
+          expect(cbSpy).toHaveBeenCalledWith('SUBSCRIBED')
+        })
       })
     })
 

--- a/packages/core/realtime-js/test/RealtimeChannel.lifecycle.test.ts
+++ b/packages/core/realtime-js/test/RealtimeChannel.lifecycle.test.ts
@@ -434,7 +434,15 @@ describe('Channel Lifecycle Management', () => {
           status: 'ok',
         })
 
+        expect(cbSpy).toHaveBeenCalledTimes(1)
         expect(cbSpy).toHaveBeenCalledWith('SUBSCRIBED')
+
+        channel.channelAdapter.getChannel().trigger('system', {
+          extension: 'postgres_changes',
+          status: 'ok',
+        })
+
+        expect(cbSpy).toHaveBeenCalledTimes(1)
 
         expect(channel.bindings.postgres_changes).toStrictEqual([
           {
@@ -530,6 +538,129 @@ describe('Channel Lifecycle Management', () => {
         await vi.waitFor(() => {
           expect(cbSpy).toHaveBeenCalledWith('SUBSCRIBED')
         })
+      })
+
+      test.each([
+        ['the default timeout', undefined, defaultTimeout],
+        ['a custom timeout', 250, 250],
+      ])(
+        'times out while waiting for postgres system ready with %s',
+        async (_, timeout, waitMs) => {
+          testSetup.cleanup()
+          testSetup = setupRealtimeTest({
+            useFakeTimers: true,
+            timeout: defaultTimeout,
+            socketHandlers: {
+              phx_join: (socket, message) => {
+                socket.send(phxReply(message as string, singlePostgresChangeReply))
+              },
+            },
+          })
+
+          channel = testSetup.client.channel('topic')
+          const cbSpy = vi.fn()
+
+          channel.on('postgres_changes', { event: '*', schema: '*' }, () => {})
+          channel.subscribe(cbSpy, timeout)
+
+          await vi.waitFor(() => {
+            expect(channel.bindings.postgres_changes?.[0]?.id).toBe('abc')
+          })
+
+          expect(cbSpy).not.toHaveBeenCalledWith('SUBSCRIBED')
+
+          vi.advanceTimersByTime(waitMs - 1)
+          expect(cbSpy).not.toHaveBeenCalledWith('TIMED_OUT')
+
+          vi.advanceTimersByTime(1)
+
+          await vi.waitFor(() => {
+            expect(cbSpy).toHaveBeenCalledWith('TIMED_OUT', undefined)
+          })
+
+          expect(channel.state).toBe(CHANNEL_STATES.errored)
+
+          channel.channelAdapter.getChannel().trigger('system', {
+            extension: 'postgres_changes',
+            status: 'ok',
+          })
+
+          expect(cbSpy).toHaveBeenCalledTimes(1)
+        }
+      )
+
+      test('handles non-ok postgres system status while waiting', async () => {
+        testSetup.cleanup()
+        testSetup = setupRealtimeTest({
+          useFakeTimers: true,
+          timeout: defaultTimeout,
+          socketHandlers: {
+            phx_join: (socket, message) => {
+              socket.send(phxReply(message as string, singlePostgresChangeReply))
+            },
+          },
+        })
+
+        channel = testSetup.client.channel('topic')
+        const cbSpy = vi.fn()
+
+        channel.on('postgres_changes', { event: '*', schema: '*' }, () => {})
+        channel.subscribe(cbSpy)
+
+        await vi.waitFor(() => {
+          expect(channel.bindings.postgres_changes?.[0]?.id).toBe('abc')
+        })
+
+        channel.channelAdapter.getChannel().trigger('system', {
+          extension: 'postgres_changes',
+          status: 'error',
+          message: 'replication failed',
+        })
+
+        await vi.waitFor(() => {
+          expect(cbSpy).toHaveBeenCalledWith(
+            'CHANNEL_ERROR',
+            expect.objectContaining({ message: 'replication failed' })
+          )
+        })
+
+        expect(channel.state).toBe(CHANNEL_STATES.errored)
+      })
+
+      test('resets pending subscribe state on channel error', async () => {
+        testSetup.cleanup()
+        testSetup = setupRealtimeTest({
+          useFakeTimers: true,
+          timeout: defaultTimeout,
+          socketHandlers: {
+            phx_join: (socket, message) => {
+              socket.send(phxReply(message as string, singlePostgresChangeReply))
+            },
+          },
+        })
+
+        channel = testSetup.client.channel('topic')
+        const cbSpy = vi.fn()
+
+        channel.on('postgres_changes', { event: '*', schema: '*' }, () => {})
+        channel.subscribe(cbSpy)
+
+        await vi.waitFor(() => {
+          expect(channel.bindings.postgres_changes?.[0]?.id).toBe('abc')
+        })
+
+        channel.channelAdapter.getChannel().trigger('phx_error', 'boom')
+
+        await vi.waitFor(() => {
+          expect(cbSpy).toHaveBeenCalledWith('CHANNEL_ERROR', expect.any(Error))
+        })
+
+        channel.channelAdapter.getChannel().trigger('system', {
+          extension: 'postgres_changes',
+          status: 'ok',
+        })
+
+        expect(cbSpy).toHaveBeenCalledTimes(1)
       })
     })
 


### PR DESCRIPTION
## TL;DR 
 
Delay `SUBSCRIBED` only for channels that bind `postgres_changes` callbacks exclusively
 and keep the existing timing for mixed channels

## Prob:  
`SUBSCRIBED` could be emitted before the Postgres change feed was actually ready 
which made postgres-only channels look ready too early

so now basically, wait for the `postgres_changes` system ready message before emitting `SUBSCRIBED` 
for postgres-only channels while leaving channels with `broadcast` or `presence` callbacks unchanged

## ref:
- follow up to https://github.com/supabase/supabase-js/pull/2029 &
 aligned with Eduardo’s suggestion :D 
- closes #1599
- https://github.com/supabase/supabase-js/pull/2029#issuecomment-4626790886