### PR TITLE
fix(postgrest): surface helpful hint for browser DNS failures (ERR_NA…

### DIFF
--- a/packages/core/postgrest-js/src/PostgrestBuilder.ts
+++ b/packages/core/postgrest-js/src/PostgrestBuilder.ts
@@ -411,8 +411,25 @@ export default abstract class PostgrestBuilder<
             errorDetails += `\n${cause.stack}`
           }
         } else {
-          // No cause available, just include the error stack
+          // No cause available — include the error stack.
+          // In browsers, DNS failures (ERR_NAME_NOT_RESOLVED) surface as a plain
+          // TypeError("Failed to fetch") with no cause and no error code.
+          // Detect this pattern and surface a human-readable hint so developers
+          // know to check their project URL / DNS rather than their code.
           errorDetails = fetchError?.stack ?? ''
+
+          const msg: string = fetchError?.message ?? ''
+          if (
+            msg === 'Failed to fetch' || // Chrome / Edge
+            msg === 'NetworkError when attempting to fetch resource.' || // Firefox
+            msg === 'Load failed' // Safari
+          ) {
+            hint =
+              'Network request failed — the Supabase project URL could not be reached. ' +
+              'This is usually caused by a DNS resolution failure (e.g. ERR_NAME_NOT_RESOLVED in Chrome). ' +
+              'Verify that your SUPABASE_URL is correct and that the project is active in the Supabase dashboard. ' +
+              'If the issue persists, check https://status.supabase.com for platform outages.'
+          }
         }
 
         // Get URL length for potential hints

--- a/packages/core/postgrest-js/test/fetch-errors.test.ts
+++ b/packages/core/postgrest-js/test/fetch-errors.test.ts
@@ -133,7 +133,34 @@ describe('Fetch error handling', () => {
     // When no cause, details should still have the stack trace
     expect(res.error!.details).toBeTruthy()
   })
+  // Browser environments (Chrome/Edge/Firefox/Safari) surface DNS failures as a plain
+  // TypeError with no `cause` and no error code.  The message varies by browser.
+  const browserDnsMessages = [
+    ['Chrome/Edge', 'Failed to fetch'],
+    ['Firefox', 'NetworkError when attempting to fetch resource.'],
+    ['Safari', 'Load failed'],
+  ]
 
+  test.each(browserDnsMessages)(
+    'should surface a helpful hint for %s DNS failure (%s)',
+    async (_browser, msg) => {
+      const mockFetch = jest.fn().mockRejectedValue(new TypeError(msg))
+
+      const postgrest = new PostgrestClient<Database>('https://nonexistent-project.supabase.co', {
+        fetch: mockFetch as any,
+      })
+
+      const res = await postgrest.from('users').select()
+
+      expect(res.error).toBeTruthy()
+      expect(res.data).toBeNull()
+      expect(res.status).toBe(0)
+      expect(res.error!.message).toContain(msg)
+      expect(res.error!.hint).toContain('DNS resolution failure')
+      expect(res.error!.hint).toContain('SUPABASE_URL')
+      expect(res.error!.hint).toContain('status.supabase.com')
+    }
+  )
   test('should handle generic errors without code', async () => {
     // Simulate a generic error
     const mockFetch = jest.fn().mockRejectedValue(new Error('Something went wrong'))


### PR DESCRIPTION
## Summary

Fixes missing error context for ERR_NAME_NOT_RESOLVED and other DNS
failures in browser environments (Chrome, Firefox, Safari).

Relates to: supabase/supabase#46821

## Problem

In browsers, DNS failures produce a plain TypeError with no `.cause`
and no error code — just the message string. supabase-js currently
returns this as an opaque stack trace with no actionable guidance.

- Chrome/Edge: `Failed to fetch`
- Firefox: `NetworkError when attempting to fetch resource.`
- Safari: `Load failed`

## Solution

Detect these three browser network-failure messages and populate
`error.hint` with a developer-friendly message pointing to:
1. The likely root cause (DNS / project URL)
2. The Supabase dashboard (to verify project status)
3. The Supabase status page for outages

## Testing

3 new test.each cases added to fetch-errors.test.ts, one per browser.
No behaviour change for Node.js paths or non-DNS errors.