### PR TITLE
fix(postgrest): fall back to RFC 9110 reason phrase when statusText is empty

### DIFF
--- a/packages/core/postgrest-js/src/PostgrestBuilder.ts
+++ b/packages/core/postgrest-js/src/PostgrestBuilder.ts
@@ -16,6 +16,58 @@ import {
 import PostgrestError from './PostgrestError'
 import { ContainsNull } from './select-query-parser/types'
 
+// HTTP/2 omits reason phrases from responses (RFC 7540 §8.1.2.4).
+// This map provides fallback text so callers always receive a non-empty statusText.
+const HTTP_STATUS_TEXTS: Record<number, string> = {
+  100: 'Continue',
+  101: 'Switching Protocols',
+  200: 'OK',
+  201: 'Created',
+  202: 'Accepted',
+  203: 'Non-Authoritative Information',
+  204: 'No Content',
+  205: 'Reset Content',
+  206: 'Partial Content',
+  300: 'Multiple Choices',
+  301: 'Moved Permanently',
+  302: 'Found',
+  303: 'See Other',
+  304: 'Not Modified',
+  307: 'Temporary Redirect',
+  308: 'Permanent Redirect',
+  400: 'Bad Request',
+  401: 'Unauthorized',
+  402: 'Payment Required',
+  403: 'Forbidden',
+  404: 'Not Found',
+  405: 'Method Not Allowed',
+  406: 'Not Acceptable',
+  407: 'Proxy Authentication Required',
+  408: 'Request Timeout',
+  409: 'Conflict',
+  410: 'Gone',
+  411: 'Length Required',
+  412: 'Precondition Failed',
+  413: 'Content Too Large',
+  414: 'URI Too Long',
+  415: 'Unsupported Media Type',
+  416: 'Range Not Satisfiable',
+  417: 'Expectation Failed',
+  422: 'Unprocessable Content',
+  425: 'Too Early',
+  426: 'Upgrade Required',
+  428: 'Precondition Required',
+  429: 'Too Many Requests',
+  431: 'Request Header Fields Too Large',
+  451: 'Unavailable For Legal Reasons',
+  500: 'Internal Server Error',
+  501: 'Not Implemented',
+  502: 'Bad Gateway',
+  503: 'Service Unavailable',
+  504: 'Gateway Timeout',
+  505: 'HTTP Version Not Supported',
+}
+
 /**
  * Sleep for a given number of milliseconds.
  * If an AbortSignal is provided, the sleep resolves early when the signal is aborted.
@@ -480,7 +532,7 @@ export default abstract class PostgrestBuilder<
     let data = null
     let count: number | null = null
     let status = res.status
-    let statusText = res.statusText
+    let statusText = res.statusText || HTTP_STATUS_TEXTS[res.status] || ''
 
     if (res.ok) {
       if (this.method !== 'HEAD') {

--- a/packages/core/postgrest-js/test/basic.test.ts
+++ b/packages/core/postgrest-js/test/basic.test.ts
@@ -2273,3 +2273,98 @@ test('should not share state between operations on same query builder', async ()
   expect((q1 as any).url.toString()).toContain('status=eq.ONLINE')
   expect((q2 as any).url.toString()).toContain('status=eq.OFFLINE')
 })
+
+// HTTP/2 strips reason phrases (RFC 7540 §8.1.2.4), leaving statusText as "".
+// The following tests verify that the client falls back to the RFC 9110 reason phrase.
+
+test('falls back to reason phrase when HTTP/2 returns empty statusText for 201', async () => {
+  const customFetch = jest.fn().mockImplementation(() =>
+    Promise.resolve({
+      ok: true,
+      status: 201,
+      statusText: '',
+      headers: { get: () => null },
+      text: () => Promise.resolve(JSON.stringify([{ id: 1 }])),
+    })
+  )
+
+  const postgrestWithCustomFetch = new PostgrestClient<Database>(REST_URL, {
+    fetch: customFetch,
+  })
+
+  const res = await postgrestWithCustomFetch.from('users').insert({ username: 'test' }).select()
+
+  expect(res.status).toBe(201)
+  expect(res.statusText).toBe('Created')
+})
+
+test('falls back to reason phrase when HTTP/2 returns empty statusText for 206', async () => {
+  const customFetch = jest.fn().mockImplementation(() =>
+    Promise.resolve({
+      ok: true,
+      status: 206,
+      statusText: '',
+      headers: { get: () => null },
+      text: () => Promise.resolve(JSON.stringify([{ id: 1 }])),
+    })
+  )
+
+  const postgrestWithCustomFetch = new PostgrestClient<Database>(REST_URL, {
+    fetch: customFetch,
+  })
+
+  const res = await postgrestWithCustomFetch.from('users').select()
+
+  expect(res.status).toBe(206)
+  expect(res.statusText).toBe('Partial Content')
+})
+
+test('falls back to reason phrase when HTTP/2 returns empty statusText for 400', async () => {
+  const customFetch = jest.fn().mockImplementation(() =>
+    Promise.resolve({
+      ok: false,
+      status: 400,
+      statusText: '',
+      headers: { get: () => null },
+      text: () =>
+        Promise.resolve(
+          JSON.stringify({
+            code: '42703',
+            details: null,
+            hint: null,
+            message: 'column "nonexistent" does not exist',
+          })
+        ),
+    })
+  )
+
+  const postgrestWithCustomFetch = new PostgrestClient<Database>(REST_URL, {
+    fetch: customFetch,
+  })
+
+  const res = await postgrestWithCustomFetch.from('users').select('nonexistent')
+
+  expect(res.status).toBe(400)
+  expect(res.statusText).toBe('Bad Request')
+})
+
+test('preserves non-empty statusText when provided by the server', async () => {
+  const customFetch = jest.fn().mockImplementation(() =>
+    Promise.resolve({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      headers: { get: () => null },
+      text: () => Promise.resolve('[]'),
+    })
+  )
+
+  const postgrestWithCustomFetch = new PostgrestClient<Database>(REST_URL, {
+    fetch: customFetch,
+  })
+
+  const res = await postgrestWithCustomFetch.from('users').select()
+
+  expect(res.status).toBe(200)
+  expect(res.statusText).toBe('OK')
+})


### PR DESCRIPTION
## 🔍 Description

### What changed?

`PostgrestBuilder` builds its `PostgrestResponse.statusText` directly from `res.statusText`. Over HTTP/2 the
response has no reason phrase at all (HTTP/2 removed the status line — see RFC 7540 §8.1.2.4 / RFC 9113), so
`fetch` exposes an **empty** `statusText`. The same happens with some runtimes/proxies even on HTTP/1.1. As a
result, error objects returned from postgrest-js carry an empty `statusText`, which makes errors harder to read
and breaks code that switches on the reason phrase.

This PR adds a fallback: when `res.statusText` is empty, it derives the canonical RFC 9110 reason phrase from the
numeric status code. The server-provided value is always preferred when present, so HTTP/1.1 behavior is unchanged.

```ts
// before
let statusText = res.statusText
// after
let statusText = res.statusText || HTTP_STATUS_TEXTS[res.status] || ''
```

`HTTP_STATUS_TEXTS` is a small module-level map of the standard status codes to their RFC 9110 reason phrases.

### Why was this change needed?

Under HTTP/2, `error.statusText` (and the `statusText` on a successful `PostgrestResponse`) comes back as `""`,
which is confusing when inspecting/logging errors and breaks any consumer that relies on the reason phrase. The
status code is still available, so we can reconstruct the standard phrase deterministically.

Closes supabase/postgrest-js#405

## 📸 Screenshots/Examples

```ts
// HTTP/2 response, status 400, no reason phrase from the server
// before: error.statusText === ""
// after:  error.statusText === "Bad Request"
```

## 🔄 Breaking changes

- [x] This PR contains no breaking changes

The server-provided `statusText` is always used when present, so HTTP/1.1 responses are unaffected. The fallback
only fills in a value where there previously was an empty string.

## 📋 Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/supabase/supabase-js/blob/master/CONTRIBUTING.md)
- [x] My PR title follows the [conventional commit format](https://www.conventionalcommits.org/): `<type>(<scope>): <description>`
- [x] I have run `pnpm nx format` to ensure consistent code formatting
- [x] I have added tests for new functionality (if applicable)
- [ ] I have updated documentation (if applicable) — n/a

## 📝 Additional notes

Added 4 unit tests in `packages/core/postgrest-js/test/basic.test.ts` covering: `201 → "Created"`,
`206 → "Partial Content"`, `400 → "Bad Request"`, and that a server-provided phrase is never overwritten.
These run as plain unit tests (fetch is mocked with `statusText: ''`) and do not require the Docker
integration stack. Verified locally: the new tests fail against the current code (`Received: ""`) and pass
with the fix.
