### PR TITLE
fix(storage): keep sortBy defaults when list() is given a partial sortBy

### DIFF
--- a/packages/core/storage-js/src/packages/StorageFileApi.ts
+++ b/packages/core/storage-js/src/packages/StorageFileApi.ts
@@ -1320,7 +1320,12 @@ export default class StorageFileApi extends BaseApiClient<StorageError> {
       }
   > {
     return this.handleOperation(async () => {
-      const body = { ...DEFAULT_SEARCH_OPTIONS, ...options, prefix: path || '' }
+      // Deep-merge `sortBy` so overriding only one of its keys (e.g. `column`) keeps the
+      // default for the other (e.g. `order`), matching how the top-level defaults behave.
+      const sortBy = options?.sortBy
+        ? { ...DEFAULT_SEARCH_OPTIONS.sortBy, ...options.sortBy }
+        : DEFAULT_SEARCH_OPTIONS.sortBy
+      const body = { ...DEFAULT_SEARCH_OPTIONS, ...options, sortBy, prefix: path || '' }
       return await post(
         this.fetch,
         `${this.url}/object/list/${this.bucketId}`,

--- a/packages/core/storage-js/test/list-sortby-defaults.test.ts
+++ b/packages/core/storage-js/test/list-sortby-defaults.test.ts
@@ -1,0 +1,42 @@
+import { StorageClient } from '../src/index'
+
+// Unit test (custom fetch capture) — proves that list() applies DEFAULT_SEARCH_OPTIONS
+// including the nested sortBy default, even when the caller overrides only part of it.
+describe('StorageFileApi.list() default sortBy merge', () => {
+  const URL = 'http://localhost/storage/v1'
+
+  const makeClient = () => {
+    let captured: { body?: unknown } | null = null
+    const fetch = (async (_url: string, opts: { body?: unknown }) => {
+      captured = opts
+      return new Response(JSON.stringify([]), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    }) as unknown as typeof globalThis.fetch
+    const client = new StorageClient(URL, {}, fetch)
+    const sentBody = () =>
+      typeof captured?.body === 'string' ? JSON.parse(captured.body) : (captured?.body as any)
+    return { client, sentBody }
+  }
+
+  test('applies the full default sortBy when no options are given', async () => {
+    const { client, sentBody } = makeClient()
+    await client.from('bucket').list('folder')
+    expect(sentBody().sortBy).toEqual({ column: 'name', order: 'asc' })
+  })
+
+  test('preserves the default sortBy.column when only sortBy.order is overridden', async () => {
+    const { client, sentBody } = makeClient()
+    await client.from('bucket').list('folder', { sortBy: { order: 'desc' } })
+    // The Storage server requires `column`; without the default fallback this sends a sortBy
+    // with no column, which the server rejects with a 400. This is the case that actually fails.
+    expect(sentBody().sortBy).toEqual({ column: 'name', order: 'desc' })
+  })
+
+  test('preserves the default sortBy.order when only sortBy.column is overridden', async () => {
+    const { client, sentBody } = makeClient()
+    await client.from('bucket').list('folder', { sortBy: { column: 'updated_at' } })
+    expect(sentBody().sortBy).toEqual({ column: 'updated_at', order: 'asc' })
+  })
+})


### PR DESCRIPTION
## 🔍 Description

### What changed?

`StorageFileApi.list()` shallow-spread its defaults into the request body, so a **partial** `sortBy` dropped the sibling default. This deep-merges `sortBy` so a partial override keeps the default for whichever key you don't set.

### Why was this change needed?

The case that actually fails today is **order-only**: `list('folder', { sortBy: { order: 'desc' } })`. On `master` this sends a `sortBy` with **no `column`**, and the Storage server requires `column`, so it returns a **400**. With the deep merge, `column` falls back to `'name'` and the request succeeds. (The symmetric column-only case likewise keeps the default `order: 'asc'`.)

## 📸 Examples / Proof

`test/list-sortby-defaults.test.ts` (Docker-free, custom-fetch capture). On `master` the order-only and column-only cases fail; with this change all pass:

- `{ sortBy: { order: 'desc' } }` → `{ column: 'name', order: 'desc' }`  *(was `{ order: 'desc' }` → server 400)*
- `{ sortBy: { column: 'updated_at' } }` → `{ column: 'updated_at', order: 'asc' }`
- no options → `{ column: 'name', order: 'asc' }`

## 🔄 Breaking changes

- [x] This PR contains no breaking changes

## 📋 Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/supabase/supabase-js/blob/master/CONTRIBUTING.md)
- [x] My PR title follows conventional commits: `fix(storage): ...`
- [x] I have run `pnpm nx format`
- [x] I have added tests
- [ ] Documentation (not needed)

## 📝 Additional notes

Rebased on `master`. `pnpm nx build storage-js` passes; the full storage integration suite (Docker) runs in CI.