### PR TITLE
ci(ci): use dependency firewall from DepthFirst

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -64,16 +64,16 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+
+      - name: Configure Dependency Firewall registry
+        run: |
+          pnpm config set //firewall.depthfirst.com/npm/:_authToken "${{ secrets.DF_FIREWALL_TOKEN }}"
+          pnpm config set registry https://firewall.depthfirst.com/npm/
+
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: 'pnpm'
-
-      - name: Configure Dependency Firewall registry
-        run: |
-          pnpm config set //firewall.depthfirst.com/npm/:_authToken ${{ secrets.DF_FIREWALL_TOKEN }}
-          pnpm config set registry https://firewall.depthfirst.com/npm/
-
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Audit production dependencies
@@ -101,16 +101,16 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+
+      - name: Configure Dependency Firewall registry
+        run: |
+          pnpm config set //firewall.depthfirst.com/npm/:_authToken "${{ secrets.DF_FIREWALL_TOKEN }}"
+          pnpm config set registry https://firewall.depthfirst.com/npm/
+
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: 'pnpm'
-
-      - name: Configure Dependency Firewall registry
-        run: |
-          pnpm config set //firewall.depthfirst.com/npm/:_authToken ${{ secrets.DF_FIREWALL_TOKEN }}
-          pnpm config set registry https://firewall.depthfirst.com/npm/
-
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - uses: nrwl/nx-set-shas@afb73a62d26e41464e9254689e1fd6122ee683c1 # v5.0.1
@@ -151,15 +151,16 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+
+      - name: Configure Dependency Firewall registry
+        run: |
+          pnpm config set //firewall.depthfirst.com/npm/:_authToken "${{ secrets.DF_FIREWALL_TOKEN }}"
+          pnpm config set registry https://firewall.depthfirst.com/npm/
+
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: 'pnpm'
-
-      - name: Configure Dependency Firewall registry
-        run: |
-          pnpm config set //firewall.depthfirst.com/npm/:_authToken ${{ secrets.DF_FIREWALL_TOKEN }}
-          pnpm config set registry https://firewall.depthfirst.com/npm/
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -216,15 +217,16 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+
+      - name: Configure Dependency Firewall registry
+        run: |
+          pnpm config set //firewall.depthfirst.com/npm/:_authToken "${{ secrets.DF_FIREWALL_TOKEN }}"
+          pnpm config set registry https://firewall.depthfirst.com/npm/
+
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: 'pnpm'
-
-      - name: Configure Dependency Firewall registry
-        run: |
-          pnpm config set //firewall.depthfirst.com/npm/:_authToken ${{ secrets.DF_FIREWALL_TOKEN }}
-          pnpm config set registry https://firewall.depthfirst.com/npm/
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -279,15 +281,16 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+
+      - name: Configure Dependency Firewall registry
+        run: |
+          pnpm config set //firewall.depthfirst.com/npm/:_authToken "${{ secrets.DF_FIREWALL_TOKEN }}"
+          pnpm config set registry https://firewall.depthfirst.com/npm/
+
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: 'pnpm'
-
-      - name: Configure Dependency Firewall registry
-        run: |
-          pnpm config set //firewall.depthfirst.com/npm/:_authToken ${{ secrets.DF_FIREWALL_TOKEN }}
-          pnpm config set registry https://firewall.depthfirst.com/npm/
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -338,15 +341,16 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+
+      - name: Configure Dependency Firewall registry
+        run: |
+          pnpm config set //firewall.depthfirst.com/npm/:_authToken "${{ secrets.DF_FIREWALL_TOKEN }}"
+          pnpm config set registry https://firewall.depthfirst.com/npm/
+
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: 'pnpm'
-
-      - name: Configure Dependency Firewall registry
-        run: |
-          pnpm config set //firewall.depthfirst.com/npm/:_authToken ${{ secrets.DF_FIREWALL_TOKEN }}
-          pnpm config set registry https://firewall.depthfirst.com/npm/
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -424,15 +428,16 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+
+      - name: Configure Dependency Firewall registry
+        run: |
+          pnpm config set //firewall.depthfirst.com/npm/:_authToken "${{ secrets.DF_FIREWALL_TOKEN }}"
+          pnpm config set registry https://firewall.depthfirst.com/npm/
+
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: 'pnpm'
-
-      - name: Configure Dependency Firewall registry
-        run: |
-          pnpm config set //firewall.depthfirst.com/npm/:_authToken ${{ secrets.DF_FIREWALL_TOKEN }}
-          pnpm config set registry https://firewall.depthfirst.com/npm/
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -77,7 +77,12 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Audit production dependencies
-        run: pnpm audit --audit-level=high --prod
+        env:
+          npm_config_registry: https://firewall.depthfirst.com/npm/
+          npm_config__authToken: ${{ secrets.DF_FIREWALL_TOKEN }}
+        run: |
+          pnpm config list
+          pnpm audit --audit-level=high --prod
       - uses: nrwl/nx-set-shas@afb73a62d26e41464e9254689e1fd6122ee683c1 # v5.0.1
       - name: Check common types are in sync
         run: pnpm run codegen:check

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -72,6 +72,7 @@ jobs:
       - name: Configure Dependency Firewall registry
         run: |
           pnpm config set //firewall.depthfirst.com/npm/:_authToken ${{ secrets.DF_FIREWALL_TOKEN }}
