### PR TITLE
fix(postgrest): quote array elements with reserved chars in contains/containedBy/overlaps

### DIFF
--- a/packages/core/postgrest-js/src/PostgrestFilterBuilder.ts
+++ b/packages/core/postgrest-js/src/PostgrestFilterBuilder.ts
@@ -1016,7 +1016,7 @@ export default class PostgrestFilterBuilder<
       this.url.searchParams.append(column, `cs.${value}`)
     } else if (Array.isArray(value)) {
       // array
-      this.url.searchParams.append(column, `cs.{${value.join(',')}}`)
+      this.url.searchParams.append(column, `cs.{${value.map(toPostgrestArrayLiteral).join(',')}}`)
     } else {
       // json
       this.url.searchParams.append(column, `cs.${JSON.stringify(value)}`)
@@ -1165,7 +1165,7 @@ export default class PostgrestFilterBuilder<
       this.url.searchParams.append(column, `cd.${value}`)
     } else if (Array.isArray(value)) {
       // array
-      this.url.searchParams.append(column, `cd.{${value.join(',')}}`)
+      this.url.searchParams.append(column, `cd.{${value.map(toPostgrestArrayLiteral).join(',')}}`)
     } else {
       // json
       this.url.searchParams.append(column, `cd.${JSON.stringify(value)}`)
@@ -1592,7 +1592,7 @@ export default class PostgrestFilterBuilder<
       this.url.searchParams.append(column, `ov.${value}`)
     } else {
       // array
-      this.url.searchParams.append(column, `ov.{${value.join(',')}}`)
+      this.url.searchParams.append(column, `ov.{${value.map(toPostgrestArrayLiteral).join(',')}}`)
     }
     return this
   }
@@ -2187,4 +2187,20 @@ export default class PostgrestFilterBuilder<
     this.url.searchParams.append(column, `${operator}.${value}`)
     return this
   }
+}
+
+/**
+ * Serializes one element of a Postgres array literal. String elements that
+ * contain a reserved character (comma, brace, double quote or backslash) or
+ * that have surrounding whitespace must be double quoted so the server reads
+ * them as a single element. Other values are emitted as is.
+ */
+function toPostgrestArrayLiteral(element: unknown): string {
+  if (
+    typeof element === 'string' &&
+    (/[,{}"\\]/.test(element) || /^\s|\s$/.test(element))
+  ) {
+    return `"${element.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`
+  }
+  return `${element}`
 }

--- a/packages/core/postgrest-js/src/PostgrestFilterBuilder.ts
+++ b/packages/core/postgrest-js/src/PostgrestFilterBuilder.ts
@@ -548,7 +548,10 @@ export default class PostgrestFilterBuilder<
   ): this
   likeAllOf(column: string, patterns: readonly string[]): this
   likeAllOf(column: string, patterns: readonly string[]): this {
-    this.url.searchParams.append(column, `like(all).{${patterns.join(',')}}`)
+    this.url.searchParams.append(
+      column,
+      `like(all).{${patterns.map(toPostgrestArrayLiteral).join(',')}}`
+    )
     return this
   }
 
@@ -567,7 +570,10 @@ export default class PostgrestFilterBuilder<
   ): this
   likeAnyOf(column: string, patterns: readonly string[]): this
   likeAnyOf(column: string, patterns: readonly string[]): this {
-    this.url.searchParams.append(column, `like(any).{${patterns.join(',')}}`)
+    this.url.searchParams.append(
+      column,
+      `like(any).{${patterns.map(toPostgrestArrayLiteral).join(',')}}`
+    )
     return this
   }
 
@@ -637,7 +643,10 @@ export default class PostgrestFilterBuilder<
   ): this
   ilikeAllOf(column: string, patterns: readonly string[]): this
   ilikeAllOf(column: string, patterns: readonly string[]): this {
-    this.url.searchParams.append(column, `ilike(all).{${patterns.join(',')}}`)
+    this.url.searchParams.append(
+      column,
+      `ilike(all).{${patterns.map(toPostgrestArrayLiteral).join(',')}}`
+    )
     return this
   }
 
