### PR TITLE
fix(functions): pass ReadableStream body through without JSON serialization

### DIFF
--- a/packages/core/functions-js/src/FunctionsClient.ts
+++ b/packages/core/functions-js/src/FunctionsClient.ts
@@ -244,6 +244,13 @@ export class FunctionsClient {
           // don't set content-type headers
           // Request will automatically add the right boundary value
           body = functionArgs
+        } else if (
+          typeof ReadableStream !== 'undefined' &&
+          functionArgs instanceof ReadableStream
+        ) {
+          // a stream is a valid fetch body; forward it untouched and let the caller set the
+          // Content-Type (don't serialize it to JSON, which would drop the payload)
+          body = functionArgs
         } else {
           // default, assume this is JSON
           _headers['Content-Type'] = 'application/json'
@@ -255,7 +262,8 @@ export class FunctionsClient {
           typeof functionArgs !== 'string' &&
           !(typeof Blob !== 'undefined' && functionArgs instanceof Blob) &&
           !(functionArgs instanceof ArrayBuffer) &&
-          !(typeof FormData !== 'undefined' && functionArgs instanceof FormData)
+          !(typeof FormData !== 'undefined' && functionArgs instanceof FormData) &&
+          !(typeof ReadableStream !== 'undefined' && functionArgs instanceof ReadableStream)
         ) {
           body = JSON.stringify(functionArgs)
         } else {
@@ -289,6 +297,10 @@ export class FunctionsClient {
         // 3. default Content-Type header
         headers: { ..._headers, ...this.headers, ...headers },
         body,
+        // a web ReadableStream body requires the half-duplex flag for native (undici) fetch
+        ...(typeof ReadableStream !== 'undefined' && body instanceof ReadableStream
+          ? { duplex: 'half' }
+          : {}),
         signal: effectiveSignal,
       }).catch((fetchError) => {
         throw new FunctionsFetchError(fetchError)

--- a/packages/core/functions-js/src/FunctionsClient.ts
+++ b/packages/core/functions-js/src/FunctionsClient.ts
@@ -223,6 +223,9 @@ export class FunctionsClient {
         url.searchParams.set('forceFunctionRegion', region)
       }
       let body: any
+      // a web ReadableStream body requires the half-duplex flag for native (undici) fetch;
+      // set alongside body wherever a stream is detected, then forwarded to fetch below
+      let duplex: 'half' | undefined
       // HTTP header names are case-insensitive, so detect a caller-supplied Content-Type
       // regardless of casing — otherwise the SDK injects a second, conflicting Content-Type.
       const hasContentTypeHeader =
@@ -251,19 +254,22 @@ export class FunctionsClient {
           // a stream is a valid fetch body; forward it untouched and let the caller set the
           // Content-Type (don't serialize it to JSON, which would drop the payload)
           body = functionArgs
+          duplex = 'half'
         } else {
           // default, assume this is JSON
           _headers['Content-Type'] = 'application/json'
           body = JSON.stringify(functionArgs)
         }
       } else {
-        if (
+        if (typeof ReadableStream !== 'undefined' && functionArgs instanceof ReadableStream) {
+          body = functionArgs
+          duplex = 'half'
+        } else if (
           functionArgs &&
           typeof functionArgs !== 'string' &&
           !(typeof Blob !== 'undefined' && functionArgs instanceof Blob) &&
           !(functionArgs instanceof ArrayBuffer) &&
-          !(typeof FormData !== 'undefined' && functionArgs instanceof FormData) &&
-          !(typeof ReadableStream !== 'undefined' && functionArgs instanceof ReadableStream)
+          !(typeof FormData !== 'undefined' && functionArgs instanceof FormData)
         ) {
           body = JSON.stringify(functionArgs)
         } else {
@@ -297,10 +303,7 @@ export class FunctionsClient {
         // 3. default Content-Type header
         headers: { ..._headers, ...this.headers, ...headers },
         body,
-        // a web ReadableStream body requires the half-duplex flag for native (undici) fetch
-        ...(typeof ReadableStream !== 'undefined' && body instanceof ReadableStream
-          ? { duplex: 'half' }
-          : {}),
+        ...(duplex ? { duplex } : {}),
         signal: effectiveSignal,
       }).catch((fetchError) => {
         throw new FunctionsFetchError(fetchError)

--- a/packages/core/functions-js/test/spec/readablestream-body.spec.ts
+++ b/packages/core/functions-js/test/spec/readablestream-body.spec.ts
@@ -1,0 +1,46 @@
+import 'jest'
+import { FunctionsClient } from '../../src/index'
+
+// Unit test (custom fetch capture) — `FunctionInvokeOptions.body` documents `ReadableStream<Uint8Array>`
+// as a supported type, but a ReadableStream matched none of the body-inference branches and fell through
+// to `JSON.stringify(functionArgs)`, which produces `"{}"` — silently dropping the stream payload.
+describe('FunctionsClient ReadableStream body', () => {
+  const makeClient = () => {
+    let captured: any = {}
+    const customFetch = (async (_url: string, opts: any) => {
+      captured = opts
+      return new Response('ok', { status: 200, headers: { 'Content-Type': 'text/plain' } })
+    }) as any
+    const client = new FunctionsClient('http://localhost', { customFetch })
+    return { client, captured: () => captured }
+  }
+
+  const makeStream = () =>
+    new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('streamed-bytes'))
+        controller.close()
+      },
+    })
+
+  test('forwards a ReadableStream body to fetch untouched (no caller Content-Type)', async () => {
+    const { client, captured } = makeClient()
+    const stream = makeStream()
+    await client.invoke('fn', { body: stream })
+    expect(captured().body).toBe(stream)
+    const contentType = new Headers(captured().headers).get('content-type')
+    expect(contentType).not.toBe('application/json')
+    // a streaming body needs the half-duplex flag, otherwise native fetch throws
+    expect(captured().duplex).toBe('half')
+  })
+
+  test('forwards a ReadableStream body when the caller sets a Content-Type', async () => {
+    const { client, captured } = makeClient()
+    const stream = makeStream()
+    await client.invoke('fn', {
+      body: stream,
+      headers: { 'Content-Type': 'application/octet-stream' },
+    })
+    expect(captured().body).toBe(stream)
+  })
+})


### PR DESCRIPTION
## 🔍 Description

### What changed?

`FunctionInvokeOptions.body` documents `ReadableStream<Uint8Array>` as a supported type, but the body-inference logic in `invoke()` had no branch for it. A `ReadableStream` matched none of the `Blob`/`ArrayBuffer`/`string`/`FormData` cases and fell through to `JSON.stringify(functionArgs)` — which produces `"{}"`, silently dropping the entire stream payload and mislabeling it `application/json`. This happened in **both** body-inference paths (with and without a caller-supplied `Content-Type`).

This PR:
1. Adds a `ReadableStream` branch in both paths that forwards the stream untouched (no forced `application/json`).
2. Sets `duplex: 'half'` on the fetch call when the body is a `ReadableStream`, which native (undici) fetch requires for a streaming request body — mirroring the existing storage-js behavior added in #2287.

### Why was this change needed?

A documented, supported body type was silently corrupted into `"{}"`. Per the WHATWG Fetch standard, `ReadableStream` is a valid `BodyInit`, and the library's own `types.ts` lists it as supported — so serializing it as JSON is a contract violation.

## 🔄 Breaking changes

- [x] This PR contains no breaking changes

## 📋 Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/supabase/supabase-js/blob/master/CONTRIBUTING.md)
- [x] My PR title follows the [conventional commit format](https://www.conventionalcommits.org/)
- [x] I have run `pnpm nx format`
- [x] I have added tests for new functionality

## 📝 Additional notes

**Fail-before / pass-after** — added `test/spec/readablestream-body.spec.ts` (Docker-free, custom-fetch capture) covering a stream body both with and without a caller `Content-Type`, asserting the stream is forwarded unchanged and `duplex: 'half'` is set:

- **Before fix (on `master`):** ❌ both cases — `expect(received).toBe(stream)` → `Received: "{}"`
- **After fix:** ✅ both pass (stream forwarded, `duplex: 'half'` set)