### PR TITLE
fix(realtime): forward opts to send() in track()

### DIFF
--- a/packages/core/realtime-js/src/RealtimeChannel.ts
+++ b/packages/core/realtime-js/src/RealtimeChannel.ts
@@ -501,7 +501,7 @@ export default class RealtimeChannel {
         event: 'track',
         payload,
       },
-      opts.timeout || this.timeout
+      opts
     )
   }
 

--- a/packages/core/realtime-js/test/RealtimeChannel.presence.test.ts
+++ b/packages/core/realtime-js/test/RealtimeChannel.presence.test.ts
@@ -320,6 +320,47 @@ describe('Presence helper methods', () => {
 
     expect(resp).toBe('ok')
   })
+
+  test('track forwards a custom timeout from opts to send', async () => {
+    channel.subscribe()
+    await waitForChannelSubscribed(channel)
+
+    const pushSpy = vi.spyOn(channel.channelAdapter.getChannel(), 'push')
+
+    await channel.track({ id: 123 }, { timeout: 2500 })
+
+    expect(pushSpy).toHaveBeenCalledWith(
+      'presence',
+      { type: 'presence', event: 'track', payload: { id: 123 } },
+      2500
+    )
+  })
+
+  test('track falls back to the channel timeout when opts has no timeout', async () => {
+    channel.subscribe()
+    await waitForChannelSubscribed(channel)
+
+    const pushSpy = vi.spyOn(channel.channelAdapter.getChannel(), 'push')
+
+    await channel.track({ id: 123 })
+
+    expect(pushSpy).toHaveBeenCalledWith(
+      'presence',
+      { type: 'presence', event: 'track', payload: { id: 123 } },
+      defaultTimeout
+    )
+  })
+
+  test('untrack forwards a custom timeout from opts to send', async () => {
+    channel.subscribe()
+    await waitForChannelSubscribed(channel)
+
+    const pushSpy = vi.spyOn(channel.channelAdapter.getChannel(), 'push')
+
+    await channel.untrack({ timeout: 2500 })
+
+    expect(pushSpy).toHaveBeenCalledWith('presence', { type: 'presence', event: 'untrack' }, 2500)
+  })
 })
 
 describe('Presence configuration override', () => {


### PR DESCRIPTION
## What

RealtimeChannel.track() accepts an opts parameter (e.g. { timeout: 5000 }), but was passing opts.timeout || this.timeout — a plain number — as the second argument to send(). Since send() expects opts: { [key: string]: any }, accessing .timeout on a number always returns undefined, so the actual timeout from the caller is silently ignored.

untrack() already passes opts directly and works correctly. This aligns track() with the same behavior.

## Before

```ts
async track(payload, opts = {}) {
  return await this.send({ type: 'presence', event: 'track', payload }, opts.timeout || this.timeout)
  //                                                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  //                                                          number passed where object is expected
}
```

## After

```ts
async track(payload, opts = {}) {
  return await this.send({ type: 'presence', event: 'track', payload }, opts)
}
```