@@ -656,7 +665,10 @@ export default class PostgrestFilterBuilder<
   ): this
   ilikeAnyOf(column: string, patterns: readonly string[]): this
   ilikeAnyOf(column: string, patterns: readonly string[]): this {
-    this.url.searchParams.append(column, `ilike(any).{${patterns.join(',')}}`)
+    this.url.searchParams.append(
+      column,
+      `ilike(any).{${patterns.map(toPostgrestArrayLiteral).join(',')}}`
+    )
     return this
   }
 
@@ -2190,16 +2202,15 @@ export default class PostgrestFilterBuilder<
 }
 
 /**
- * Serializes one element of a Postgres array literal. String elements that
- * contain a reserved character (comma, brace, double quote or backslash) or
- * that have surrounding whitespace must be double quoted so the server reads
- * them as a single element. Other values are emitted as is.
+ * Serializes one element of a Postgres array literal, mirroring PostgREST's own
+ * `pgBuildArrayLiteral`: every string element is double quoted (with `\` and `"`
+ * escaped) so the server reads it as a single text element. Quoting every string
+ * also preserves an empty string and the literal word `null`, which Postgres
+ * reads back as SQL NULL when they are emitted unquoted. Non-string values are
+ * emitted as is.
  */
 function toPostgrestArrayLiteral(element: unknown): string {
-  if (
-    typeof element === 'string' &&
-    (/[,{}"\\]/.test(element) || /^\s|\s$/.test(element))
-  ) {
+  if (typeof element === 'string') {
     return `"${element.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`
   }
   return `${element}`

--- a/packages/core/postgrest-js/test/array-literal.test.ts
+++ b/packages/core/postgrest-js/test/array-literal.test.ts
@@ -1,0 +1,17 @@
+import { PostgrestClient } from '../src/index'
+
+const postgrest = new PostgrestClient('http://localhost:54321/rest/v1')
+
+test('quotes array elements with reserved characters in contains/containedBy/overlaps', () => {
+  const contains: any = postgrest.from('t').select().contains('tags', ['Doe, John', 'admin'])
+  expect(contains.url.searchParams.get('tags')).toBe('cs.{"Doe, John",admin}')
+
+  const containedBy: any = postgrest.from('t').select().containedBy('tags', ['a,b', 'c'])
+  expect(containedBy.url.searchParams.get('tags')).toBe('cd.{"a,b",c}')
+
+  const overlaps: any = postgrest.from('t').select().overlaps('tags', ['x"y', 'z'])
+  expect(overlaps.url.searchParams.get('tags')).toBe('ov.{"x\\"y",z}')
+
+  const numbers: any = postgrest.from('t').select().contains('nums', [1, 2, 3])
+  expect(numbers.url.searchParams.get('nums')).toBe('cs.{1,2,3}')
+})

--- a/packages/core/postgrest-js/test/array-literal.test.ts
+++ b/packages/core/postgrest-js/test/array-literal.test.ts
@@ -2,16 +2,35 @@ import { PostgrestClient } from '../src/index'
 
 const postgrest = new PostgrestClient('http://localhost:54321/rest/v1')
 
-test('quotes array elements with reserved characters in contains/containedBy/overlaps', () => {
+test('quotes every string element in contains/containedBy/overlaps', () => {
   const contains: any = postgrest.from('t').select().contains('tags', ['Doe, John', 'admin'])
-  expect(contains.url.searchParams.get('tags')).toBe('cs.{"Doe, John",admin}')
+  expect(contains.url.searchParams.get('tags')).toBe('cs.{"Doe, John","admin"}')
 
   const containedBy: any = postgrest.from('t').select().containedBy('tags', ['a,b', 'c'])
-  expect(containedBy.url.searchParams.get('tags')).toBe('cd.{"a,b",c}')
+  expect(containedBy.url.searchParams.get('tags')).toBe('cd.{"a,b","c"}')
 
   const overlaps: any = postgrest.from('t').select().overlaps('tags', ['x"y', 'z'])
-  expect(overlaps.url.searchParams.get('tags')).toBe('ov.{"x\\"y",z}')
+  expect(overlaps.url.searchParams.get('tags')).toBe('ov.{"x\\"y","z"}')
 
   const numbers: any = postgrest.from('t').select().contains('nums', [1, 2, 3])
   expect(numbers.url.searchParams.get('nums')).toBe('cs.{1,2,3}')
+})
+
+test('quotes an empty string and the literal word null so they are not read back as SQL NULL', () => {
+  const q: any = postgrest.from('t').select().contains('tags', ['', 'null'])
+  expect(q.url.searchParams.get('tags')).toBe('cs.{"","null"}')
+})
+
+test('quotes every pattern in likeAllOf/likeAnyOf/ilikeAllOf/ilikeAnyOf', () => {
+  const likeAll: any = postgrest.from('t').select().likeAllOf('name', ['%a,b%', 'c'])
+  expect(likeAll.url.searchParams.get('name')).toBe('like(all).{"%a,b%","c"}')
+
+  const likeAny: any = postgrest.from('t').select().likeAnyOf('name', ['%a,b%', 'c'])
+  expect(likeAny.url.searchParams.get('name')).toBe('like(any).{"%a,b%","c"}')
+
+  const ilikeAll: any = postgrest.from('t').select().ilikeAllOf('name', ['%a,b%', 'c'])
+  expect(ilikeAll.url.searchParams.get('name')).toBe('ilike(all).{"%a,b%","c"}')
+
+  const ilikeAny: any = postgrest.from('t').select().ilikeAnyOf('name', ['%a,b%', 'c'])
+  expect(ilikeAny.url.searchParams.get('name')).toBe('ilike(any).{"%a,b%","c"}')
 })

--- a/packages/core/postgrest-js/test/filters.test.ts
+++ b/packages/core/postgrest-js/test/filters.test.ts
@@ -460,6 +460,30 @@ test('contains with array', async () => {
   `)
 })
 
+test('contains with an array element containing a comma', async () => {
+  const res = await postgrest
+    .from('cornercase')
+    .select('array_column')
+    .contains('array_column', ['Doe, John'])
+  expect(res).toMatchInlineSnapshot(`
+    {
+      "count": null,
+      "data": [
+        {
+          "array_column": [
+            "Doe, John",
+            "admin",
+          ],
+        },
+      ],
+      "error": null,
+      "status": 200,
+      "statusText": "OK",
+      "success": true,
+    }
+  `)
+})
+
 test('containedBy', async () => {
   const res = await postgrest.from('users').select('age_range').containedBy('age_range', '[1,2)')
   expect(res).toMatchInlineSnapshot(`

--- a/packages/core/postgrest-js/test/supabase/seed.sql
+++ b/packages/core/postgrest-js/test/supabase/seed.sql
@@ -91,7 +91,8 @@ INSERT INTO public.cornercase (id, array_column)
 VALUES
   (1, ARRAY['test', 'one']),
   (2, ARRAY['another']),
-  (3, ARRAY['test2']);
+  (3, ARRAY['test2']),
+  (4, ARRAY['Doe, John', 'admin']);
 
 -- Insert sample hotels
 INSERT INTO hotel (id, name)


### PR DESCRIPTION
The array branches of `.contains()`, `.containedBy()` and `.overlaps()` build the
Postgres array literal with a raw `value.join(',')`, so an array element that
contains a comma is split into several elements and the server evaluates a
different filter than the one requested.

For example `.contains('tags', ['Doe, John', 'admin'])` emitted
`tags=cs.{Doe, John,admin}`, which Postgres reads as three elements
(`Doe`, ` John`, `admin`) instead of the intended two. The correct literal is
`tags=cs.{"Doe, John",admin}`. The same defect applied to `containedBy` and
`overlaps`.

A Postgres array literal requires elements that contain the delimiter, braces,
quotes, backslash or surrounding whitespace to be double quoted. The `.in()` and
`.notIn()` filters already quote reserved characters, and the realtime filter
builder does full quoting, so these three were the outliers.

The fix adds a small helper that double quotes and escapes only string elements
with reserved characters or surrounding whitespace. Numbers, booleans, plain
strings, and the range and JSON branches are unchanged. Added a test asserting
the emitted request URL.
