### PR TITLE
ci(ci): skip dependency firewall on fork PRs without token

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -30,6 +30,7 @@ jobs:
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Configure Dependency Firewall registry
+        shell: bash
         env:
           DF_FIREWALL_TOKEN: ${{ secrets.DF_FIREWALL_TOKEN }}
         run: |
@@ -81,6 +82,7 @@ jobs:
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Configure Dependency Firewall registry
+        shell: bash
         env:
           DF_FIREWALL_TOKEN: ${{ secrets.DF_FIREWALL_TOKEN }}
         run: |
@@ -127,6 +129,7 @@ jobs:
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Configure Dependency Firewall registry
+        shell: bash
         env:
           DF_FIREWALL_TOKEN: ${{ secrets.DF_FIREWALL_TOKEN }}
         run: |
@@ -186,6 +189,7 @@ jobs:
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Configure Dependency Firewall registry
+        shell: bash
         env:
           DF_FIREWALL_TOKEN: ${{ secrets.DF_FIREWALL_TOKEN }}
         run: |
@@ -261,6 +265,7 @@ jobs:
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Configure Dependency Firewall registry
+        shell: bash
         env:
           DF_FIREWALL_TOKEN: ${{ secrets.DF_FIREWALL_TOKEN }}
         run: |
@@ -334,6 +339,7 @@ jobs:
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Configure Dependency Firewall registry
+        shell: bash
         env:
           DF_FIREWALL_TOKEN: ${{ secrets.DF_FIREWALL_TOKEN }}
         run: |
@@ -403,6 +409,7 @@ jobs:
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Configure Dependency Firewall registry
+        shell: bash
         env:
           DF_FIREWALL_TOKEN: ${{ secrets.DF_FIREWALL_TOKEN }}
         run: |
@@ -499,6 +506,7 @@ jobs:
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Configure Dependency Firewall registry
+        shell: bash
         env:
           DF_FIREWALL_TOKEN: ${{ secrets.DF_FIREWALL_TOKEN }}
         run: |

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -30,17 +30,24 @@ jobs:
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Configure Dependency Firewall registry
+        env:
+          DF_FIREWALL_TOKEN: ${{ secrets.DF_FIREWALL_TOKEN }}
         run: |
-          pnpm config set //firewall.depthfirst.com/npm/:_authToken "${{ secrets.DF_FIREWALL_TOKEN }}"
-          pnpm config set registry https://firewall.depthfirst.com/npm/
+          # The firewall token is withheld from fork-triggered PR runs, so only route
+          # through the firewall when the token is present. Forks fall back to the
+          # default public npm registry (install still uses --frozen-lockfile).
+          if [ -n "$DF_FIREWALL_TOKEN" ]; then
+            pnpm config set //firewall.depthfirst.com/npm/:_authToken "$DF_FIREWALL_TOKEN"
+            pnpm config set registry https://firewall.depthfirst.com/npm/
+          else
+            echo "No DF_FIREWALL_TOKEN (likely a fork PR); using the default public npm registry."
+          fi
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: 'pnpm'
       - name: Install dependencies
-        env:
-          pnpm_config_registry: https://firewall.depthfirst.com/npm/
         run: pnpm install --frozen-lockfile
       - uses: nrwl/nx-set-shas@afb73a62d26e41464e9254689e1fd6122ee683c1 # v5.0.1
       - name: Detect affected packages
@@ -74,17 +81,24 @@ jobs:
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Configure Dependency Firewall registry
+        env:
+          DF_FIREWALL_TOKEN: ${{ secrets.DF_FIREWALL_TOKEN }}
         run: |
-          pnpm config set //firewall.depthfirst.com/npm/:_authToken "${{ secrets.DF_FIREWALL_TOKEN }}"
-          pnpm config set registry https://firewall.depthfirst.com/npm/
+          # The firewall token is withheld from fork-triggered PR runs, so only route
+          # through the firewall when the token is present. Forks fall back to the
+          # default public npm registry (install still uses --frozen-lockfile).
+          if [ -n "$DF_FIREWALL_TOKEN" ]; then
+            pnpm config set //firewall.depthfirst.com/npm/:_authToken "$DF_FIREWALL_TOKEN"
+            pnpm config set registry https://firewall.depthfirst.com/npm/
+          else
+            echo "No DF_FIREWALL_TOKEN (likely a fork PR); using the default public npm registry."
+          fi
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: 'pnpm'
       - name: Install dependencies
