### PR TITLE
fix(auth): preserve default lock acquire timeout

### DIFF
--- a/packages/core/supabase-js/src/SupabaseClient.ts
+++ b/packages/core/supabase-js/src/SupabaseClient.ts
@@ -615,7 +615,7 @@ export default class SupabaseClient<
       throwOnError,
       experimental,
       fetch,
-      lockAcquireTimeout,
+      ...(lockAcquireTimeout !== undefined ? { lockAcquireTimeout } : {}),
       skipAutoInitialize,
       // auth checks if there is a custom authorizaiton header using this flag
       // so it knows whether to return an error when getUser is called with no session

--- a/packages/core/supabase-js/test/unit/SupabaseAuthClient.test.ts
+++ b/packages/core/supabase-js/test/unit/SupabaseAuthClient.test.ts
@@ -123,6 +123,11 @@ test('createClient with auth.experimental.passkey enables the admin passkey API'
 // surfaces both the production code AND these tests together so the
 // removal is mechanical.
 
+test('createClient should preserve the default auth.lockAcquireTimeout when unset', () => {
+  const supa = new SupabaseClient('https://example.supabase.com', 'supabaseKey')
+  expect((supa.auth as unknown as { lockAcquireTimeout: number }).lockAcquireTimeout).toBe(5000)
+})
+
 test('_initSupabaseAuthClient should pass through lockAcquireTimeout option', () => {
   const client = new SupabaseClient('https://example.supabase.com', 'supabaseKey')
   const authClient = client['_initSupabaseAuthClient'](


### PR DESCRIPTION
## Description

Fixes supabase/supabase-js#2492.

`SupabaseClient` was always forwarding `lockAcquireTimeout` to `SupabaseAuthClient`, even when the caller did not configure it. Because the forwarded property was explicitly `undefined`, auth-js' default merge treated it as an override and replaced the documented `5000` ms default with `undefined`.

This PR only includes `lockAcquireTimeout` in the auth client options when it is actually defined, so default-config clients keep auth-js' fallback while explicit values still pass through.

## Testing

- `pnpm install --frozen-lockfile`
- `pnpm nx test:unit supabase-js --testPathPatterns=SupabaseAuthClient.test.ts`
- `pnpm prettier --check packages/core/supabase-js/src/SupabaseClient.ts packages/core/supabase-js/test/unit/SupabaseAuthClient.test.ts`
- `pnpm exec eslint packages/core/supabase-js/src/SupabaseClient.ts packages/core/supabase-js/test/unit/SupabaseAuthClient.test.ts` (0 errors; existing warnings only)
- `git diff --check`

Notes:

- `pnpm nx typecheck supabase-js` was blocked before running by an existing workspace sync warning from Nx.
- `pnpm nx lint supabase-js` was blocked by a missing optional Expo integration lint dependency (`eslint-config-expo/flat`), so I ran ESLint on the changed files directly instead.
