### PR TITLE
fix(release): pin Deno and bound JSR publish to survive stranded-task hangs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -96,6 +96,11 @@ jobs:
           cache: 'pnpm'
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Setup Deno
+        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
+        with:
+          deno-version: v2.8.2
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
@@ -268,6 +273,11 @@ jobs:
           cache: 'pnpm'
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Setup Deno
+        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
+        with:
+          deno-version: v2.8.2
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
@@ -382,6 +392,11 @@ jobs:
           cache: 'pnpm'
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Setup Deno
+        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
+        with:
+          deno-version: v2.8.2
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
@@ -491,6 +506,11 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
           registry-url: 'https://registry.npmjs.org'
+
+      - name: Setup Deno
+        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
+        with:
+          deno-version: v2.8.2
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/scripts/publish-to-jsr.ts
+++ b/scripts/publish-to-jsr.ts
@@ -1,4 +1,4 @@
-import { execSync } from 'child_process'
+import { spawnSync } from 'child_process'
 import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs'
 import { dirname, join } from 'path'
 
@@ -69,15 +69,6 @@ function getArg(name: string): string | undefined {
 const tag = getArg('tag') || 'latest'
 const dryRun = process.argv.includes('--dry-run')
 
-function safeExec(cmd: string, opts = {}) {
-  try {
-    return execSync(cmd, { stdio: 'inherit', ...opts })
-  } catch (err) {
-    console.error(`❌ Command failed: ${cmd}`)
-    throw err
-  }
-}
-
 async function publishToJsr() {
   console.log(`\n📦 Publishing packages to JSR (tag: ${tag})...\n`)
 
@@ -125,15 +116,29 @@ async function publishToJsr() {
     console.log(`\n📤 Publishing @supabase/${pkg}@${version} to JSR...`)
 
     try {
-      // Change to package directory and publish
-      // Note: In GitHub Actions, authentication happens automatically via OIDC
-      // Provenance is automatically enabled when using OIDC (no flag needed)
-      // Local publishing will prompt for interactive browser authentication
-      const publishCmd = dryRun
-        ? `cd "${packagePath}" && pnpm exec jsr publish --dry-run --allow-dirty`
-        : `cd "${packagePath}" && pnpm exec jsr publish --allow-dirty`
-
-      safeExec(publishCmd)
+      // Call `deno publish` directly (instead of `pnpm exec jsr publish`) so we
+      // use the pinned Deno from `denoland/setup-deno` in publish.yml rather
+      // than whatever the `jsr` npm wrapper downloads from dl.deno.land at
+      // runtime. Timeout caps JSR queue stranding (jsr-io/jsr#1448) at 10 min
+      // instead of letting the unbounded poll loop wedge the workflow.
+      const args = ['publish', '--allow-dirty']
+      if (dryRun) args.push('--dry-run')
+      console.log(`   Command: deno ${args.join(' ')}`)
+      const result = spawnSync('deno', args, {
+        cwd: packagePath,
+        stdio: 'inherit',
+        timeout: 10 * 60 * 1000,
+        killSignal: 'SIGKILL',
+      })
+      if (result.signal === 'SIGKILL') {
+        throw new Error(
+          `deno publish for ${pkg} timed out after 10 minutes — likely JSR task stranding, see jsr-io/jsr#1448`
+        )
+      }
+      if (result.error) throw result.error
+      if (result.status !== 0) {
+        throw new Error(`deno publish for ${pkg} exited with status ${result.status}`)
+      }
 
       console.log(`✅ Successfully published @supabase/${pkg}@${version} to JSR`)
       results.push({ package: pkg, success: true })


### PR DESCRIPTION
JSR's publish queue can leave tasks stranded in `processing` for 30+ min (jsr-io/jsr#1448), and the Deno CLI polls /publish_status without a timeout, wedging the workflow to GH Actions' 6h ceiling and blocking the partial-failure Slack notification that would normally surface this.

  - Pin Deno to v2.8.2 via denoland/setup-deno across the four release jobs, removing the implicit dl.deno.land/release-latest.txt lookup the `jsr` npm wrapper does on every CI run.
  - Call `deno publish` directly in publish-to-jsr.ts so the pinned binary runs instead of whatever the wrapper fetches.
  - Spawn it via spawnSync with a 10-min timeout + SIGKILL. The existing try/catch already routes failures into the partial-failure notification wired in release-canary.ts, so a stranded publish surfaces cleanly instead of holding the workflow open.

  Refs: jsr-io/jsr#1448, jsr-io/jsr#1449