-        env:
-          pnpm_config_registry: https://firewall.depthfirst.com/npm/
         run: pnpm install --frozen-lockfile
       - name: Audit production dependencies
         run: pnpm audit --audit-level=high --prod --registry https://registry.npmjs.org
@@ -113,17 +127,24 @@ jobs:
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Configure Dependency Firewall registry
+        env:
+          DF_FIREWALL_TOKEN: ${{ secrets.DF_FIREWALL_TOKEN }}
         run: |
-          pnpm config set //firewall.depthfirst.com/npm/:_authToken "${{ secrets.DF_FIREWALL_TOKEN }}"
-          pnpm config set registry https://firewall.depthfirst.com/npm/
+          # The firewall token is withheld from fork-triggered PR runs, so only route
+          # through the firewall when the token is present. Forks fall back to the
+          # default public npm registry (install still uses --frozen-lockfile).
+          if [ -n "$DF_FIREWALL_TOKEN" ]; then
+            pnpm config set //firewall.depthfirst.com/npm/:_authToken "$DF_FIREWALL_TOKEN"
+            pnpm config set registry https://firewall.depthfirst.com/npm/
+          else
+            echo "No DF_FIREWALL_TOKEN (likely a fork PR); using the default public npm registry."
+          fi
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: 'pnpm'
       - name: Install dependencies
-        env:
-          pnpm_config_registry: https://firewall.depthfirst.com/npm/
         run: pnpm install --frozen-lockfile
       - uses: nrwl/nx-set-shas@afb73a62d26e41464e9254689e1fd6122ee683c1 # v5.0.1
       - name: Run test:ci for affected packages
@@ -165,9 +186,18 @@ jobs:
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Configure Dependency Firewall registry
+        env:
+          DF_FIREWALL_TOKEN: ${{ secrets.DF_FIREWALL_TOKEN }}
         run: |
-          pnpm config set //firewall.depthfirst.com/npm/:_authToken "${{ secrets.DF_FIREWALL_TOKEN }}"
-          pnpm config set registry https://firewall.depthfirst.com/npm/
+          # The firewall token is withheld from fork-triggered PR runs, so only route
+          # through the firewall when the token is present. Forks fall back to the
+          # default public npm registry (install still uses --frozen-lockfile).
+          if [ -n "$DF_FIREWALL_TOKEN" ]; then
+            pnpm config set //firewall.depthfirst.com/npm/:_authToken "$DF_FIREWALL_TOKEN"
+            pnpm config set registry https://firewall.depthfirst.com/npm/
+          else
+            echo "No DF_FIREWALL_TOKEN (likely a fork PR); using the default public npm registry."
+          fi
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -175,8 +205,6 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        env:
-          pnpm_config_registry: https://firewall.depthfirst.com/npm/
         run: pnpm install --frozen-lockfile
       - name: Cache Supabase Docker images
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -233,9 +261,18 @@ jobs:
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Configure Dependency Firewall registry
+        env:
+          DF_FIREWALL_TOKEN: ${{ secrets.DF_FIREWALL_TOKEN }}
         run: |