+          pnpm config set registry https://firewall.depthfirst.com/npm/
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -108,6 +109,7 @@ jobs:
       - name: Configure Dependency Firewall registry
         run: |
           pnpm config set //firewall.depthfirst.com/npm/:_authToken ${{ secrets.DF_FIREWALL_TOKEN }}
+          pnpm config set registry https://firewall.depthfirst.com/npm/
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -157,6 +159,7 @@ jobs:
       - name: Configure Dependency Firewall registry
         run: |
           pnpm config set //firewall.depthfirst.com/npm/:_authToken ${{ secrets.DF_FIREWALL_TOKEN }}
+          pnpm config set registry https://firewall.depthfirst.com/npm/
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -221,6 +224,7 @@ jobs:
       - name: Configure Dependency Firewall registry
         run: |
           pnpm config set //firewall.depthfirst.com/npm/:_authToken ${{ secrets.DF_FIREWALL_TOKEN }}
+          pnpm config set registry https://firewall.depthfirst.com/npm/
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -283,6 +287,7 @@ jobs:
       - name: Configure Dependency Firewall registry
         run: |
           pnpm config set //firewall.depthfirst.com/npm/:_authToken ${{ secrets.DF_FIREWALL_TOKEN }}
+          pnpm config set registry https://firewall.depthfirst.com/npm/
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -341,6 +346,7 @@ jobs:
       - name: Configure Dependency Firewall registry
         run: |
           pnpm config set //firewall.depthfirst.com/npm/:_authToken ${{ secrets.DF_FIREWALL_TOKEN }}
+          pnpm config set registry https://firewall.depthfirst.com/npm/
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -426,6 +432,7 @@ jobs:
       - name: Configure Dependency Firewall registry
         run: |
           pnpm config set //firewall.depthfirst.com/npm/:_authToken ${{ secrets.DF_FIREWALL_TOKEN }}
+          pnpm config set registry https://firewall.depthfirst.com/npm/
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -68,6 +68,11 @@ jobs:
         with:
           node-version: 22
           cache: 'pnpm'
+
+      - name: Configure Dependency Firewall registry
+        run: |
+          pnpm config set //firewall.depthfirst.com/npm/:_authToken ${{ secrets.DF_FIREWALL_TOKEN }}
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Audit production dependencies
@@ -99,6 +104,11 @@ jobs:
         with:
           node-version: 22
           cache: 'pnpm'
+
+      - name: Configure Dependency Firewall registry
+        run: |
+          pnpm config set //firewall.depthfirst.com/npm/:_authToken ${{ secrets.DF_FIREWALL_TOKEN }}
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - uses: nrwl/nx-set-shas@afb73a62d26e41464e9254689e1fd6122ee683c1 # v5.0.1
@@ -143,6 +153,11 @@ jobs:
         with:
           node-version: 22
           cache: 'pnpm'
