### PR TITLE
fix(storage): resolve createSignedUrls return type mismatch

### DIFF
--- a/packages/core/storage-js/src/packages/StorageFileApi.ts
+++ b/packages/core/storage-js/src/packages/StorageFileApi.ts
@@ -788,7 +788,12 @@ export default class StorageFileApi extends BaseApiClient<StorageError> {
     options?: { download?: string | boolean; cacheNonce?: string }
   ): Promise<
     | {
-        data: { error: string | null; path: string | null; signedUrl: string | null }[]
+        data: {
+          error: string | null
+          path: string | null
+          signedURL: string | null
+          signedUrl: string | null
+        }[]
         error: null
       }
     | {
@@ -812,12 +817,14 @@ export default class StorageFileApi extends BaseApiClient<StorageError> {
 
       const queryString = query.toString()
 
-      return data.map((datum: { signedURL: string }) => ({
-        ...datum,
-        signedUrl: datum.signedURL
-          ? encodeURI(`${this.url}${datum.signedURL}${queryString ? `&${queryString}` : ''}`)
-          : null,
-      }))
+      return data.map(
+        (datum: { error: string | null; path: string | null; signedURL: string | null }) => ({
+          ...datum,
+          signedUrl: datum.signedURL
+            ? encodeURI(`${this.url}${datum.signedURL}${queryString ? `&${queryString}` : ''}`)
+            : null,
+        })
+      )
     })
   }
 


### PR DESCRIPTION
This PR fixes a type signature mismatch in `createSignedUrls` (reported in supabase/storage-js#169). The API response actually contains both `signedURL` (raw path) and `signedUrl` (fully qualified URL), but only `signedUrl` was defined in the TypeScript type signature. This PR updates the signature to correctly expose both fields to TypeScript consumers.