-          pnpm config set //firewall.depthfirst.com/npm/:_authToken "${{ secrets.DF_FIREWALL_TOKEN }}"
-          pnpm config set registry https://firewall.depthfirst.com/npm/
+          # The firewall token is withheld from fork-triggered PR runs, so only route
+          # through the firewall when the token is present. Forks fall back to the
+          # default public npm registry (install still uses --frozen-lockfile).
+          if [ -n "$DF_FIREWALL_TOKEN" ]; then
+            pnpm config set //firewall.depthfirst.com/npm/:_authToken "$DF_FIREWALL_TOKEN"
+            pnpm config set registry https://firewall.depthfirst.com/npm/
+          else
+            echo "No DF_FIREWALL_TOKEN (likely a fork PR); using the default public npm registry."
+          fi
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -243,8 +280,6 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        env:
-          pnpm_config_registry: https://firewall.depthfirst.com/npm/
         run: pnpm install --frozen-lockfile
       - name: Cache Supabase Docker images
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -299,9 +334,18 @@ jobs:
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Configure Dependency Firewall registry
+        env:
+          DF_FIREWALL_TOKEN: ${{ secrets.DF_FIREWALL_TOKEN }}
         run: |
-          pnpm config set //firewall.depthfirst.com/npm/:_authToken "${{ secrets.DF_FIREWALL_TOKEN }}"
-          pnpm config set registry https://firewall.depthfirst.com/npm/
+          # The firewall token is withheld from fork-triggered PR runs, so only route
+          # through the firewall when the token is present. Forks fall back to the
+          # default public npm registry (install still uses --frozen-lockfile).
+          if [ -n "$DF_FIREWALL_TOKEN" ]; then
+            pnpm config set //firewall.depthfirst.com/npm/:_authToken "$DF_FIREWALL_TOKEN"
+            pnpm config set registry https://firewall.depthfirst.com/npm/
+          else
+            echo "No DF_FIREWALL_TOKEN (likely a fork PR); using the default public npm registry."
+          fi
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -309,8 +353,6 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        env:
-          pnpm_config_registry: https://firewall.depthfirst.com/npm/
         run: pnpm install --frozen-lockfile
       - name: Cache Supabase Docker images
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -361,9 +403,18 @@ jobs:
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Configure Dependency Firewall registry
+        env:
+          DF_FIREWALL_TOKEN: ${{ secrets.DF_FIREWALL_TOKEN }}
         run: |
-          pnpm config set //firewall.depthfirst.com/npm/:_authToken "${{ secrets.DF_FIREWALL_TOKEN }}"
-          pnpm config set registry https://firewall.depthfirst.com/npm/
+          # The firewall token is withheld from fork-triggered PR runs, so only route
+          # through the firewall when the token is present. Forks fall back to the
+          # default public npm registry (install still uses --frozen-lockfile).
+          if [ -n "$DF_FIREWALL_TOKEN" ]; then
+            pnpm config set //firewall.depthfirst.com/npm/:_authToken "$DF_FIREWALL_TOKEN"
+            pnpm config set registry https://firewall.depthfirst.com/npm/
+          else
+            echo "No DF_FIREWALL_TOKEN (likely a fork PR); using the default public npm registry."
+          fi
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -371,8 +422,6 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        env:
-          pnpm_config_registry: https://firewall.depthfirst.com/npm/
         run: pnpm install --frozen-lockfile
       - name: Cache Supabase Docker images
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -450,9 +499,18 @@ jobs:
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Configure Dependency Firewall registry
+        env:
+          DF_FIREWALL_TOKEN: ${{ secrets.DF_FIREWALL_TOKEN }}
         run: |
-          pnpm config set //firewall.depthfirst.com/npm/:_authToken "${{ secrets.DF_FIREWALL_TOKEN }}"
-          pnpm config set registry https://firewall.depthfirst.com/npm/
+          # The firewall token is withheld from fork-triggered PR runs, so only route
+          # through the firewall when the token is present. Forks fall back to the
+          # default public npm registry (install still uses --frozen-lockfile).
+          if [ -n "$DF_FIREWALL_TOKEN" ]; then
+            pnpm config set //firewall.depthfirst.com/npm/:_authToken "$DF_FIREWALL_TOKEN"
+            pnpm config set registry https://firewall.depthfirst.com/npm/
+          else
+            echo "No DF_FIREWALL_TOKEN (likely a fork PR); using the default public npm registry."
+          fi
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -460,8 +518,6 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        env:
-          pnpm_config_registry: https://firewall.depthfirst.com/npm/
         run: pnpm install --frozen-lockfile
       - name: Cache Supabase Docker images
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5

