### PR TITLE
ci: use merged SDK compliance workflow

### DIFF
--- a/.github/workflows/validate-capabilities.yml
+++ b/.github/workflows/validate-capabilities.yml
@@ -1,10 +1,7 @@
-name: Validate SDK Compliance
+name: SDK Compliance
 
 on:
   pull_request:
-    paths:
-      - 'sdk-compliance.yaml'
-      - '.github/workflows/validate-capabilities.yml'
 
 permissions:
   contents: read
@@ -12,3 +9,5 @@ permissions:
 jobs:
   validate:
     uses: supabase/sdk/.github/workflows/validate-sdk-compliance.yml@main
+    with:
+      language: javascript


### PR DESCRIPTION
## Summary

- The `supabase/sdk` repo merged `validate-sdk-compliance.yml` and `check-api-compliance.yml` into a single reusable workflow (`validate-sdk-compliance.yml`)
- The merged workflow now requires a `language` input and always runs both a `validate` job and a `check` job
- The old `check-api-compliance.yml` reusable workflow has been deleted from `supabase/sdk`

## Changes

- Add required `with: language: javascript` input to the reusable workflow call
- Remove the `paths:` filter so the workflow runs on all PRs — the `check` job uses `github.event.pull_request.base.sha` to compare branches and must fire on every PR, not only when `sdk-compliance.yaml` changes
- Rename workflow from `Validate SDK Compliance` to `SDK Compliance` to match the new reusable workflow name