### PR TITLE
fix(storage): avoid double-encoding download filename in signed URLs

### DIFF
--- a/packages/core/storage-js/src/packages/StorageFileApi.ts
+++ b/packages/core/storage-js/src/packages/StorageFileApi.ts
@@ -727,10 +727,11 @@ export default class StorageFileApi extends BaseApiClient<StorageError> {
       const queryString = query.toString()
 
       // `data.signedURL` contains a `token` query parameter, so append extra params with `&`
-      // only when we actually have something to add.
-      const signedUrl = encodeURI(
-        `${this.url}${data.signedURL}${queryString ? `&${queryString}` : ''}`
-      )
+      // only when we actually have something to add. encodeURI only the path/token portion —
+      // `queryString` is already percent-encoded by URLSearchParams, so re-encoding it would
+      // double-encode the `download` filename.
+      const base = encodeURI(`${this.url}${data.signedURL}`)
+      const signedUrl = queryString ? `${base}&${queryString}` : base
 
       return { signedUrl }
     })
@@ -815,7 +816,7 @@ export default class StorageFileApi extends BaseApiClient<StorageError> {
       return data.map((datum: { signedURL: string }) => ({
         ...datum,
         signedUrl: datum.signedURL
-          ? encodeURI(`${this.url}${datum.signedURL}${queryString ? `&${queryString}` : ''}`)
+          ? encodeURI(`${this.url}${datum.signedURL}`) + (queryString ? `&${queryString}` : '')
           : null,
       }))
     })

--- a/packages/core/storage-js/test/signed-url-download-encoding.test.ts
+++ b/packages/core/storage-js/test/signed-url-download-encoding.test.ts
@@ -1,0 +1,57 @@
+import { StorageClient } from '../src/index'
+
+// Unit test (custom fetch capture) — proves createSignedUrl / createSignedUrls do not double-encode
+// the `download` query value. `URLSearchParams` already percent-encodes (`&` -> `%26`); wrapping the
+// whole URL *including* that query in `encodeURI()` re-encodes every `%` (`%26` -> `%2526`), which the
+// server then decodes once into the wrong literal filename (`a%26b.png` instead of `a&b.png`).
+// The sibling `getPublicUrl` encodeURI()s only the path and appends the query raw — the correct shape.
+describe('StorageFileApi signed-url download encoding', () => {
+  const URL = 'http://localhost/storage/v1'
+
+  const makeClient = () => {
+    const fetch = (async (_url: string, opts: { body?: string }) => {
+      const body = opts?.body ? JSON.parse(opts.body) : {}
+      if (Array.isArray(body.paths)) {
+        // createSignedUrls (plural)
+        return new Response(
+          JSON.stringify(
+            body.paths.map((p: string) => ({
+              signedURL: `/object/sign/bucket/${p}?token=tok`,
+              error: null,
+              path: p,
+            }))
+          ),
+          { status: 200, headers: { 'content-type': 'application/json' } }
+        )
+      }
+      // createSignedUrl (singular)
+      return new Response(JSON.stringify({ signedURL: '/object/sign/bucket/p.png?token=tok' }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    }) as unknown as typeof globalThis.fetch
+    return new StorageClient(URL, {}, fetch)
+  }
+
+  test('createSignedUrl single-encodes the download filename (no double encoding)', async () => {
+    const { data } = await makeClient()
+      .from('bucket')
+      .createSignedUrl('p.png', 60, { download: 'a&b.png' })
+    expect(data!.signedUrl).toContain('download=a%26b.png')
+    expect(data!.signedUrl).not.toContain('a%2526b.png')
+  })
+
+  test('createSignedUrls single-encodes the download filename (no double encoding)', async () => {
+    const { data } = await makeClient()
+      .from('bucket')
+      .createSignedUrls(['p.png'], 60, { download: 'a&b.png' })
+    expect(data![0].signedUrl).toContain('download=a%26b.png')
+    expect(data![0].signedUrl).not.toContain('a%2526b.png')
+  })
+
+  test('getPublicUrl (sibling) already single-encodes the same filename', () => {
+    const { data } = makeClient().from('bucket').getPublicUrl('p.png', { download: 'a&b.png' })
+    expect(data.publicUrl).toContain('download=a%26b.png')
+    expect(data.publicUrl).not.toContain('a%2526b.png')
+  })
+})


### PR DESCRIPTION
## 🔍 Description

### What changed?

`createSignedUrl` and `createSignedUrls` build the `download` / `cacheNonce` query with `URLSearchParams` (which already percent-encodes), then wrapped the **entire** URL — including that query — in `encodeURI(...)`. `encodeURI` does not skip an existing `%`, so every `%XX` produced by `URLSearchParams` was re-encoded to `%25XX`, double-encoding the `download` filename.

This PR `encodeURI`s only the path/token portion and appends the already-encoded query string raw — matching the correct sibling methods `getPublicUrl` and `download`.

```diff
- const signedUrl = encodeURI(
-   `${this.url}${data.signedURL}${queryString ? `&${queryString}` : ''}`
- )
+ const base = encodeURI(`${this.url}${data.signedURL}`)
+ const signedUrl = queryString ? `${base}&${queryString}` : base
```

(and the analogous change in `createSignedUrls`).

### Why was this change needed?

The double-encoding corrupts any `download` filename containing characters that `URLSearchParams` percent-encodes — `&`, non-ASCII, `+`, `#`, `,`, etc.

| `download` value | query before (buggy) | server decodes to | query after (fixed) | server decodes to |
| --- | --- | --- | --- | --- |
| `a&b.png` | `download=a%2526b.png` | `a%26b.png` ❌ | `download=a%26b.png` | `a&b.png` ✅ |

The storage server route `src/http/routes/object/getSignedObject.ts` URL-decodes the `download` query value once (Fastify) and uses it verbatim as the `Content-Disposition` filename, so the client must send exactly one encoding layer — which `URLSearchParams` already provides. The sibling `getPublicUrl` (and `download`) already do this correctly; `createSignedUrl`/`createSignedUrls` were the inconsistent ones.

## 🔄 Breaking changes

- [x] This PR contains no breaking changes

## 📋 Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/supabase/supabase-js/blob/master/CONTRIBUTING.md)
- [x] My PR title follows the [conventional commit format](https://www.conventionalcommits.org/)
- [x] I have run `pnpm nx format`
- [x] I have added tests for new functionality

## 📝 Additional notes

**Fail-before / pass-after** — added `signed-url-download-encoding.test.ts` (Docker-free, custom-fetch capture) covering both signed-url methods, plus a contrast assertion that `getPublicUrl` already single-encodes the same filename:

- **Before fix:** ❌ `Expected substring "download=a%26b.png", Received "...&download=a%2526b.png"` (both `createSignedUrl` and `createSignedUrls`)
- **After fix:** ✅ all 3 pass; existing Docker-free storage unit suites stay green (66 passed)