--- a/.github/workflows/ci-supabase-js.yml
+++ b/.github/workflows/ci-supabase-js.yml
@@ -22,6 +22,7 @@ jobs:
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Configure Dependency Firewall registry
+        shell: bash
         env:
           DF_FIREWALL_TOKEN: ${{ secrets.DF_FIREWALL_TOKEN }}
         run: |
@@ -87,6 +88,7 @@ jobs:
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Configure Dependency Firewall registry
+        shell: bash
         env:
           DF_FIREWALL_TOKEN: ${{ secrets.DF_FIREWALL_TOKEN }}
         run: |
@@ -138,6 +140,7 @@ jobs:
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Configure Dependency Firewall registry
+        shell: bash
         env:
           DF_FIREWALL_TOKEN: ${{ secrets.DF_FIREWALL_TOKEN }}
         run: |

--- a/.github/workflows/ci-supabase-js.yml
+++ b/.github/workflows/ci-supabase-js.yml
@@ -22,9 +22,18 @@ jobs:
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Configure Dependency Firewall registry
+        env:
+          DF_FIREWALL_TOKEN: ${{ secrets.DF_FIREWALL_TOKEN }}
         run: |
-          pnpm config set //firewall.depthfirst.com/npm/:_authToken "${{ secrets.DF_FIREWALL_TOKEN }}"
-          pnpm config set registry https://firewall.depthfirst.com/npm/
+          # The firewall token is withheld from fork-triggered PR runs, so only route
+          # through the firewall when the token is present. Forks fall back to the
+          # default public npm registry (install still uses --frozen-lockfile).
+          if [ -n "$DF_FIREWALL_TOKEN" ]; then
+            pnpm config set //firewall.depthfirst.com/npm/:_authToken "$DF_FIREWALL_TOKEN"
+            pnpm config set registry https://firewall.depthfirst.com/npm/
+          else
+            echo "No DF_FIREWALL_TOKEN (likely a fork PR); using the default public npm registry."
+          fi
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -32,8 +41,6 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        env:
-          pnpm_config_registry: https://firewall.depthfirst.com/npm/
         run: pnpm install --frozen-lockfile
 
       - uses: nrwl/nx-set-shas@afb73a62d26e41464e9254689e1fd6122ee683c1 # v5.0.1
@@ -80,9 +87,18 @@ jobs:
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Configure Dependency Firewall registry
+        env:
+          DF_FIREWALL_TOKEN: ${{ secrets.DF_FIREWALL_TOKEN }}
         run: |
-          pnpm config set //firewall.depthfirst.com/npm/:_authToken "${{ secrets.DF_FIREWALL_TOKEN }}"
-          pnpm config set registry https://firewall.depthfirst.com/npm/
+          # The firewall token is withheld from fork-triggered PR runs, so only route
+          # through the firewall when the token is present. Forks fall back to the
+          # default public npm registry (install still uses --frozen-lockfile).
+          if [ -n "$DF_FIREWALL_TOKEN" ]; then
+            pnpm config set //firewall.depthfirst.com/npm/:_authToken "$DF_FIREWALL_TOKEN"
+            pnpm config set registry https://firewall.depthfirst.com/npm/
+          else
+            echo "No DF_FIREWALL_TOKEN (likely a fork PR); using the default public npm registry."
+          fi
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -91,8 +107,6 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        env:
-          pnpm_config_registry: https://firewall.depthfirst.com/npm/
         run: pnpm install --frozen-lockfile
 
       - name: Type Check + Unit Tests + Coverage
@@ -124,9 +138,18 @@ jobs:
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Configure Dependency Firewall registry
+        env:
+          DF_FIREWALL_TOKEN: ${{ secrets.DF_FIREWALL_TOKEN }}
         run: |
