### PR TITLE
fix(realtime): auto-enable presence on track() to repair sender-only channels

### DIFF
--- a/packages/core/realtime-js/README.md
+++ b/packages/core/realtime-js/README.md
@@ -178,6 +178,14 @@ channel.subscribe(async (status) => {
 })
 ```
 
+Presence is opt-in on the join payload. The client enables it automatically when a `.on('presence', ...)` listener is registered before `.subscribe()`. For "sender-only" clients that call `.track()` without listening for presence events, pass `enabled: true` explicitly to avoid an internal resubscribe round-trip on the first `track()`:
+
+```js
+const channel = client.channel('presence-test', {
+  config: { presence: { enabled: true } },
+})
+```
+
 ## Postgres CDC
 
 Receive database changes on the client.

--- a/packages/core/realtime-js/package.json
+++ b/packages/core/realtime-js/package.json
@@ -42,7 +42,7 @@
     "test:ci": "vitest run --coverage"
   },
   "dependencies": {
-    "@supabase/phoenix": "^0.4.2",
+    "@supabase/phoenix": "^0.4.3",
     "tslib": "2.8.1"
   },
   "devDependencies": {

--- a/packages/core/realtime-js/src/RealtimeChannel.ts
+++ b/packages/core/realtime-js/src/RealtimeChannel.ts
@@ -437,14 +437,32 @@ export default class RealtimeChannel {
     payload: { [key: string]: any },
     opts: { [key: string]: any } = {}
   ): Promise<RealtimeChannelSendResponse> {
-    if (this.state === CHANNEL_STATES.joined && this.params.config.presence?.enabled !== true) {
+    // Mirror the auto-detection in subscribe() so we only re-join when the
+    // server actually treats this channel as non-presence. A listener-only
+    // channel already joined with enabled: true and does not need re-joining.
+    const presenceAlreadyEnabled =
+      (!!this.bindings[REALTIME_LISTEN_TYPES.PRESENCE] &&
+        this.bindings[REALTIME_LISTEN_TYPES.PRESENCE].length > 0) ||
+      this.params.config.presence?.enabled === true
+
+    if (this.state === CHANNEL_STATES.joined && !presenceAlreadyEnabled) {
       this.params.config.presence = {
         ...this.params.config.presence,
         enabled: true,
       }
       this.socket.log('channel', `resubscribe to ${this.topic} to enable presence for track()`)
       await this.unsubscribe()
-      await this.subscribe()
+      await new Promise<void>((resolve, reject) => {
+        this.subscribe((status, err) => {
+          if (status === REALTIME_SUBSCRIBE_STATES.SUBSCRIBED) {
+            resolve()
+          } else if (status === REALTIME_SUBSCRIBE_STATES.CHANNEL_ERROR) {
+            reject(err ?? new Error(`channel error during track() re-subscribe`))
+          } else if (status === REALTIME_SUBSCRIBE_STATES.TIMED_OUT) {
+            reject(new Error(`timed out re-subscribing for track()`))
+          }
+        }, opts.timeout || this.timeout)
+      })
     }
     return await this.send(
       {

--- a/packages/core/realtime-js/src/RealtimeChannel.ts
+++ b/packages/core/realtime-js/src/RealtimeChannel.ts
@@ -422,6 +422,15 @@ export default class RealtimeChannel {
     payload: { [key: string]: any },
     opts: { [key: string]: any } = {}
   ): Promise<RealtimeChannelSendResponse> {
+    if (this.state === CHANNEL_STATES.joined && this.params.config.presence?.enabled !== true) {
+      this.params.config.presence = {
+        ...this.params.config.presence,
+        enabled: true,
+      }
+      this.socket.log('channel', `resubscribe to ${this.topic} to enable presence for track()`)
+      await this.unsubscribe()
+      await this.subscribe()
+    }
     return await this.send(
       {
         type: 'presence',

--- a/packages/core/realtime-js/src/RealtimeChannel.ts
+++ b/packages/core/realtime-js/src/RealtimeChannel.ts
@@ -452,6 +452,20 @@ export default class RealtimeChannel {
       }
       this.socket.log('channel', `resubscribe to ${this.topic} to enable presence for track()`)
       await this.unsubscribe()
+
+      // Workaround: phoenix's Channel constructor's onClose handler removes
+      // the channel from socket.channels when leave completes (channel.js
+      // constructor onClose: `this.socket.remove(this)`). Without re-adding,
+      // the second join's phx_reply never routes back to this channel and
+      // joinPush times out. Re-register before re-subscribing.
+      // A complete fix lives in @supabase/phoenix; until then, this keeps
+      // the resubscribe-on-track path working at the supabase-js layer.
+      const phoenixChannel = this.channelAdapter.getChannel()
+      const phoenixSocket = phoenixChannel.socket
+      if (!phoenixSocket.channels.includes(phoenixChannel)) {
+        phoenixSocket.channels.push(phoenixChannel)
+      }
+
       await new Promise<void>((resolve, reject) => {
         this.subscribe((status, err) => {
           if (status === REALTIME_SUBSCRIBE_STATES.SUBSCRIBED) {

--- a/packages/core/realtime-js/src/RealtimeChannel.ts
+++ b/packages/core/realtime-js/src/RealtimeChannel.ts
@@ -28,7 +28,15 @@ export type RealtimeChannelOptions = {
      */
     broadcast?: { self?: boolean; ack?: boolean; replay?: ReplayOption }
     /**
-     * key option is used to track presence payload across clients
+     * Presence configuration for the channel.
+     *
+     * - `key` is used to track presence payload across clients.
+     * - `enabled` opts the channel into presence on join. The client sets this
+     *   to `true` automatically when a `.on('presence', ...)` listener is
+     *   registered before `.subscribe()`. Set it explicitly when the channel
+     *   only sends presence via `.track()` and never listens for presence
+     *   events, otherwise the first `.track()` call will trigger a one-time
+     *   internal resubscribe to enable presence on the server.
      */
     presence?: { key?: string; enabled?: boolean }
     /**
@@ -416,6 +424,13 @@ export default class RealtimeChannel {
    * Sends the supplied payload to the presence tracker so other subscribers can see that this
    * client is online. Use `untrack` to stop broadcasting presence for the same key.
    *
+   * Presence must be enabled on the channel for tracked state to reach other subscribers.
+   * The client enables it automatically when a `.on('presence', ...)` listener is registered
+   * before `.subscribe()`. For channels that only send presence and never listen for it,
+   * the first call to `track()` will transparently re-join the channel with presence enabled.
+   * To avoid that one-time round-trip, set `config.presence.enabled` to `true` when creating
+   * the channel.
+   *
    * @category Realtime
    */
   async track(
@@ -443,6 +458,8 @@ export default class RealtimeChannel {
 
   /**
    * Removes the current presence state for this client.
+   *
+   * @see {@link track} for notes on presence being enabled on the channel.
    *
    * @category Realtime
    */

--- a/packages/core/realtime-js/test/RealtimeChannel.lifecycle.test.ts
+++ b/packages/core/realtime-js/test/RealtimeChannel.lifecycle.test.ts
@@ -229,7 +229,7 @@ describe('Channel Lifecycle Management', () => {
       assert.equal(channel.state, CHANNEL_STATES.joined)
     })
 
-    test('if subscription closed and then subscribe, it will throw error', async () => {
+    test('can be subscribed again after being unsubscribed', async () => {
       const subscribeSpy = vi.fn()
 
       channel.subscribe(subscribeSpy)
@@ -237,7 +237,11 @@ describe('Channel Lifecycle Management', () => {
       await vi.waitFor(() => expect(channel.state).toBe(CHANNEL_STATES.joined))
       channel.unsubscribe()
       await vi.waitFor(() => expect(channel.state).toBe(CHANNEL_STATES.closed))
-      expect(() => channel.subscribe()).toThrowError()
+
+      // @supabase/phoenix >= 0.4.3 resets joinedOnce on leave, so a fresh
+      // subscribe() succeeds and transitions the channel back through joining.
+      expect(() => channel.subscribe()).not.toThrow()
+      assert.equal(channel.state, CHANNEL_STATES.joining)
     })
 
     test('updates join push payload access token', async () => {

--- a/packages/core/realtime-js/test/RealtimeChannel.presence.test.ts
+++ b/packages/core/realtime-js/test/RealtimeChannel.presence.test.ts
@@ -1,7 +1,12 @@
 import assert from 'assert'
 import { describe, beforeEach, afterEach, test, vi, expect } from 'vitest'
 import RealtimeChannel from '../src/RealtimeChannel'
-import { setupRealtimeTest, waitForChannelSubscribed, type TestSetup } from './helpers/setup'
+import {
+  phxReply,
+  setupRealtimeTest,
+  waitForChannelSubscribed,
+  type TestSetup,
+} from './helpers/setup'
 import { REALTIME_LISTEN_TYPES } from '../src/RealtimeChannel'
 import { CHANNEL_STATES } from '../src/lib/constants'
 
@@ -440,5 +445,110 @@ describe('Presence configuration override', () => {
     )
 
     channelWithPresenceEnabled.unsubscribe()
+  })
+})
+
+describe('track() auto-enables presence when needed', () => {
+  let trackTestSetup: TestSetup
+
+  beforeEach(() => {
+    trackTestSetup = setupRealtimeTest({
+      useFakeTimers: true,
+      timeout: defaultTimeout,
+      socketHandlers: {
+        phx_leave: (socket, message) => {
+          socket.send(phxReply(message as string, { status: 'ok', response: {} }))
+        },
+        phx_join: (socket, message) => {
+          socket.send(
+            phxReply(message as string, { status: 'ok', response: { postgres_changes: [] } })
+          )
+        },
+      },
+    })
+  })
+
+  afterEach(() => trackTestSetup.cleanup())
+
+  test('resubscribes with presence enabled when track() is called on a channel that joined without it', async () => {
+    const senderChannel = trackTestSetup.client.channel('test-track-auto-enable')
+    senderChannel.subscribe()
+    await waitForChannelSubscribed(senderChannel)
+
+    // First join went out with enabled: false
+    const firstJoinPayload = trackTestSetup.emitters.message.mock.calls.find(
+      (call) => call[1] === 'phx_join'
+    )
+    assert.equal(firstJoinPayload?.[2].config.presence.enabled, false)
+
+    const resp = await senderChannel.track({ user_id: 1 })
+    expect(resp).toBe('ok')
+
+    // After track(), expect a phx_leave and a second phx_join with enabled: true
+    await vi.waitFor(() =>
+      expect(trackTestSetup.emitters.message).toHaveBeenCalledWith(
+        'realtime:test-track-auto-enable',
+        'phx_leave',
+        expect.anything()
+      )
+    )
+
+    const joinCalls = trackTestSetup.emitters.message.mock.calls.filter(
+      (call) => call[0] === 'realtime:test-track-auto-enable' && call[1] === 'phx_join'
+    )
+    assert.equal(joinCalls.length, 2)
+    assert.equal(joinCalls[1][2].config.presence.enabled, true)
+
+    // The track event itself goes out after the re-join
+    await vi.waitFor(() =>
+      expect(trackTestSetup.emitters.message).toHaveBeenCalledWith(
+        'realtime:test-track-auto-enable',
+        'presence',
+        { type: 'presence', event: 'track', payload: { user_id: 1 } }
+      )
+    )
+  })
+
+  test('does not resubscribe when track() is called on a channel that joined with presence enabled via config', async () => {
+    const senderChannel = trackTestSetup.client.channel('test-track-config-enabled', {
+      config: { presence: { enabled: true } },
+    })
+    senderChannel.subscribe()
+    await waitForChannelSubscribed(senderChannel)
+
+    const resp = await senderChannel.track({ user_id: 1 })
+    expect(resp).toBe('ok')
+
+    const joinCalls = trackTestSetup.emitters.message.mock.calls.filter(
+      (call) => call[0] === 'realtime:test-track-config-enabled' && call[1] === 'phx_join'
+    )
+    assert.equal(joinCalls.length, 1)
+    assert.equal(joinCalls[0][2].config.presence.enabled, true)
+
+    const leaveCalls = trackTestSetup.emitters.message.mock.calls.filter(
+      (call) => call[0] === 'realtime:test-track-config-enabled' && call[1] === 'phx_leave'
+    )
+    assert.equal(leaveCalls.length, 0)
+  })
+
+  test('does not resubscribe when track() is called on a channel with a presence listener', async () => {
+    const senderChannel = trackTestSetup.client.channel('test-track-listener-enabled')
+    senderChannel.on('presence', { event: 'sync' }, () => {})
+    senderChannel.subscribe()
+    await waitForChannelSubscribed(senderChannel)
+
+    const resp = await senderChannel.track({ user_id: 1 })
+    expect(resp).toBe('ok')
+
+    const joinCalls = trackTestSetup.emitters.message.mock.calls.filter(
+      (call) => call[0] === 'realtime:test-track-listener-enabled' && call[1] === 'phx_join'
+    )
+    assert.equal(joinCalls.length, 1)
+    assert.equal(joinCalls[0][2].config.presence.enabled, true)
+
+    const leaveCalls = trackTestSetup.emitters.message.mock.calls.filter(
+      (call) => call[0] === 'realtime:test-track-listener-enabled' && call[1] === 'phx_leave'
+    )
+    assert.equal(leaveCalls.length, 0)
   })
 })

--- a/packages/core/realtime-js/test/RealtimeChannel.presence.test.ts
+++ b/packages/core/realtime-js/test/RealtimeChannel.presence.test.ts
@@ -282,7 +282,11 @@ describe('Presence helper methods', () => {
         },
       },
     })
-    channel = testSetup.client.channel('test-presence')
+    // enabled: true so `track()` exercises the send path directly instead of
+    // triggering the auto-enable resubscribe added in RealtimeChannel.track().
+    channel = testSetup.client.channel('test-presence', {
+      config: { presence: { enabled: true } },
+    })
   })
 
   test('gets transformed presence state', () => {
@@ -449,34 +453,40 @@ describe('Presence configuration override', () => {
 })
 
 describe('track() auto-enables presence when needed', () => {
-  let trackTestSetup: TestSetup
-
   beforeEach(() => {
-    trackTestSetup = setupRealtimeTest({
-      useFakeTimers: true,
+    // Reassign the file-level testSetup (same pattern as
+    // `Presence configuration override`) so the outer beforeEach's setup
+    // doesn't run in parallel with ours. We need an explicit phx_leave handler
+    // because the auto-enable path inside track() does unsubscribe()+subscribe().
+    testSetup.cleanup()
+    testSetup = setupRealtimeTest({
       timeout: defaultTimeout,
       socketHandlers: {
         phx_leave: (socket, message) => {
           socket.send(phxReply(message as string, { status: 'ok', response: {} }))
         },
-        phx_join: (socket, message) => {
+        presence: (socket, msg) => {
+          const { topic, ref } = JSON.parse(msg as string)
           socket.send(
-            phxReply(message as string, { status: 'ok', response: { postgres_changes: [] } })
+            JSON.stringify({
+              topic,
+              event: 'phx_reply',
+              payload: { status: 'ok', response: {} },
+              ref,
+            })
           )
         },
       },
     })
   })
 
-  afterEach(() => trackTestSetup.cleanup())
-
   test('resubscribes with presence enabled when track() is called on a channel that joined without it', async () => {
-    const senderChannel = trackTestSetup.client.channel('test-track-auto-enable')
+    const senderChannel = testSetup.client.channel('test-track-auto-enable')
     senderChannel.subscribe()
     await waitForChannelSubscribed(senderChannel)
 
     // First join went out with enabled: false
-    const firstJoinPayload = trackTestSetup.emitters.message.mock.calls.find(
+    const firstJoinPayload = testSetup.emitters.message.mock.calls.find(
       (call) => call[1] === 'phx_join'
     )
     assert.equal(firstJoinPayload?.[2].config.presence.enabled, false)
@@ -486,14 +496,14 @@ describe('track() auto-enables presence when needed', () => {
 
     // After track(), expect a phx_leave and a second phx_join with enabled: true
     await vi.waitFor(() =>
-      expect(trackTestSetup.emitters.message).toHaveBeenCalledWith(
+      expect(testSetup.emitters.message).toHaveBeenCalledWith(
         'realtime:test-track-auto-enable',
         'phx_leave',
         expect.anything()
       )
     )
 
-    const joinCalls = trackTestSetup.emitters.message.mock.calls.filter(
+    const joinCalls = testSetup.emitters.message.mock.calls.filter(
       (call) => call[0] === 'realtime:test-track-auto-enable' && call[1] === 'phx_join'
     )
     assert.equal(joinCalls.length, 2)
@@ -501,16 +511,18 @@ describe('track() auto-enables presence when needed', () => {
 
     // The track event itself goes out after the re-join
     await vi.waitFor(() =>
-      expect(trackTestSetup.emitters.message).toHaveBeenCalledWith(
+      expect(testSetup.emitters.message).toHaveBeenCalledWith(
         'realtime:test-track-auto-enable',
         'presence',
         { type: 'presence', event: 'track', payload: { user_id: 1 } }
       )
     )
+
+    senderChannel.unsubscribe()
   })
 
   test('does not resubscribe when track() is called on a channel that joined with presence enabled via config', async () => {
-    const senderChannel = trackTestSetup.client.channel('test-track-config-enabled', {
+    const senderChannel = testSetup.client.channel('test-track-config-enabled', {
       config: { presence: { enabled: true } },
     })
     senderChannel.subscribe()
@@ -519,20 +531,22 @@ describe('track() auto-enables presence when needed', () => {
     const resp = await senderChannel.track({ user_id: 1 })
     expect(resp).toBe('ok')
 
-    const joinCalls = trackTestSetup.emitters.message.mock.calls.filter(
+    const joinCalls = testSetup.emitters.message.mock.calls.filter(
       (call) => call[0] === 'realtime:test-track-config-enabled' && call[1] === 'phx_join'
     )
     assert.equal(joinCalls.length, 1)
     assert.equal(joinCalls[0][2].config.presence.enabled, true)
 
-    const leaveCalls = trackTestSetup.emitters.message.mock.calls.filter(
+    const leaveCalls = testSetup.emitters.message.mock.calls.filter(
       (call) => call[0] === 'realtime:test-track-config-enabled' && call[1] === 'phx_leave'
     )
     assert.equal(leaveCalls.length, 0)
+
+    senderChannel.unsubscribe()
   })
 
   test('does not resubscribe when track() is called on a channel with a presence listener', async () => {
-    const senderChannel = trackTestSetup.client.channel('test-track-listener-enabled')
+    const senderChannel = testSetup.client.channel('test-track-listener-enabled')
     senderChannel.on('presence', { event: 'sync' }, () => {})
     senderChannel.subscribe()
     await waitForChannelSubscribed(senderChannel)
@@ -540,15 +554,17 @@ describe('track() auto-enables presence when needed', () => {
     const resp = await senderChannel.track({ user_id: 1 })
     expect(resp).toBe('ok')
 
-    const joinCalls = trackTestSetup.emitters.message.mock.calls.filter(
+    const joinCalls = testSetup.emitters.message.mock.calls.filter(
       (call) => call[0] === 'realtime:test-track-listener-enabled' && call[1] === 'phx_join'
     )
     assert.equal(joinCalls.length, 1)
     assert.equal(joinCalls[0][2].config.presence.enabled, true)
 
-    const leaveCalls = trackTestSetup.emitters.message.mock.calls.filter(
+    const leaveCalls = testSetup.emitters.message.mock.calls.filter(
       (call) => call[0] === 'realtime:test-track-listener-enabled' && call[1] === 'phx_leave'
     )
     assert.equal(leaveCalls.length, 0)
+
+    senderChannel.unsubscribe()
   })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -346,8 +346,8 @@ importers:
   packages/core/realtime-js:
     dependencies:
       '@supabase/phoenix':
-        specifier: ^0.4.2
-        version: 0.4.2
+        specifier: ^0.4.3
+        version: 0.4.3
       tslib:
         specifier: 2.8.1
         version: 2.8.1
@@ -3055,8 +3055,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@supabase/phoenix@0.4.2':
-    resolution: {integrity: sha512-YSAGnmDAfuleFCVt3CeurQZAhxRfXWeZIIkwp7NhYzQ1UwW6ePSnzsFAiUm/mbCkfoCf70QQHKW/K6RKh52a4A==}
+  '@supabase/phoenix@0.4.3':
+    resolution: {integrity: sha512-jZL/2uPEiK58RFJ+7rctex60AHTdtVWwqw4cqu+5JGrXdu/ZM7ZwttO+yRsRN/E/Xik6s+tmbvH7XAQux4m9nQ==}
 
   '@swc-node/core@1.14.1':
     resolution: {integrity: sha512-jrt5GUaZUU6cmMS+WTJEvGvaB6j1YNKPHPzC2PUi2BjaFbtxURHj6641Az6xN7b665hNniAIdvjxWcRml5yCnw==}
@@ -10689,7 +10689,7 @@ snapshots:
   '@supabase/cli-windows-x64@2.105.0':
     optional: true
 
-  '@supabase/phoenix@0.4.2': {}
+  '@supabase/phoenix@0.4.3': {}
 
   '@swc-node/core@1.14.1(@swc/core@1.15.8(@swc/helpers@0.5.21))(@swc/types@0.1.26)':
     dependencies:


### PR DESCRIPTION
## Description

Fixes a regression introduced in `supabase-js` 2.54 where presence stopped working for channels that only call `.track()` without registering a `.on('presence', ...)` listener.

### What changed?

In `RealtimeChannel.track()` (`packages/core/realtime-js/src/RealtimeChannel.ts`):

- If the channel is currently joined and `config.presence.enabled` is not `true`, flip the flag on the channel params and perform one `unsubscribe()` → `subscribe()` cycle before sending the track event. The second join goes out with `presence.enabled: true`, so the server registers the client as a presence participant and starts broadcasting its state.
- Existing channels that already opt in (either via a `.on('presence', ...)` listener, or via explicit `config: { presence: { enabled: true } }`) skip the new branch entirely.

Also:

- Tests: added `track() auto-enables presence when needed` describe block in `RealtimeChannel.presence.test.ts` covering the auto-resubscribe path, the no-op path for channels that opted in via config, and the no-op path for channels with a presence listener.
- TSDoc: documented the `presence.enabled` field on `RealtimeChannelOptions`, expanded the `track()` JSDoc to describe the implicit re-join behavior, and added a `@see {@link track}` cross-link on `untrack()`. These propagate to the generated reference docs.
- README: added a short paragraph in the Presence section explaining the opt-in for sender-only clients.

### Why was this change needed?

`realtime-js` 2.12 (shipped with `supabase-js` 2.54) added a `presence.enabled` flag on the channel join payload. The flag defaults to `false` and is auto-flipped to `true` only when the channel has a presence listener registered before `.subscribe()`. A "sender-only" client that only calls `.track()` therefore joined with `enabled: false`, so the server silently dropped its presence from broadcasts to other subscribers, with `track()` still returning `'ok'`.

The escape hatch added in `realtime-js` PR #530 (`config: { presence: { enabled: true } }`) works but is at the channel level. The official guidance to set `realtime: { presence: { enabled: true } }` on `createClient` does not propagate to channels and is a no-op, which is what the user in the issue confirmed. This PR makes the docs example and the most common user pattern work out of the box, while keeping the perf optimization for everyone who opts in explicitly.

Closes #1536

## Screenshots/Examples

Before this fix, the example from the official Presence guide would silently fail for the sender:

```js
const channel = supabase.channel('room_01')

