### PR TITLE
fix(supabase): relax db schema type constraints in createClient options

### DIFF
--- a/packages/core/supabase-js/src/SupabaseClient.ts
+++ b/packages/core/supabase-js/src/SupabaseClient.ts
@@ -394,7 +394,7 @@ export default class SupabaseClient<
 
     this.rest = new PostgrestClient(new URL('rest/v1', baseUrl).href, {
       headers: this.headers,
-      schema: settings.db.schema,
+      schema: settings.db.schema as any,
       fetch: this.fetch,
       timeout: settings.db.timeout,
       urlLengthLimit: settings.db.urlLengthLimit,

--- a/packages/core/supabase-js/src/lib/types.ts
+++ b/packages/core/supabase-js/src/lib/types.ts
@@ -98,7 +98,7 @@ export type SupabaseClientOptions<SchemaName> = {
    * The Postgres schema which your tables belong to. Must be on the list of exposed schemas in Supabase. Defaults to `public`.
    */
   db?: {
-    schema?: SchemaName
+    schema?: string
     /**
      * Optional timeout in milliseconds for PostgREST requests.
      * When set, requests will automatically abort after this duration to prevent indefinite hangs.

--- a/packages/core/supabase-js/src/lib/types.ts
+++ b/packages/core/supabase-js/src/lib/types.ts
@@ -98,7 +98,7 @@ export type SupabaseClientOptions<SchemaName> = {
    * The Postgres schema which your tables belong to. Must be on the list of exposed schemas in Supabase. Defaults to `public`.
    */
   db?: {
-    schema?: string
+    schema?: SchemaName | (string & {})
     /**
      * Optional timeout in milliseconds for PostgREST requests.
      * When set, requests will automatically abort after this duration to prevent indefinite hangs.

--- a/packages/core/supabase-js/test/unit/SupabaseClient.test.ts
+++ b/packages/core/supabase-js/test/unit/SupabaseClient.test.ts
@@ -231,6 +231,15 @@ describe('SupabaseClient', () => {
       expect(schemaClient).toBeDefined()
       expect(schemaClient).toBeInstanceOf(PostgrestClient)
     })
+
+    test('should initialize client with a custom schema option', () => {
+      const client = createClient<Database>(URL, KEY, {
+        db: {
+          schema: 'personal',
+        },
+      })
+      expect(client).toBeDefined()
+    })
   })
 
   describe('Table/View Queries', () => {


### PR DESCRIPTION
This PR fixes a bug (Issue #969) where TypeScript displays a type error when attempting to initialize a client with a custom database schema under `db.schema`, unless the user explicitly passes the schema as the second generic parameter to `createClient`. Because of the lack of partial generic inference in TypeScript, when only the first generic parameter `<Database>` is supplied, the second generic parameter (`SchemaName`) defaults to `'public'`, restricting the type of the `db.schema` option to `'public'`. This PR relaxes the `schema` option type under `db` to `string` so that initialization compiles successfully, while preserving type-safety of database/schema queries.