-          pnpm config set //firewall.depthfirst.com/npm/:_authToken "${{ secrets.DF_FIREWALL_TOKEN }}"
-          pnpm config set registry https://firewall.depthfirst.com/npm/
+          # The firewall token is withheld from fork-triggered PR runs, so only route
+          # through the firewall when the token is present. Forks fall back to the
+          # default public npm registry (install still uses --frozen-lockfile).
+          if [ -n "$DF_FIREWALL_TOKEN" ]; then
+            pnpm config set //firewall.depthfirst.com/npm/:_authToken "$DF_FIREWALL_TOKEN"
+            pnpm config set registry https://firewall.depthfirst.com/npm/
+          else
+            echo "No DF_FIREWALL_TOKEN (likely a fork PR); using the default public npm registry."
+          fi
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -135,8 +158,6 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        env:
-          pnpm_config_registry: https://firewall.depthfirst.com/npm/
         run: pnpm install --frozen-lockfile
 
       - name: Download build artifacts

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,9 +23,18 @@ jobs:
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Configure Dependency Firewall registry
+        env:
+          DF_FIREWALL_TOKEN: ${{ secrets.DF_FIREWALL_TOKEN }}
         run: |
-          pnpm config set //firewall.depthfirst.com/npm/:_authToken "${{ secrets.DF_FIREWALL_TOKEN }}"
-          pnpm config set registry https://firewall.depthfirst.com/npm/
+          # The firewall token is withheld from fork-triggered PR runs, so only route
+          # through the firewall when the token is present. Forks fall back to the
+          # default public npm registry (install still uses --frozen-lockfile).
+          if [ -n "$DF_FIREWALL_TOKEN" ]; then
+            pnpm config set //firewall.depthfirst.com/npm/:_authToken "$DF_FIREWALL_TOKEN"
+            pnpm config set registry https://firewall.depthfirst.com/npm/
+          else
+            echo "No DF_FIREWALL_TOKEN (likely a fork PR); using the default public npm registry."
+          fi
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -34,8 +43,6 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        env:
-          pnpm_config_registry: https://firewall.depthfirst.com/npm/
         run: pnpm install --frozen-lockfile
 
       - name: Generate JSON documentation for all packages

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,6 +23,7 @@ jobs:
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Configure Dependency Firewall registry
+        shell: bash
         env:
           DF_FIREWALL_TOKEN: ${{ secrets.DF_FIREWALL_TOKEN }}
         run: |

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -36,9 +36,18 @@ jobs:
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Configure Dependency Firewall registry
+        env:
+          DF_FIREWALL_TOKEN: ${{ secrets.DF_FIREWALL_TOKEN }}
         run: |
-          pnpm config set //firewall.depthfirst.com/npm/:_authToken "${{ secrets.DF_FIREWALL_TOKEN }}"
-          pnpm config set registry https://firewall.depthfirst.com/npm/
+          # The firewall token is withheld from fork-triggered PR runs, so only route
+          # through the firewall when the token is present. Forks fall back to the
+          # default public npm registry (install still uses --frozen-lockfile).
+          if [ -n "$DF_FIREWALL_TOKEN" ]; then
+            pnpm config set //firewall.depthfirst.com/npm/:_authToken "$DF_FIREWALL_TOKEN"
+            pnpm config set registry https://firewall.depthfirst.com/npm/
+          else
+            echo "No DF_FIREWALL_TOKEN (likely a fork PR); using the default public npm registry."
+          fi
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -57,8 +66,6 @@ jobs:
           bun-version: latest
 
       - name: Install dependencies
-        env:
-          pnpm_config_registry: https://firewall.depthfirst.com/npm/
         run: pnpm install --frozen-lockfile
 
       - name: Install jq for JSON parsing

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -36,6 +36,7 @@ jobs:
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Configure Dependency Firewall registry
+        shell: bash
         env:
           DF_FIREWALL_TOKEN: ${{ secrets.DF_FIREWALL_TOKEN }}
         run: |

--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -43,6 +43,7 @@ jobs:
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Configure Dependency Firewall registry
+        shell: bash
         env:
           DF_FIREWALL_TOKEN: ${{ secrets.DF_FIREWALL_TOKEN }}
         run: |

