### PR TITLE
fix(auth): validate session before user hydration in _recoverAndRefresh

### DIFF
--- a/packages/core/auth-js/src/GoTrueClient.ts
+++ b/packages/core/auth-js/src/GoTrueClient.ts
@@ -4715,6 +4715,17 @@ export default class GoTrueClient {
     try {
       const currentSession = (await getItemAsync(this.storage, this.storageKey)) as Session | null
 
+      this._debug(debugName, 'session from storage', currentSession)
+
+      if (!this._isValidSession(currentSession)) {
+        this._debug(debugName, 'session is not valid')
+        if (currentSession !== null) {
+          await this._removeSession()
+        }
+
+        return
+      }
+
       if (currentSession && this.userStorage) {
         let maybeUser: { user: User | null } | null = (await getItemAsync(
           this.userStorage,
@@ -4752,17 +4763,6 @@ export default class GoTrueClient {
             currentSession.user = userNotAvailableProxy()
           }
         }
-      }
-
-      this._debug(debugName, 'session from storage', currentSession)
-
-      if (!this._isValidSession(currentSession)) {
-        this._debug(debugName, 'session is not valid')
-        if (currentSession !== null) {
-          await this._removeSession()
-        }
-
-        return
       }
 
       const expiresWithMargin =

--- a/packages/core/auth-js/test/GoTrueClient.browser.test.ts
+++ b/packages/core/auth-js/test/GoTrueClient.browser.test.ts
@@ -978,6 +978,27 @@ describe('Session Management Tests', () => {
     expect(client).toBeDefined()
   })
 
+  it('should remove corrupted storage value when stored session is a JSON primitive', async () => {
+    // JSON.parse('"corrupted"') returns the string "corrupted", not a Session
+    const mockStorage = {
+      getItem: jest.fn().mockResolvedValue('"corrupted"'),
+      setItem: jest.fn(),
+      removeItem: jest.fn(),
+    }
+
+    const client = new (require('../src/GoTrueClient').default)({
+      url: 'http://localhost:9999',
+      autoRefreshToken: false,
+      persistSession: true,
+      storage: mockStorage,
+    })
+
+    await client.initialize()
+
+    // The corrupted value should be removed
+    expect(mockStorage.removeItem).toHaveBeenCalled()
+  })
+
   it('should handle session with invalid tokens', async () => {
     const mockSession = {
       access_token: '',

--- a/packages/core/auth-js/test/GoTrueClient.test.ts
+++ b/packages/core/auth-js/test/GoTrueClient.test.ts
@@ -3165,6 +3165,69 @@ describe('Auto Refresh', () => {
       expect(errorSpy).not.toHaveBeenCalled()
       errorSpy.mockRestore()
     })
+
+    test('should remove corrupted storage value when stored session is a JSON string primitive', async () => {
+      const storageKey = 'test-corrupted-string-session'
+      // JSON.parse('"hello"') succeeds and returns the string "hello" —
+      // a valid JSON value but not a session object.
+      const storage = memoryLocalStorageAdapter({
+        [storageKey]: '"hello"',
+      })
+      const client = new GoTrueClient({
+        url: GOTRUE_URL_SIGNUP_ENABLED_AUTO_CONFIRM_ON,
+        autoRefreshToken: false,
+        persistSession: true,
+        storage,
+        storageKey,
+      })
+
+      // Should not throw
+      // @ts-expect-error 'Allow access to private _recoverAndRefresh'
+      await client._recoverAndRefresh()
+
+      // The corrupted value should be removed
+      const storedValue = await storage.getItem(storageKey)
+      expect(storedValue).toBeNull()
+    })
+
+    test('should remove corrupted storage value when stored session is a JSON number', async () => {
+      const storageKey = 'test-corrupted-number-session'
+      const storage = memoryLocalStorageAdapter({
+        [storageKey]: '123',
+      })
+      const client = new GoTrueClient({
+        url: GOTRUE_URL_SIGNUP_ENABLED_AUTO_CONFIRM_ON,
+        autoRefreshToken: false,
+        persistSession: true,
+        storage,
+        storageKey,
+      })
+
+      // @ts-expect-error 'Allow access to private _recoverAndRefresh'
+      await client._recoverAndRefresh()
+
+      const storedValue = await storage.getItem(storageKey)
+      expect(storedValue).toBeNull()
+    })
+
+    test('should not call _removeSession when no session exists in storage', async () => {
+      const storageKey = 'test-no-session-exists'
+      const storage = memoryLocalStorageAdapter({})
+      const client = new GoTrueClient({
+        url: GOTRUE_URL_SIGNUP_ENABLED_AUTO_CONFIRM_ON,
+        autoRefreshToken: false,
+        persistSession: true,
+        storage,
+        storageKey,
+      })
+
+      // @ts-expect-error 'Allow access to private _recoverAndRefresh'
+      await client._recoverAndRefresh()
+
+      // No error, no cleanup needed — storage should remain as-is
+      const storedValue = await storage.getItem(storageKey)
+      expect(storedValue).toBeNull()
+    })
   })
 
   test('should handle auto refresh start/stop multiple times', async () => {


### PR DESCRIPTION
## Description

### What changed?

Reordered `_recoverAndRefresh` so `_isValidSession` validation and `_removeSession` cleanup run **before** user-hydration (`.user` assignment), matching the existing pattern in `__loadSession`.

**Files:**
- `packages/core/auth-js/src/GoTrueClient.ts` — moved the validation + cleanup block ahead of the user-hydration branches
- `packages/core/auth-js/test/GoTrueClient.test.ts` — 3 new unit tests (JSON string primitive, JSON number, null session)
- `packages/core/auth-js/test/GoTrueClient.browser.test.ts` — 1 new browser test

### Why was this change needed?

When a stored auth session was a valid JSON value but not a `Session` object (e.g. corrupted to `"hello"`, `123`, `true`), `_recoverAndRefresh` tried `currentSession.user = ...` before checking `_isValidSession`. In strict mode, assigning `.user` to a primitive throws `TypeError: Cannot create property 'user' on string`. The outer `catch` silently logged the error without calling `_removeSession()`, so the corrupted value was never cleaned up and every subsequent `initialize()` repeated the same failure.

`__loadSession` already handled this correctly — the fix mirrors that pattern.

Closes #2494

---

## 🔄 Breaking changes

- [x] This PR contains no breaking changes

---

## 📋 Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/supabase/supabase-js/blob/master/CONTRIBUTING.md)
- [x] My PR title follows the [conventional commit format](https://www.conventionalcommits.org/): `<type>(<scope>): <description>`
- [x] I have run `pnpm nx format` to ensure consistent code formatting
- [x] I have added tests for new functionality (if applicable)
- [x] I have updated documentation (if applicable)

---

## 📝 Additional notes

The change is a pure reorder — no new validation logic, no new functions. `_isValidSession` is a TypeScript type guard (`maybeSession is Session`), so after the early return on invalid, the compiler narrows `currentSession` to `Session` for the hydration code below.

**Test locally:**
```bash
cd packages/core/auth-js
node test/generate-signing-keys.js
./node_modules/.bin/jest --config jest.config.js \
  --testPathPatterns="GoTrueClient.test" \
  --testNamePattern="corrupted|no session exists" \
  --forceExit
```