### PR TITLE
fix(realtime): forward track() timeout option to send

### DIFF
--- a/packages/core/realtime-js/src/RealtimeChannel.ts
+++ b/packages/core/realtime-js/src/RealtimeChannel.ts
@@ -428,7 +428,7 @@ export default class RealtimeChannel {
         event: 'track',
         payload,
       },
-      opts.timeout || this.timeout
+      opts
     )
   }
 

--- a/packages/core/realtime-js/test/RealtimeChannel.presence.test.ts
+++ b/packages/core/realtime-js/test/RealtimeChannel.presence.test.ts
@@ -320,6 +320,22 @@ describe('Presence helper methods', () => {
 
     expect(resp).toBe('ok')
   })
+
+  test('track() forwards a custom timeout option to the underlying push', async () => {
+    channel.subscribe()
+    await waitForChannelSubscribed(channel)
+
+    // @ts-ignore - channelAdapter is internal; spy on the push call to assert the timeout
+    const pushSpy = vi.spyOn(channel.channelAdapter as any, 'push')
+
+    await channel.track({ id: 123 }, { timeout: 1234 })
+
+    expect(pushSpy).toHaveBeenCalledWith(
+      'presence',
+      expect.objectContaining({ type: 'presence', event: 'track' }),
+      1234
+    )
+  })
 })
 
 describe('Presence configuration override', () => {


### PR DESCRIPTION
## 🔍 Description

### What changed?

`RealtimeChannel.track()` passed `opts.timeout || this.timeout` (a **number**) as the second argument to `send()`. But `send(args, opts)` treats its second argument as an **options object** and reads `opts.timeout` internally. A number's `.timeout` is `undefined`, so the caller's `track(payload, { timeout })` was silently dropped and the channel's default timeout was always used.

This PR makes `track()` forward the whole `opts` object — matching its sibling `untrack(opts)`, which already does exactly this (`send` then applies `opts.timeout || this.timeout` internally).

```diff
       },
-      opts.timeout || this.timeout
+      opts
     )
```

### Why was this change needed?

Custom per-`track` timeouts were silently ignored — `channel.track(payload, { timeout })` had no effect.

## 🔄 Breaking changes

- [x] This PR contains no breaking changes

## 📋 Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/supabase/supabase-js/blob/master/CONTRIBUTING.md)
- [x] My PR title follows the [conventional commit format](https://www.conventionalcommits.org/)
- [x] I have run `pnpm nx format`
- [x] I have added tests for new functionality

## 📝 Additional notes

**Fail-before / pass-after** — added `track() forwards a custom timeout option to the underlying push` in `RealtimeChannel.presence.test.ts`, which spies on the underlying `channelAdapter.push` call:

- **Before fix:** ❌ `expected push to be called with timeout 1234, received 1000` (the channel default)
- **After fix:** ✅ passes; full `realtime-js` suite green (355 passed, 1 skipped)