+
+      - name: Configure Dependency Firewall registry
+        run: |
+          pnpm config set //firewall.depthfirst.com/npm/:_authToken ${{ secrets.DF_FIREWALL_TOKEN }}
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Cache Supabase Docker images
@@ -202,6 +217,11 @@ jobs:
         with:
           node-version: 22
           cache: 'pnpm'
+
+      - name: Configure Dependency Firewall registry
+        run: |
+          pnpm config set //firewall.depthfirst.com/npm/:_authToken ${{ secrets.DF_FIREWALL_TOKEN }}
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Cache Supabase Docker images
@@ -259,6 +279,11 @@ jobs:
         with:
           node-version: 22
           cache: 'pnpm'
+
+      - name: Configure Dependency Firewall registry
+        run: |
+          pnpm config set //firewall.depthfirst.com/npm/:_authToken ${{ secrets.DF_FIREWALL_TOKEN }}
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Cache Supabase Docker images
@@ -312,6 +337,11 @@ jobs:
         with:
           node-version: 22
           cache: 'pnpm'
+
+      - name: Configure Dependency Firewall registry
+        run: |
+          pnpm config set //firewall.depthfirst.com/npm/:_authToken ${{ secrets.DF_FIREWALL_TOKEN }}
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Cache Supabase Docker images
@@ -392,6 +422,11 @@ jobs:
         with:
           node-version: 22
           cache: 'pnpm'
+
+      - name: Configure Dependency Firewall registry
+        run: |
+          pnpm config set //firewall.depthfirst.com/npm/:_authToken ${{ secrets.DF_FIREWALL_TOKEN }}
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Cache Supabase Docker images

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -77,12 +77,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Audit production dependencies
-        env:
-          npm_config_registry: https://firewall.depthfirst.com/npm/
-          npm_config__authToken: ${{ secrets.DF_FIREWALL_TOKEN }}
-        run: |
-          pnpm config list
-          pnpm audit --audit-level=high --prod
+        run: pnpm audit --audit-level=high --prod --registry https://registry.npmjs.org
       - uses: nrwl/nx-set-shas@afb73a62d26e41464e9254689e1fd6122ee683c1 # v5.0.1
       - name: Check common types are in sync
         run: pnpm run codegen:check

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -28,6 +28,12 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+
+      - name: Configure Dependency Firewall registry
+        run: |
+          pnpm config set //firewall.depthfirst.com/npm/:_authToken "${{ secrets.DF_FIREWALL_TOKEN }}"
+          pnpm config set registry https://firewall.depthfirst.com/npm/
+
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -33,6 +33,8 @@ jobs:
           node-version: 22
           cache: 'pnpm'
       - name: Install dependencies
+        env:
+          pnpm_config_registry: https://firewall.depthfirst.com/npm/
         run: pnpm install --frozen-lockfile
       - uses: nrwl/nx-set-shas@afb73a62d26e41464e9254689e1fd6122ee683c1 # v5.0.1
       - name: Detect affected packages
@@ -75,6 +77,8 @@ jobs:
           node-version: 22
           cache: 'pnpm'
       - name: Install dependencies
+        env:
+          pnpm_config_registry: https://firewall.depthfirst.com/npm/
         run: pnpm install --frozen-lockfile
       - name: Audit production dependencies
         run: pnpm audit --audit-level=high --prod --registry https://registry.npmjs.org
@@ -112,6 +116,8 @@ jobs:
           node-version: 22
           cache: 'pnpm'
       - name: Install dependencies
+        env:
+          pnpm_config_registry: https://firewall.depthfirst.com/npm/
         run: pnpm install --frozen-lockfile
       - uses: nrwl/nx-set-shas@afb73a62d26e41464e9254689e1fd6122ee683c1 # v5.0.1
       - name: Run test:ci for affected packages