--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -43,8 +43,18 @@ jobs:
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Configure Dependency Firewall registry
+        env:
+          DF_FIREWALL_TOKEN: ${{ secrets.DF_FIREWALL_TOKEN }}
         run: |
-          pnpm config set //firewall.depthfirst.com/npm/:_authToken "${{ secrets.DF_FIREWALL_TOKEN }}"
+          # The firewall token is withheld from fork-triggered PR runs, so only route
+          # through the firewall when the token is present. Forks fall back to the
+          # default public npm registry (install still uses --frozen-lockfile).
+          if [ -n "$DF_FIREWALL_TOKEN" ]; then
+            pnpm config set //firewall.depthfirst.com/npm/:_authToken "$DF_FIREWALL_TOKEN"
+            pnpm config set registry https://firewall.depthfirst.com/npm/
+          else
+            echo "No DF_FIREWALL_TOKEN (likely a fork PR); using the default public npm registry."
+          fi
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -53,8 +63,6 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        env:
-          pnpm_config_registry: https://firewall.depthfirst.com/npm/
         run: pnpm install --frozen-lockfile
 
       - name: Set up Nx SHAs

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -91,6 +91,7 @@ jobs:
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Configure Dependency Firewall registry
+        shell: bash
         env:
           DF_FIREWALL_TOKEN: ${{ secrets.DF_FIREWALL_TOKEN }}
         run: |
@@ -286,6 +287,7 @@ jobs:
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Configure Dependency Firewall registry
+        shell: bash
         env:
           DF_FIREWALL_TOKEN: ${{ secrets.DF_FIREWALL_TOKEN }}
         run: |
@@ -422,6 +424,7 @@ jobs:
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Configure Dependency Firewall registry
+        shell: bash
         env:
           DF_FIREWALL_TOKEN: ${{ secrets.DF_FIREWALL_TOKEN }}
         run: |
@@ -555,6 +558,7 @@ jobs:
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Configure Dependency Firewall registry
+        shell: bash
         env:
           DF_FIREWALL_TOKEN: ${{ secrets.DF_FIREWALL_TOKEN }}
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -91,9 +91,18 @@ jobs:
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Configure Dependency Firewall registry
+        env:
+          DF_FIREWALL_TOKEN: ${{ secrets.DF_FIREWALL_TOKEN }}
         run: |
-          pnpm config set //firewall.depthfirst.com/npm/:_authToken "${{ secrets.DF_FIREWALL_TOKEN }}"
-          pnpm config set registry https://firewall.depthfirst.com/npm/
+          # The firewall token is withheld from fork-triggered PR runs, so only route
+          # through the firewall when the token is present. Forks fall back to the
+          # default public npm registry (install still uses --frozen-lockfile).
+          if [ -n "$DF_FIREWALL_TOKEN" ]; then
+            pnpm config set //firewall.depthfirst.com/npm/:_authToken "$DF_FIREWALL_TOKEN"
+            pnpm config set registry https://firewall.depthfirst.com/npm/
+          else
+            echo "No DF_FIREWALL_TOKEN (likely a fork PR); using the default public npm registry."
+          fi
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -110,8 +119,6 @@ jobs:
         run: echo "DENO_BIN_PATH=$(which deno)" >> "$GITHUB_ENV"
 
       - name: Install dependencies
-        env:
-          pnpm_config_registry: https://firewall.depthfirst.com/npm/
         run: pnpm install --frozen-lockfile
 
       - name: Configure git
@@ -279,9 +286,18 @@ jobs:
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Configure Dependency Firewall registry
+        env:
+          DF_FIREWALL_TOKEN: ${{ secrets.DF_FIREWALL_TOKEN }}
         run: |
