### PR TITLE
chore: update sdk-compliance.yaml for realtime capability renames

### DIFF
--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -163,18 +163,14 @@ features:
 
   # realtime
   realtime.channel.broadcast_http: implemented
-  realtime.channel.channel: implemented
   realtime.channel.send: implemented
   realtime.channel.subscribe: implemented
   realtime.channel.unsubscribe: implemented
+  realtime.client.channel: implemented
   realtime.client.connect: implemented
   realtime.client.connection_state: implemented
   realtime.client.disconnect: implemented
-  realtime.client.endpoint_url: implemented
   realtime.client.get_channels: implemented
-  realtime.client.is_connected: implemented
-  realtime.client.is_connecting: implemented
-  realtime.client.is_disconnecting: implemented
   realtime.client.listen_heartbeats: implemented
   realtime.client.remove_all_channels: implemented
   realtime.client.remove_channel: implemented


### PR DESCRIPTION
## Summary

Syncs `sdk-compliance.yaml` with the upstream canonical capability registry changes landed in [supabase/sdk#27](https://github.com/supabase/sdk/pull/27).

### Removed capabilities (no longer in the canonical registry)

- `realtime.client.endpoint_url`
- `realtime.client.is_connected`
- `realtime.client.is_connecting`
- `realtime.client.is_disconnecting`

These four entries were removed from the canonical spec, so they are dropped from the compliance declaration.

### Renamed capability

- `realtime.channel.channel` → `realtime.client.channel`

The capability was moved from the `channel` group to the `client` group in the canonical registry. The entry is now listed alongside the other `realtime.client.*` capabilities.

## Depends on

https://github.com/supabase/sdk/pull/27