@@ -163,6 +169,8 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
+        env:
+          pnpm_config_registry: https://firewall.depthfirst.com/npm/
         run: pnpm install --frozen-lockfile
       - name: Cache Supabase Docker images
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -229,6 +237,8 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
+        env:
+          pnpm_config_registry: https://firewall.depthfirst.com/npm/
         run: pnpm install --frozen-lockfile
       - name: Cache Supabase Docker images
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -293,6 +303,8 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
+        env:
+          pnpm_config_registry: https://firewall.depthfirst.com/npm/
         run: pnpm install --frozen-lockfile
       - name: Cache Supabase Docker images
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -353,6 +365,8 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
+        env:
+          pnpm_config_registry: https://firewall.depthfirst.com/npm/
         run: pnpm install --frozen-lockfile
       - name: Cache Supabase Docker images
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -440,6 +454,8 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
+        env:
+          pnpm_config_registry: https://firewall.depthfirst.com/npm/
         run: pnpm install --frozen-lockfile
       - name: Cache Supabase Docker images
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5

--- a/.github/workflows/ci-supabase-js.yml
+++ b/.github/workflows/ci-supabase-js.yml
@@ -29,6 +29,7 @@ jobs:
       - name: Configure Dependency Firewall registry
         run: |
           pnpm config set //firewall.depthfirst.com/npm/:_authToken ${{ secrets.DF_FIREWALL_TOKEN }}
+          pnpm config set registry https://firewall.depthfirst.com/npm/
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -85,6 +86,7 @@ jobs:
       - name: Configure Dependency Firewall registry
         run: |
           pnpm config set //firewall.depthfirst.com/npm/:_authToken ${{ secrets.DF_FIREWALL_TOKEN }}
+          pnpm config set registry https://firewall.depthfirst.com/npm/
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -126,6 +128,7 @@ jobs:
       - name: Configure Dependency Firewall registry
         run: |
           pnpm config set //firewall.depthfirst.com/npm/:_authToken ${{ secrets.DF_FIREWALL_TOKEN }}
+          pnpm config set registry https://firewall.depthfirst.com/npm/
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci-supabase-js.yml
+++ b/.github/workflows/ci-supabase-js.yml
@@ -21,15 +21,15 @@ jobs:
 
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
+      - name: Configure Dependency Firewall registry
+        run: |
+          pnpm config set //firewall.depthfirst.com/npm/:_authToken "${{ secrets.DF_FIREWALL_TOKEN }}"
+          pnpm config set registry https://firewall.depthfirst.com/npm/
+
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
-
-      - name: Configure Dependency Firewall registry
-        run: |
-          pnpm config set //firewall.depthfirst.com/npm/:_authToken ${{ secrets.DF_FIREWALL_TOKEN }}
-          pnpm config set registry https://firewall.depthfirst.com/npm/
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -77,16 +77,16 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
+      - name: Configure Dependency Firewall registry
+        run: |
+          pnpm config set //firewall.depthfirst.com/npm/:_authToken "${{ secrets.DF_FIREWALL_TOKEN }}"
+          pnpm config set registry https://firewall.depthfirst.com/npm/
+
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node }}
           cache: 'pnpm'
-
-      - name: Configure Dependency Firewall registry
-        run: |
-          pnpm config set //firewall.depthfirst.com/npm/:_authToken ${{ secrets.DF_FIREWALL_TOKEN }}
-          pnpm config set registry https://firewall.depthfirst.com/npm/
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -119,16 +119,16 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
+      - name: Configure Dependency Firewall registry
+        run: |
+          pnpm config set //firewall.depthfirst.com/npm/:_authToken "${{ secrets.DF_FIREWALL_TOKEN }}"
+          pnpm config set registry https://firewall.depthfirst.com/npm/
+
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
-
-      - name: Configure Dependency Firewall registry
-        run: |
-          pnpm config set //firewall.depthfirst.com/npm/:_authToken ${{ secrets.DF_FIREWALL_TOKEN }}
-          pnpm config set registry https://firewall.depthfirst.com/npm/
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci-supabase-js.yml
+++ b/.github/workflows/ci-supabase-js.yml
@@ -26,6 +26,10 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
 
+      - name: Configure Dependency Firewall registry
+        run: |
+          pnpm config set //firewall.depthfirst.com/npm/:_authToken ${{ secrets.DF_FIREWALL_TOKEN }}
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
@@ -78,6 +82,10 @@ jobs:
           node-version: ${{ matrix.node }}
           cache: 'pnpm'
 
