### PR TITLE
feat(auth): add custom_claims_allowlist to custom providers admin API

### DIFF
--- a/packages/core/auth-js/src/lib/types.ts
+++ b/packages/core/auth-js/src/lib/types.ts
@@ -2250,6 +2250,14 @@ export type CustomOAuthProvider = {
   acceptable_client_ids?: string[]
   /** OAuth scopes requested during authorization */
   scopes?: string[]
+  /**
+   * Allowlist of raw identity provider claim keys to copy verbatim into the
+   * user's `custom_claims` field (within `identity_data` and
+   * `raw_user_meta_data`), e.g. `["groups", "org_id", "mail"]`. This is an
+   * opt-in allowlist that defaults to empty (no claims captured) and operates
+   * independently from `attribute_mapping`.
+   */
+  custom_claims_allowlist?: string[]
   /** Whether PKCE is enabled */
   pkce_enabled?: boolean
   /** Mapping of provider attributes to Supabase user attributes */
@@ -2300,6 +2308,14 @@ export type CreateCustomProviderParams = {
   acceptable_client_ids?: string[]
   /** OAuth scopes requested during authorization */
   scopes?: string[]
+  /**
+   * Allowlist of raw identity provider claim keys to copy verbatim into the
+   * user's `custom_claims` field (within `identity_data` and
+   * `raw_user_meta_data`), e.g. `["groups", "org_id", "mail"]`. This is an
+   * opt-in allowlist that defaults to empty (no claims captured) and operates
+   * independently from `attribute_mapping`.
+   */
+  custom_claims_allowlist?: string[]
   /** Whether PKCE is enabled */
   pkce_enabled?: boolean
   /** Mapping of provider attributes to Supabase user attributes */
@@ -2342,6 +2358,14 @@ export type UpdateCustomProviderParams = {
   acceptable_client_ids?: string[]
   /** OAuth scopes requested during authorization */
   scopes?: string[]
+  /**
+   * Allowlist of raw identity provider claim keys to copy verbatim into the
+   * user's `custom_claims` field (within `identity_data` and
+   * `raw_user_meta_data`), e.g. `["groups", "org_id", "mail"]`. This is an
+   * opt-in allowlist that defaults to empty (no claims captured) and operates
+   * independently from `attribute_mapping`.
+   */
+  custom_claims_allowlist?: string[]
   /** Whether PKCE is enabled */
   pkce_enabled?: boolean
   /** Mapping of provider attributes to Supabase user attributes */


### PR DESCRIPTION
## Description

Adds the new `custom_claims_allowlist` parameter to the auth-js admin **custom providers** API, mirroring the auth server change in [supabase/auth#2576](https://github.com/supabase/auth/pull/2576).

The allowlist is a flat list of raw identity provider claim keys (e.g. `["groups", "org_id", "mail", "sn"]`) that get copied verbatim into a user's `custom_claims` field (within `identity_data` and `raw_user_meta_data`). It is opt-in (defaults to empty — nothing captured) and operates independently from `attribute_mapping`.

Since `GoTrueAdminApi` passes the params object straight through as the request body for create/update, the change is purely additive to the type definitions:

- `CustomOAuthProvider` — new optional `custom_claims_allowlist?: string[]` returned in responses
- `CreateCustomProviderParams` — accept it on `customProviders.createProvider(...)`
- `UpdateCustomProviderParams` — accept it on `customProviders.updateProvider(...)`

Each field includes JSDoc describing the allowlist behavior.

## Type of Change

- [x] New feature (feat)

## Testing

- [x] `nx build auth-js` passes (type-check clean)
- No dedicated test suite exists for the custom providers admin API yet; this is an additive, type-only change passed through to the existing request body.

## Checklist

- [x] Code formatted (`nx format`)
- [x] Builds passing (`nx build auth-js`)
- [x] Used conventional commits
- [x] Documentation updated (JSDoc on all three types)

🤖 Generated with [Claude Code](https://claude.com/claude-code)