### PR TITLE
fix(supabase): resolve workspace deps from source for typedoc

### DIFF
--- a/packages/core/supabase-js/package.json
+++ b/packages/core/supabase-js/package.json
@@ -82,7 +82,7 @@
     "test:hermes-compat": "node test/bundle-hermes-compat.test.cjs",
     "test:module-resolution": "npm run test:exports && npm run test:esm && npm run test:cjs && npm run test:hermes-compat",
     "docs": "typedoc --entryPoints src/index.ts --entryPoints src/cors.ts --out docs/v2",
-    "docs:json": "typedoc --entryPoints src/index.ts --entryPoints src/cors.ts --json docs/v2/spec.json --excludeExternals",
+    "docs:json": "typedoc --tsconfig tsconfig.typedoc.json --entryPoints src/index.ts --entryPoints src/cors.ts --json docs/v2/spec.json --excludeExternals",
     "serve:coverage": "pnpm nx test:coverage supabase-js && pnpm dlx serve test/coverage",
     "update:test-deps": "pnpm run update:test-deps:expo && pnpm run update:test-deps:next && pnpm run update:test-deps:deno && pnpm run update:test-deps:bun",
     "update:test-deps:expo": "cd test/integration/expo && pnpm install --ignore-workspace",

--- a/packages/core/supabase-js/tsconfig.typedoc.json
+++ b/packages/core/supabase-js/tsconfig.typedoc.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "lib": ["es2022", "dom"],
+    "paths": {
+      "@supabase/auth-js": ["../auth-js/src/index.ts"],
+      "@supabase/functions-js": ["../functions-js/src/index.ts"],
+      "@supabase/postgrest-js": ["../postgrest-js/src/index.ts"],
+      "@supabase/realtime-js": ["../realtime-js/src/index.ts"],
+      "@supabase/storage-js": ["../storage-js/src/index.ts"],
+      "@supabase/tracing": ["../../shared/tracing/src/index.ts"]
+    }
+  },
+  "references": []
+}


### PR DESCRIPTION
The SDK compliance check (`validate / Check public API against capability matrix`) runs `pnpm install` but never builds workspace packages. `supabase-js` imports from `@supabase/auth-js`, `@supabase/realtime-js`, etc., whose `types` fields point to `dist/` outputs that don't exist without a build — so TypeDoc fails to compile.

**Fix:** adds `tsconfig.typedoc.json` with `paths` mappings that resolve all workspace packages directly from their source files, and updates the `docs:json` script to use it.

---

**Why this PR's own compliance check fails:** the workflow diffs the PR branch against the base (current master). The base predates this fix, so the base's TypeDoc run still fails and the check can't complete. This is a bootstrapping problem — the first PR that introduces a fix for the check will always fail its own check.

Once this merges to master, all subsequent PRs will compile cleanly on both sides of the diff and the check will work correctly.