+      - name: Configure Dependency Firewall registry
+        run: |
+          pnpm config set //firewall.depthfirst.com/npm/:_authToken ${{ secrets.DF_FIREWALL_TOKEN }}
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
@@ -114,6 +122,10 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
+
+      - name: Configure Dependency Firewall registry
+        run: |
+          pnpm config set //firewall.depthfirst.com/npm/:_authToken ${{ secrets.DF_FIREWALL_TOKEN }}
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci-supabase-js.yml
+++ b/.github/workflows/ci-supabase-js.yml
@@ -32,6 +32,8 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
+        env:
+          pnpm_config_registry: https://firewall.depthfirst.com/npm/
         run: pnpm install --frozen-lockfile
 
       - uses: nrwl/nx-set-shas@afb73a62d26e41464e9254689e1fd6122ee683c1 # v5.0.1
@@ -89,6 +91,8 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
+        env:
+          pnpm_config_registry: https://firewall.depthfirst.com/npm/
         run: pnpm install --frozen-lockfile
 
       - name: Type Check + Unit Tests + Coverage
@@ -131,6 +135,8 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
+        env:
+          pnpm_config_registry: https://firewall.depthfirst.com/npm/
         run: pnpm install --frozen-lockfile
 
       - name: Download build artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
     permissions:
       actions: read
       contents: read
+    secrets: inherit
 
   ci-supabase-js:
     name: Supabase-JS Integration CI
@@ -38,6 +39,7 @@ jobs:
     permissions:
       actions: read
       contents: read
+    secrets: inherit
 
   coveralls-finish:
     name: Coveralls Finished

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,6 +22,11 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
+      - name: Configure Dependency Firewall registry
+        run: |
+          pnpm config set //firewall.depthfirst.com/npm/:_authToken "${{ secrets.DF_FIREWALL_TOKEN }}"
+          pnpm config set registry https://firewall.depthfirst.com/npm/
+
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -29,6 +34,8 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
+        env:
+          pnpm_config_registry: https://firewall.depthfirst.com/npm/
         run: pnpm install --frozen-lockfile
 
       - name: Generate JSON documentation for all packages
@@ -108,7 +115,7 @@ jobs:
           <body>
               <h1>Supabase JavaScript Libraries - API Documentation</h1>
               <p>TypeScript/JavaScript API documentation for all Supabase JS SDKs.</p>
-              
+
               <h2>Available Documentation:</h2>
               <ul>
                   <li>
@@ -136,7 +143,7 @@ jobs:
                       <div class="description">Main isomorphic SDK combining all SDKs</div>
                   </li>
               </ul>
-              
+
               <hr style="margin-top: 50px; border: 1px solid #eee;">
               <p style="color: #999; font-size: 12px;">
                   Generated from the <a href="https://github.com/supabase/supabase-js">supabase-js</a> monorepo.

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -35,6 +35,11 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
+      - name: Configure Dependency Firewall registry
+        run: |
+          pnpm config set //firewall.depthfirst.com/npm/:_authToken "${{ secrets.DF_FIREWALL_TOKEN }}"
+          pnpm config set registry https://firewall.depthfirst.com/npm/
+
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -52,6 +57,8 @@ jobs:
           bun-version: latest
 
       - name: Install dependencies
+        env:
+          pnpm_config_registry: https://firewall.depthfirst.com/npm/
         run: pnpm install --frozen-lockfile
 
       - name: Install jq for JSON parsing

--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -98,3 +98,4 @@ jobs:
     uses: ./.github/workflows/integration-tests.yml
     with:
       commit_hash: ${{ needs.preview.outputs.commit_hash }}
+    secrets: inherit

--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -42,6 +42,10 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
+      - name: Configure Dependency Firewall registry
+        run: |
+          pnpm config set //firewall.depthfirst.com/npm/:_authToken "${{ secrets.DF_FIREWALL_TOKEN }}"
+
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -49,6 +53,8 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
+        env:
+          pnpm_config_registry: https://firewall.depthfirst.com/npm/
         run: pnpm install --frozen-lockfile
 
       - name: Set up Nx SHAs

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -105,6 +105,8 @@ jobs:
         run: echo "DENO_BIN_PATH=$(which deno)" >> "$GITHUB_ENV"
 
       - name: Install dependencies