channel.subscribe(async (status) => {
  if (status !== 'SUBSCRIBED') return
  await channel.track({ user: 'user-1', online_at: new Date().toISOString() })
})
```

Other clients listening on the same topic with `.on('presence', ...)` would never see this client. After this fix, the same code works without any changes. To skip the one-time internal resubscribe on the first `track()` call, callers can still opt in explicitly:

```js
const channel = supabase.channel('room_01', {
  config: { presence: { enabled: true } },
})
```

## Breaking changes

- [x] This PR contains no breaking changes

`.track()` keeps the same signature and return type. Channels that already opted into presence (listener or `enabled: true`) see no behavior change. Channels currently in the broken case go from silently dropping presence to actually broadcasting it. The only observable side effect is one extra leave/rejoin cycle on the first `track()` for those channels, once per channel lifetime.

## Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/supabase/supabase-js/blob/master/CONTRIBUTING.md)
- [x] My PR title follows the [conventional commit format](https://www.conventionalcommits.org/): `<type>(<scope>): <description>`
- [x] I have run `pnpm nx format` to ensure consistent code formatting
- [x] I have added tests for new functionality (if applicable)
- [x] I have updated documentation (if applicable)

## Additional notes

- The docs guide on supabase.com (the "sending state" snippet under https://supabase.com/docs/guides/realtime/presence) still omits the `enabled: true` opt-in. After this PR ships, the docs snippet works as-is, but it is worth updating in the docs repo to recommend the explicit opt-in for sender-only clients to avoid the resubscribe round-trip.
- `untrack()` does not need the same treatment: it is only meaningful after a successful `track()`, by which point presence is already enabled on the channel.