### PR TITLE
fix(functions): clean up cross-signal abort listener on invoke() return

### DIFF
--- a/packages/core/functions-js/src/FunctionsClient.ts
+++ b/packages/core/functions-js/src/FunctionsClient.ts
@@ -205,6 +205,7 @@ export class FunctionsClient {
   ): Promise<FunctionsResponse<T>> {
     let timeoutId: ReturnType<typeof setTimeout> | undefined
     let timeoutController: AbortController | undefined
+    let onAbort: (() => void) | undefined
 
     try {
       const { headers, method, body: functionArgs, signal, timeout } = options
@@ -269,8 +270,10 @@ export class FunctionsClient {
         // If user provided their own signal, we need to respect both
         if (signal) {
           effectiveSignal = timeoutController.signal
-          // If the user's signal is aborted, abort our timeout controller too
-          signal.addEventListener('abort', () => timeoutController!.abort())
+          // If the user's signal is aborted, abort our timeout controller too.
+          // Store the listener so we can clean it up in finally.
+          onAbort = () => timeoutController!.abort()
+          signal.addEventListener('abort', onAbort)
         } else {
           effectiveSignal = timeoutController.signal
         }
@@ -330,6 +333,11 @@ export class FunctionsClient {
       // Clear the timeout if it was set
       if (timeoutId) {
         clearTimeout(timeoutId)
+      }
+      // Remove the cross-signal listener to prevent memory leaks when the caller
+      // reuses the same AbortSignal across multiple invocations.
+      if (onAbort) {
+        options.signal?.removeEventListener('abort', onAbort)
       }
     }
   }

--- a/packages/core/functions-js/test/FunctionsClient.test.ts
+++ b/packages/core/functions-js/test/FunctionsClient.test.ts
@@ -1,0 +1,50 @@
+import { FunctionsClient } from '../src/index'
+
+describe('FunctionsClient', () => {
+  describe('invoke – abort listener cleanup when timeout + signal are both set', () => {
+    it('removes the listener from the caller signal after a successful invoke', async () => {
+      const mockFetch = jest.fn().mockResolvedValue({
+        ok: true,
+        headers: { get: () => 'application/json' },
+        json: () => Promise.resolve({ ok: true }),
+      })
+
+      const client = new FunctionsClient('http://localhost', { customFetch: mockFetch })
+      const controller = new AbortController()
+
+      const addSpy = jest.spyOn(controller.signal, 'addEventListener')
+      const removeSpy = jest.spyOn(controller.signal, 'removeEventListener')
+
+      await client.invoke('test-fn', { timeout: 5000, signal: controller.signal })
+
+      const addedFn = addSpy.mock.calls.find(([event]) => event === 'abort')?.[1]
+      const removedFn = removeSpy.mock.calls.find(([event]) => event === 'abort')?.[1]
+
+      expect(addedFn).toBeDefined()
+      expect(addedFn).toBe(removedFn)
+    })
+
+    it('removes the listener from the caller signal after a failed invoke', async () => {
+      const mockFetch = jest.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        headers: { get: () => null },
+        text: () => Promise.resolve('Internal Server Error'),
+      })
+
+      const client = new FunctionsClient('http://localhost', { customFetch: mockFetch })
+      const controller = new AbortController()
+
+      const addSpy = jest.spyOn(controller.signal, 'addEventListener')
+      const removeSpy = jest.spyOn(controller.signal, 'removeEventListener')
+
+      await client.invoke('test-fn', { timeout: 5000, signal: controller.signal })
+
+      const addedFn = addSpy.mock.calls.find(([event]) => event === 'abort')?.[1]
+      const removedFn = removeSpy.mock.calls.find(([event]) => event === 'abort')?.[1]
+
+      expect(addedFn).toBeDefined()
+      expect(addedFn).toBe(removedFn)
+    })
+  })
+})


### PR DESCRIPTION
When invoke() is called with both timeout and signal, an event listener is registered on the caller's AbortSignal to forward aborts to the internal timeoutController. That listener was never removed, so callers that reuse the same AbortController across multiple invocations accumulate dangling listeners — keeping the timeoutController alive indefinitely.

Root cause: the listener was created as an inline arrow function () => timeoutController!.abort()), so no reference existed to pass to removeEventListener.

Fix: store the listener in onAbort before registering it, and call options.signal?.removeEventListener('abort', onAbort) in the finally block so it's cleaned up on every code path (success, error, and abort).

Two unit tests are included that assert the same function reference is passed to both addEventListener and removeEventListener.