### PR TITLE
fix(realtime): suppress disconnected status from onHeartbeat consumers

### DIFF
--- a/packages/core/realtime-js/src/RealtimeClient.ts
+++ b/packages/core/realtime-js/src/RealtimeClient.ts
@@ -527,7 +527,7 @@ export default class RealtimeClient {
 
   /**
    * Sets a callback that receives lifecycle events for internal heartbeat messages.
-   * Useful for instrumenting connection health (e.g. sent/ok/timeout/disconnected).
+   * Useful for instrumenting connection health (e.g. sent/ok/timeout).
    *
    * @category Realtime
    */
@@ -714,6 +714,7 @@ export default class RealtimeClient {
   /** @internal */
   private _wrapHeartbeatCallback(heartbeatCallback?: HeartbeatCallback): HeartbeatCallback {
     return (status, latency) => {
+      if (status === 'disconnected') return
       if (status == 'sent') this._setAuthSafely()
       if (heartbeatCallback) heartbeatCallback(status, latency)
     }


### PR DESCRIPTION
## Description

### What changed?

- `_wrapHeartbeatCallback` in `RealtimeClient` now silently drops any heartbeat status of `'disconnected'` before forwarding to the consumer callback
- Removed `disconnected` from the `onHeartbeat` JSDoc example statuses

### Why was this change needed?

`onHeartbeat` exposes a `'disconnected'` status via `HeartbeatStatus`, but it fires nondeterministically. The emission comes from `@supabase/phoenix`'s `Socket.sendHeartbeat()` as a race-condition safeguard: if the heartbeat timer fires after the connection closes but before `clearHeartbeats()` runs in `onConnClose`, the `!isConnected()` guard emits `'disconnected'`. Whether a consumer's callback ever receives it depends entirely on OS scheduler timing.

Connection lifecycle signals belong to the close handler and state-change events, not the heartbeat path. Consumers relying on `'disconnected'` from `onHeartbeat` cannot do so reliably.

Closes #2488

## Screenshots/Examples

Before: consumers could receive `'disconnected'` from `onHeartbeat` intermittently with no way to depend on it.

After: `onHeartbeat` only fires `'sent'`, `'ok'`, `'error'`, and `'timeout'` -- all deterministic heartbeat lifecycle statuses. Use socket state-change events (`onOpen`, `onClose`, `onError`) for connection lifecycle.

## Breaking changes

- [x] This PR contains no breaking changes

`HeartbeatStatus` still includes `'disconnected'` in the type union -- no type surface is removed. The only observable change is that the nondeterministic emission is swallowed before reaching any consumer. A follow-up breaking change to remove `'disconnected'` from `HeartbeatStatus` entirely is tracked for v3.

## Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/supabase/supabase-js/blob/master/CONTRIBUTING.md)
- [x] My PR title follows the [conventional commit format](https://www.conventionalcommits.org/): `<type>(<scope>): <description>`
- [x] I have run `pnpm nx format` to ensure consistent code formatting
- [ ] I have added tests for new functionality (if applicable)
- [x] I have updated documentation (if applicable)

## Additional notes

The root-cause fix (removing the `heartbeatCallback("disconnected")` emission from `@supabase/phoenix`'s `sendHeartbeat()`). Once that ships, the suppression guard added here can be removed as dead code.