### PR TITLE
fix(release): restore JSR publish flags and enable for beta

### DIFF
--- a/scripts/publish-to-jsr.ts
+++ b/scripts/publish-to-jsr.ts
@@ -121,7 +121,19 @@ async function publishToJsr() {
       // than whatever the `jsr` npm wrapper downloads from dl.deno.land at
       // runtime. Timeout caps JSR queue stranding (jsr-io/jsr#1448) at 10 min
       // instead of letting the unbounded poll loop wedge the workflow.
-      const args = ['publish', '--allow-dirty']
+      //
+      // Flags mirror what the `jsr` npm wrapper passes for Node-style projects
+      // (package.json present): sloppy imports, BYO node_modules, bare node
+      // builtins, and --no-check. Without them Deno rejects our extension-less
+      // imports and unsupported tsconfig options as hard errors.
+      const args = [
+        'publish',
+        '--allow-dirty',
+        '--unstable-bare-node-builtins',
+        '--unstable-sloppy-imports',
+        '--unstable-byonm',
+        '--no-check',
+      ]
       if (dryRun) args.push('--dry-run')
       console.log(`   Command: deno ${args.join(' ')}`)
       const result = spawnSync('deno', args, {
@@ -129,6 +141,7 @@ async function publishToJsr() {
         stdio: 'inherit',
         timeout: 10 * 60 * 1000,
         killSignal: 'SIGKILL',
+        env: { ...process.env, DENO_DISABLE_PEDANTIC_NODE_WARNINGS: 'true' },
       })
       if (result.signal === 'SIGKILL') {
         throw new Error(

--- a/scripts/release-beta.ts
+++ b/scripts/release-beta.ts
@@ -94,5 +94,16 @@ function safeExec(cmd: string, opts = {}) {
     verbose: true,
   })
 
+  // Publish all packages to JSR. Mirrors the pattern in release-canary.ts and
+  // release-stable.ts: failures here don't fail the npm release that already
+  // succeeded above.
+  console.log('\n📦 Publishing packages to JSR (beta)...')
+  try {
+    safeExec('pnpm exec tsx scripts/publish-to-jsr.ts --tag=beta')
+  } catch (error) {
+    console.error('❌ Failed to publish to JSR:', error)
+    console.log('⚠️  Continuing with release despite JSR publish failure')
+  }
+
   process.exit(Object.values(publishResult).every((r) => r.code === 0) ? 0 : 1)
 })()


### PR DESCRIPTION
The previous switch to `deno publish` direct (d797a65c) dropped flags the `jsr` npm wrapper was injecting for Node-style projects (any package with a `package.json`), causing every JSR publish since 2.108.2-canary.1 to fail type-check with TS2307 (extension-less imports) and TS5095/TS5109 (incompatible tsconfig options).

This PR passes `--unstable-bare-node-builtins`, `--unstable-sloppy-imports`, `--unstable-byonm`, `--no-check`, and sets `DENO_DISABLE_PEDANTIC_NODE_WARNINGS=true` in `scripts/publish-to-jsr.ts`, matching exactly what the wrapper was injecting for years before the switch.

Also extends JSR publishing to beta releases in `scripts/release-beta.ts`, using the same try/catch + partial-failure pattern as stable and canary, so beta versions reach JSR alongside npm.