-          pnpm config set //firewall.depthfirst.com/npm/:_authToken "${{ secrets.DF_FIREWALL_TOKEN }}"
-          pnpm config set registry https://firewall.depthfirst.com/npm/
+          # The firewall token is withheld from fork-triggered PR runs, so only route
+          # through the firewall when the token is present. Forks fall back to the
+          # default public npm registry (install still uses --frozen-lockfile).
+          if [ -n "$DF_FIREWALL_TOKEN" ]; then
+            pnpm config set //firewall.depthfirst.com/npm/:_authToken "$DF_FIREWALL_TOKEN"
+            pnpm config set registry https://firewall.depthfirst.com/npm/
+          else
+            echo "No DF_FIREWALL_TOKEN (likely a fork PR); using the default public npm registry."
+          fi
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -298,8 +314,6 @@ jobs:
         run: echo "DENO_BIN_PATH=$(which deno)" >> "$GITHUB_ENV"
 
       - name: Install dependencies
-        env:
-          pnpm_config_registry: https://firewall.depthfirst.com/npm/
         run: pnpm install --frozen-lockfile
 
       - name: Configure git
@@ -408,9 +422,18 @@ jobs:
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Configure Dependency Firewall registry
+        env:
+          DF_FIREWALL_TOKEN: ${{ secrets.DF_FIREWALL_TOKEN }}
         run: |
-          pnpm config set //firewall.depthfirst.com/npm/:_authToken "${{ secrets.DF_FIREWALL_TOKEN }}"
-          pnpm config set registry https://firewall.depthfirst.com/npm/
+          # The firewall token is withheld from fork-triggered PR runs, so only route
+          # through the firewall when the token is present. Forks fall back to the
+          # default public npm registry (install still uses --frozen-lockfile).
+          if [ -n "$DF_FIREWALL_TOKEN" ]; then
+            pnpm config set //firewall.depthfirst.com/npm/:_authToken "$DF_FIREWALL_TOKEN"
+            pnpm config set registry https://firewall.depthfirst.com/npm/
+          else
+            echo "No DF_FIREWALL_TOKEN (likely a fork PR); using the default public npm registry."
+          fi
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -427,8 +450,6 @@ jobs:
         run: echo "DENO_BIN_PATH=$(which deno)" >> "$GITHUB_ENV"
 
       - name: Install dependencies
-        env:
-          pnpm_config_registry: https://firewall.depthfirst.com/npm/
         run: pnpm install --frozen-lockfile
 
       - name: Configure git
@@ -534,8 +555,18 @@ jobs:
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Configure Dependency Firewall registry
+        env:
+          DF_FIREWALL_TOKEN: ${{ secrets.DF_FIREWALL_TOKEN }}
         run: |
-          pnpm config set //firewall.depthfirst.com/npm/:_authToken "${{ secrets.DF_FIREWALL_TOKEN }}"
+          # The firewall token is withheld from fork-triggered PR runs, so only route
+          # through the firewall when the token is present. Forks fall back to the
+          # default public npm registry (install still uses --frozen-lockfile).
+          if [ -n "$DF_FIREWALL_TOKEN" ]; then
+            pnpm config set //firewall.depthfirst.com/npm/:_authToken "$DF_FIREWALL_TOKEN"
+            pnpm config set registry https://firewall.depthfirst.com/npm/
+          else
+            echo "No DF_FIREWALL_TOKEN (likely a fork PR); using the default public npm registry."
+          fi
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -553,8 +584,6 @@ jobs:
         run: echo "DENO_BIN_PATH=$(which deno)" >> "$GITHUB_ENV"
 
       - name: Install dependencies
-        env:
-          pnpm_config_registry: https://firewall.depthfirst.com/npm/
         run: pnpm install --frozen-lockfile
       - name: Configure git
         run: |


### PR DESCRIPTION
Fork-triggered PR runs do not receive repository secrets, so `DF_FIREWALL_TOKEN` was empty and `pnpm install` hit the DepthFirst firewall registry with no auth, failing every external contributor PR at install time with a 401.

This gates the firewall configuration on the token actually being present: when it is (internal branches, master, publish), installs route through the firewall as before; when it is not (forks), they fall back to the default public npm registry. The hard-pinned `pnpm_config_registry` env on each install step is removed so the fallback can take effect, and `--frozen-lockfile` still enforces lockfile integrity in both cases. Applied across all six affected workflows.