### PR TITLE
fix(supabase): set realtime auth token on INITIAL_SESSION event

### DIFF
--- a/packages/core/supabase-js/src/SupabaseClient.ts
+++ b/packages/core/supabase-js/src/SupabaseClient.ts
@@ -645,7 +645,7 @@ export default class SupabaseClient<
     token?: string
   ) {
     if (
-      (event === 'TOKEN_REFRESHED' || event === 'SIGNED_IN') &&
+      (event === 'TOKEN_REFRESHED' || event === 'SIGNED_IN' || event === 'INITIAL_SESSION') &&
       this.changedAccessToken !== token
     ) {
       this.changedAccessToken = token

--- a/packages/core/supabase-js/test/unit/SupabaseClient.test.ts
+++ b/packages/core/supabase-js/test/unit/SupabaseClient.test.ts
@@ -351,6 +351,12 @@ describe('SupabaseClient', () => {
         setAuthSpy.mockClear()
 
         // @ts-ignore - accessing private method for testing
+        client._handleTokenChanged('INITIAL_SESSION', 'CLIENT', 'initial-token')
+        expect(setAuthSpy).toHaveBeenCalledWith('initial-token')
+
+        setAuthSpy.mockClear()
+
+        // @ts-ignore - accessing private method for testing
         client._handleTokenChanged('SIGNED_IN', 'CLIENT', 'signin-token')
         expect(setAuthSpy).toHaveBeenCalledWith('signin-token')
 


### PR DESCRIPTION
This PR fixes a bug (Issue #1730) where the Realtime client fails to set the auth token on initial session load / storage recovery. Currently, the Supabase client handles `TOKEN_REFRESHED` and `SIGNED_IN` events in `_handleTokenChanged`, but completely misses the `INITIAL_SESSION` event which is fired when the session is loaded from storage upon client initialization. This causes Realtime channels with RLS/JWT claims to silently fail. This PR adds `INITIAL_SESSION` to the list of handled events.