### PR TITLE
fix(functions): honor a caller's Content-Type override regardless of casing

### DIFF
--- a/packages/core/functions-js/src/FunctionsClient.ts
+++ b/packages/core/functions-js/src/FunctionsClient.ts
@@ -220,10 +220,11 @@ export class FunctionsClient {
         url.searchParams.set('forceFunctionRegion', region)
       }
       let body: any
-      if (
-        functionArgs &&
-        ((headers && !Object.prototype.hasOwnProperty.call(headers, 'Content-Type')) || !headers)
-      ) {
+      // HTTP header names are case-insensitive, so detect a caller-supplied Content-Type
+      // regardless of casing — otherwise the SDK injects a second, conflicting Content-Type.
+      const hasContentTypeHeader =
+        !!headers && Object.keys(headers).some((key) => key.toLowerCase() === 'content-type')
+      if (functionArgs && !hasContentTypeHeader) {
         if (
           (typeof Blob !== 'undefined' && functionArgs instanceof Blob) ||
           functionArgs instanceof ArrayBuffer

--- a/packages/core/functions-js/test/spec/params.spec.ts
+++ b/packages/core/functions-js/test/spec/params.spec.ts
@@ -543,4 +543,44 @@ describe('body stringify with custom headers', () => {
       })
     )
   })
+
+  // HTTP header names are case-insensitive, so a caller-supplied Content-Type must be
+  // honored regardless of casing — the SDK must not inject its own conflicting one.
+  const effectiveContentTypes = (mockFetch: jest.Mock): string[] => {
+    const headers = (mockFetch.mock.calls[0][1] as { headers?: Record<string, string> }).headers
+    return Object.entries(headers ?? {})
+      .filter(([key]) => key.toLowerCase() === 'content-type')
+      .map(([, value]) => value)
+  }
+
+  test('honors an uppercase Content-Type override (baseline)', async () => {
+    const mockFetch = jest.fn().mockResolvedValue(new Response('ok'))
+    const client = new FunctionsClient('http://localhost', { customFetch: mockFetch })
+
+    await client.invoke('test-fn', {
+      body: { a: 1 },
+      headers: { 'Content-Type': 'application/vnd.api+json' },
+    })
+
+    expect(effectiveContentTypes(mockFetch)).toEqual(['application/vnd.api+json'])
+  })
+
+  test('honors a lowercase content-type override without injecting a conflicting one', async () => {
+    const mockFetch = jest.fn().mockResolvedValue(new Response('ok'))
+    const client = new FunctionsClient('http://localhost', { customFetch: mockFetch })
+
+    await client.invoke('test-fn', {
+      body: { a: 1 },
+      headers: { 'content-type': 'application/vnd.api+json' },
+    })
+
+    expect(effectiveContentTypes(mockFetch)).toEqual(['application/vnd.api+json'])
+    // body still routes through the JSON serialization branch
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        body: '{"a":1}',
+      })
+    )
+  })
 })


### PR DESCRIPTION
## 🔍 Description

### What changed?

`FunctionsClient.invoke()` decided whether to auto-set a `Content-Type` using a **case-sensitive** `hasOwnProperty('Content-Type')` check. HTTP header names are case-insensitive, so a caller-supplied lowercase `content-type` was not detected. This matches the header name case-insensitively before deciding to auto-set/serialize.

### Why was this change needed?

With a lowercase `content-type`, the SDK fell into the auto-detect branch: it set its own `Content-Type: application/json`, JSON-stringified the body, then merged the caller's header on top — producing **two conflicting `Content-Type` headers** and ignoring the caller's intent. The docs state you can override by passing your own Content-Type header.

## 📸 Examples / Proof

Tests live in `test/spec/params.spec.ts` inside the existing `body stringify with custom headers` block (reusing its `customFetch` harness). On `master` the lowercase case fails:

```
- Expected:  ["application/vnd.api+json"]
+ Received:  ["application/json", "application/vnd.api+json"]
```

The lowercase test also asserts the request **body** is still `'{"a":1}'`, locking in that the fix routes through the correct (JSON) serialization branch. The uppercase baseline is unchanged.

## 🔄 Breaking changes

- [x] This PR contains no breaking changes

## 📋 Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/supabase/supabase-js/blob/master/CONTRIBUTING.md)
- [x] My PR title follows conventional commits: `fix(functions): ...`
- [x] I have run `pnpm nx format`
- [x] I have added tests
- [ ] Documentation (not needed)

## 📝 Additional notes

Rebased on `master`. Addressed review: moved the tests into `params.spec.ts` (removed the standalone file) and added the request-body assertion for the lowercase case.