+        env:
+          pnpm_config_registry: https://firewall.depthfirst.com/npm/
         run: pnpm install --frozen-lockfile
 
       - name: Configure git
@@ -285,6 +287,8 @@ jobs:
         run: echo "DENO_BIN_PATH=$(which deno)" >> "$GITHUB_ENV"
 
       - name: Install dependencies
+        env:
+          pnpm_config_registry: https://firewall.depthfirst.com/npm/
         run: pnpm install --frozen-lockfile
 
       - name: Configure git
@@ -407,6 +411,8 @@ jobs:
         run: echo "DENO_BIN_PATH=$(which deno)" >> "$GITHUB_ENV"
 
       - name: Install dependencies
+        env:
+          pnpm_config_registry: https://firewall.depthfirst.com/npm/
         run: pnpm install --frozen-lockfile
 
       - name: Configure git
@@ -509,6 +515,10 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
+      - name: Configure Dependency Firewall registry
+        run: |
+          pnpm config set //firewall.depthfirst.com/npm/:_authToken "${{ secrets.DF_FIREWALL_TOKEN }}"
+
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -525,6 +535,8 @@ jobs:
         run: echo "DENO_BIN_PATH=$(which deno)" >> "$GITHUB_ENV"
 
       - name: Install dependencies
+        env:
+          pnpm_config_registry: https://firewall.depthfirst.com/npm/
         run: pnpm install --frozen-lockfile
       - name: Configure git
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -90,6 +90,11 @@ jobs:
 
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
+      - name: Configure Dependency Firewall registry
+        run: |
+          pnpm config set //firewall.depthfirst.com/npm/:_authToken "${{ secrets.DF_FIREWALL_TOKEN }}"
+          pnpm config set registry https://firewall.depthfirst.com/npm/
+
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -170,6 +175,7 @@ jobs:
     permissions:
       actions: read
       contents: write
+    secrets: inherit
 
   trigger-dogfood:
     name: Trigger Dogfood
@@ -271,6 +277,11 @@ jobs:
           persist-credentials: false
 
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+
+      - name: Configure Dependency Firewall registry
+        run: |
+          pnpm config set //firewall.depthfirst.com/npm/:_authToken "${{ secrets.DF_FIREWALL_TOKEN }}"
+          pnpm config set registry https://firewall.depthfirst.com/npm/
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -396,6 +407,11 @@ jobs:
 
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
+      - name: Configure Dependency Firewall registry
+        run: |
+          pnpm config set //firewall.depthfirst.com/npm/:_authToken "${{ secrets.DF_FIREWALL_TOKEN }}"
+          pnpm config set registry https://firewall.depthfirst.com/npm/
+
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -446,6 +462,7 @@ jobs:
     permissions:
       actions: read
       contents: read
+    secrets: inherit
 
   ci-supabase-js:
     if: ${{ github.event_name == 'push' }}
@@ -454,6 +471,7 @@ jobs:
     permissions:
       actions: read
       contents: read
+    secrets: inherit
 
   # ==========================================
   # COVERALLS FINISH (aggregates coverage from all packages)


### PR DESCRIPTION

## 🔍 Description

uses DepthFirst's dependency firewall to secure npm packages

https://depthfirst.com/dependency-firewall

### What changed?

uses DF's registry when running CI

### Why was this change needed?

Supply chain security 🔒 ⛓️ 


## 📋 Checklist

<!-- Ensure all items are checked before submitting -->

- [x] I have read the [Contributing Guidelines](https://github.com/supabase/supabase-js/blob/master/CONTRIBUTING.md)
- [x] My PR title follows the [conventional commit format](https://www.conventionalcommits.org/): `<type>(<scope>): <description>`
- [x] I have run `pnpm nx format` to ensure consistent code formatting
- [x] I have added tests for new functionality (if applicable)
- [x] I have updated documentation (if applicable)

## 📝 Additional notes

<!-- Add any additional notes, context, or concerns for reviewers -->

<!-- Thank you for contributing to Supabase! 💚 -->
