### PR TITLE
fix(auth): accept uppercase UUIDs in validateUUID

### DIFF
--- a/packages/core/auth-js/src/lib/helpers.ts
+++ b/packages/core/auth-js/src/lib/helpers.ts
@@ -369,7 +369,7 @@ export function getAlgorithm(
   }
 }
 
-const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
 export function validateUUID(str: string) {
   if (!UUID_REGEX.test(str)) {

--- a/packages/core/auth-js/test/helpers.test.ts
+++ b/packages/core/auth-js/test/helpers.test.ts
@@ -313,6 +313,16 @@ describe('validateUUID', () => {
       shouldThrow: false,
     },
     {
+      name: 'should accept uppercase UUID (UUIDs are case-insensitive per RFC 9562/4122)',
+      input: '123E4567-E89B-12D3-A456-426614174000',
+      shouldThrow: false,
+    },
+    {
+      name: 'should accept mixed-case UUID',
+      input: '123e4567-E89B-12d3-A456-426614174000',
+      shouldThrow: false,
+    },
+    {
       name: 'should reject invalid UUID format',
       input: 'not-a-uuid',
       shouldThrow: true,


### PR DESCRIPTION
## 🔍 Description

### What changed?

`validateUUID()` checked its input against `UUID_REGEX`, which lacked the case-insensitive (`i`) flag:

```diff
-const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
```

As a result, any UUID containing uppercase hex (e.g. `123E4567-E89B-12D3-A456-426614174000`) was rejected **client-side** with `Expected parameter to be UUID but is not`, before the request was ever sent — even though the value is a perfectly valid UUID and the GoTrue server accepts it.

This affects the public admin methods that validate a UUID argument: `getUserById`, `updateUserById`, `deleteUser`, `_listFactors`, `_deleteFactor`, `_adminListPasskeys`, `_adminDeletePasskey`.

### Why was this change needed?

UUIDs are case-insensitive on input. Per **RFC 9562 §4** (and RFC 4122 §3): *"The hexadecimal values 'a' through 'f' … are case insensitive on input."* The GoTrue server (Go `uuid` parser) accepts uppercase UUIDs, so rejecting them in the client is incorrect and blocks valid calls.

## 🔄 Breaking changes

- [x] This PR contains no breaking changes

## 📋 Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/supabase/supabase-js/blob/master/CONTRIBUTING.md)
- [x] My PR title follows the [conventional commit format](https://www.conventionalcommits.org/)
- [x] I have run `pnpm nx format`
- [x] I have added tests for new functionality

## 📝 Additional notes

**Fail-before / pass-after** — added uppercase and mixed-case cases to the `validateUUID` test in `helpers.test.ts`:

- **Before fix:** ❌ `should accept uppercase UUID` and `should accept mixed-case UUID` both throw `@supabase/auth-js: Expected parameter to be UUID but is not`
- **After fix:** ✅ all 26 `helpers.test.ts` tests pass