### PR TITLE
test(realtime): gate chat e2e send on SUBSCRIBED to fix flaky tests

### DIFF
--- a/packages/core/realtime-js/example/components/chat.tsx
+++ b/packages/core/realtime-js/example/components/chat.tsx
@@ -33,7 +33,12 @@ export function Chat() {
   const [status, setStatus] = useState<string>("CONNECTING");
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const channelRef = useRef<RealtimeChannel | null>(null);
-  const supabase = createClient();
+  // Create the client once. `createClient()` returns a fresh instance (and a fresh
+  // GoTrueClient) on every call, so calling it inline on each render produced a new
+  // `supabase` reference, which is a dependency of the subscribe effect below. That made
+  // the effect tear down and re-create the channel on every render, spawning a flood of
+  // GoTrueClient instances and preventing the channel from staying SUBSCRIBED.
+  const [supabase] = useState(createClient);
 
   // Get username on mount
   useEffect(() => {

--- a/packages/core/realtime-js/example/components/chat.tsx
+++ b/packages/core/realtime-js/example/components/chat.tsx
@@ -30,6 +30,7 @@ export function Chat() {
   const [onlineUsers, setOnlineUsers] = useState<PresenceState[]>([]);
   const [input, setInput] = useState("");
   const [username, setUsername] = useState("");
+  const [status, setStatus] = useState<string>("CONNECTING");
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const channelRef = useRef<RealtimeChannel | null>(null);
   const supabase = createClient();
@@ -62,6 +63,9 @@ export function Chat() {
 
     fetchMessages();
 
+    // Re-engage the readiness gate while the (new) channel joins
+    setStatus("CONNECTING");
+
     // Subscribe to new messages and presence
     const channel = supabase
       .channel(`room:${room}`)
@@ -73,8 +77,9 @@ export function Chat() {
         const users = Object.values(state).flat();
         setOnlineUsers(users);
       })
-      .subscribe(async (status) => {
-        if (status === "SUBSCRIBED") {
+      .subscribe(async (channelStatus) => {
+        setStatus(channelStatus);
+        if (channelStatus === "SUBSCRIBED") {
           await channel.track({ username });
         }
       });
@@ -189,7 +194,7 @@ export function Chat() {
               placeholder="Type a message..."
               className="flex-1"
             />
-            <Button type="submit" disabled={!input.trim()}>
+            <Button type="submit" disabled={!input.trim() || status !== "SUBSCRIBED"}>
               Send
             </Button>
           </form>

--- a/packages/core/supabase-js/test/integration.browser.test.ts
+++ b/packages/core/supabase-js/test/integration.browser.test.ts
@@ -164,7 +164,10 @@ describe('Realtime integration test', () => {
 
       it('connects to realtime', async () => {
         await page.goto(`http://localhost:${port}?vsn=${vsn}`)
-        await page.waitForSelector('#realtime_status', { timeout: 2000 })
+        // `#realtime_status` is rendered only once the channel reaches SUBSCRIBED, so
+        // waiting for the selector is the readiness gate. Allow a CI-realistic budget for
+        // CDN script load + Babel transpile + websocket connect + channel join.
+        await page.waitForSelector('#realtime_status', { timeout: 30000 })
         const realtimeStatus = await page.$eval('#realtime_status', (el) => el.innerHTML)
         assertEquals(realtimeStatus, 'SUBSCRIBED')
 
@@ -176,8 +179,8 @@ describe('Realtime integration test', () => {
       it('can broadcast and receive messages', async () => {
         await page.goto(`http://localhost:${port}?vsn=${vsn}`)
 
-        // Wait for subscription
-        await page.waitForSelector('#realtime_status', { timeout: 2000 })
+        // Wait for subscription (selector renders only once SUBSCRIBED)
+        await page.waitForSelector('#realtime_status', { timeout: 30000 })
 
         // Wait for the broadcast message to be received
         await page.waitForSelector('#received_message', { timeout: 5000 })


### PR DESCRIPTION
Fixes two flaky realtime broadcast tests that intermittently failed CI across many unrelated PRs. Both failures were readiness races, not network jitter: the tests interacted with a channel before it reached `SUBSCRIBED`.

In the realtime chat example, the Send button was enabled as soon as the input had text, so a click could land before the channel was wired up, causing `sendMessage` to early-return and the message-visible assertion to time out. Send is now disabled until the channel status is `SUBSCRIBED`, so Playwright auto-waits for readiness before clicking.

In the supabase-js browser integration test, the `#realtime_status` waits allowed only 2000ms to cover CDN script load, Babel transpile, websocket connect, and channel join, which is unrealistic in CI. The timeout is raised to 30000ms (the selector only renders once subscribed, so it remains an accurate readiness gate).