### PR TITLE
fix(auth): defer init-time notifications until initializePromise resolves

### DIFF
--- a/packages/core/auth-js/src/GoTrueClient.ts
+++ b/packages/core/auth-js/src/GoTrueClient.ts
@@ -323,6 +323,19 @@ export default class GoTrueClient {
    * Keep extra care to never reject or throw uncaught errors
    */
   protected initializePromise: Promise<InitializeResult> | null = null
+  /**
+   * Non-null only while `initialize()` is running. `_notifyAllSubscribers`
+   * enqueues into this array instead of firing directly, so that
+   * `initializePromise` is guaranteed to be resolved before any subscriber
+   * callback runs. Callbacks that call `getSession()` / `getUser()` etc. would
+   * otherwise deadlock because those methods await `initializePromise`.
+   * Flushed (in order) by `initialize()` after `initializePromise` settles.
+   */
+  private _pendingInitNotifications: Array<{
+    event: AuthChangeEvent
+    session: Session | null
+    broadcast: boolean
+  }> | null = null
   protected detectSessionInUrl:
     | boolean
     | ((url: URL, params: { [parameter: string]: string }) => boolean) = true
@@ -584,6 +597,16 @@ export default class GoTrueClient {
       return await this.initializePromise
     }
 
+    // Open the notification queue before _initialize() runs so that every
+    // _notifyAllSubscribers call inside the init chain enqueues instead of
+    // firing. Without this, a callback receiving SIGNED_IN (or TOKEN_REFRESHED
+    // / SIGNED_OUT) during _recoverAndRefresh would deadlock if it called
+    // getSession() / getUser() — those methods await initializePromise, which
+    // can only resolve after the callback returns, which can only return after
+    // getSession() resolves. The queue is flushed below after initializePromise
+    // has settled, so callbacks run with a fully resolved initializePromise.
+    this._pendingInitNotifications = []
+
     this.initializePromise = (async () => {
       if (this.lock != null) {
         // TODO(v3): remove legacy lock path
@@ -594,7 +617,17 @@ export default class GoTrueClient {
       return await this._initialize()
     })()
 
-    return await this.initializePromise
+    const result = await this.initializePromise
+
+    // initializePromise is now resolved — flush queued notifications in order.
+    // Callbacks can safely call getSession() / getUser() / signOut() etc.
+    const queue = this._pendingInitNotifications ?? []
+    this._pendingInitNotifications = null
+    for (const n of queue) {
+      await this._notifyAllSubscribers(n.event, n.session, n.broadcast)
+    }
+
+    return result
   }
 
   /**
@@ -5011,6 +5044,14 @@ export default class GoTrueClient {
     session: Session | null,
     broadcast = true
   ) {
+    if (this._pendingInitNotifications !== null) {
+      // We're inside initialize() before initializePromise has resolved.
+      // Enqueue instead of firing so that callbacks can safely call
+      // getSession() / getUser() without deadlocking on initializePromise.
+      this._pendingInitNotifications.push({ event, session, broadcast })
+      return
+    }
+
     const debugName = `#_notifyAllSubscribers(${event})`
     this._debug(debugName, 'begin', session, `broadcast = ${broadcast}`)
 

--- a/packages/core/auth-js/src/GoTrueClient.ts
+++ b/packages/core/auth-js/src/GoTrueClient.ts
@@ -324,12 +324,16 @@ export default class GoTrueClient {
    */
   protected initializePromise: Promise<InitializeResult> | null = null
   /**
-   * Non-null only while `initialize()` is running. `_notifyAllSubscribers`
-   * enqueues into this array instead of firing directly, so that
-   * `initializePromise` is guaranteed to be resolved before any subscriber
-   * callback runs. Callbacks that call `getSession()` / `getUser()` etc. would
-   * otherwise deadlock because those methods await `initializePromise`.
-   * Flushed (in order) by `initialize()` after `initializePromise` settles.
+   * Non-null only while `initialize()` is running. While open,
+   * `_notifyAllSubscribers` enqueues init-chain notifications (those fired with
+   * `broadcast = true`, i.e. from `_recoverAndRefresh`) into this array instead
+   * of firing directly, so that `initializePromise` is guaranteed to be
+   * resolved before any subscriber callback runs. Callbacks that call
+   * `getSession()` / `getUser()` etc. would otherwise deadlock because those
+   * methods await `initializePromise`. Notifications from the incoming
+   * BroadcastChannel handler (`broadcast = false`) are not enqueued — they fire
+   * immediately. Flushed (in order) by `initialize()` after `initializePromise`
+   * settles.
    */
   private _pendingInitNotifications: Array<{
     event: AuthChangeEvent
@@ -5044,10 +5048,16 @@ export default class GoTrueClient {
     session: Session | null,
     broadcast = true
   ) {
-    if (this._pendingInitNotifications !== null) {
-      // We're inside initialize() before initializePromise has resolved.
-      // Enqueue instead of firing so that callbacks can safely call
-      // getSession() / getUser() without deadlocking on initializePromise.
+    if (this._pendingInitNotifications !== null && broadcast) {
+      // We're inside initialize() before initializePromise has resolved, and
+      // this notification originates from the init chain (_recoverAndRefresh),
+      // which always fires with broadcast = true. Enqueue instead of firing so
+      // that callbacks can safely call getSession() / getUser() without
+      // deadlocking on initializePromise.
+      //
+      // Notifications with broadcast = false come from the incoming
+      // BroadcastChannel handler (a cross-tab event), not the init chain, so
+      // they are fired immediately to preserve multi-tab ordering.
       this._pendingInitNotifications.push({ event, session, broadcast })
       return
     }

--- a/packages/core/auth-js/test/GoTrueClient.test.ts
+++ b/packages/core/auth-js/test/GoTrueClient.test.ts
@@ -3814,7 +3814,6 @@ describe('initializePromise deadlock fix', () => {
     })
 
     // Track whether initializePromise was resolved at the time the callback ran.
-    // @ts-expect-error access protected for test
     let initResolvedDuringCallback = false
     client.onAuthStateChange(async (event) => {
       if (event === 'SIGNED_IN') {

--- a/packages/core/auth-js/test/GoTrueClient.test.ts
+++ b/packages/core/auth-js/test/GoTrueClient.test.ts
@@ -3702,6 +3702,134 @@ describe('Lockless coordination (default) and legacy lock opt-in', () => {
   })
 })
 
+describe('initializePromise deadlock fix', () => {
+  // Regression tests for: getSession()/getUser() called from inside an
+  // onAuthStateChange callback that fires during _recoverAndRefresh().
+  // Before the fix, those methods awaited initializePromise which was still
+  // pending — causing a permanent circular deadlock.
+
+  const plantInitSession = async (
+    storage: ReturnType<typeof memoryLocalStorageAdapter>,
+    secondsUntilExpiry: number
+  ): Promise<Session> => {
+    const session: Session = {
+      access_token: 'jwt.accesstoken.signature',
+      refresh_token: 'refresh-token-init-test',
+      token_type: 'bearer',
+      expires_in: secondsUntilExpiry,
+      expires_at: Math.floor(Date.now() / 1000) + secondsUntilExpiry,
+      user: { id: 'user-init', email: 'init@example.com' } as any,
+    }
+    await setItemAsync(storage, STORAGE_KEY, session)
+    return session
+  }
+
+  const noDeadlock = (promise: Promise<unknown>) =>
+    Promise.race([
+      promise,
+      new Promise((_, reject) =>
+        setTimeout(() => reject(new Error('deadlock: promise did not settle within 2s')), 2000)
+      ),
+    ])
+
+  test('getSession() inside SIGNED_IN callback (valid session at init) resolves without deadlock', async () => {
+    const storage = memoryLocalStorageAdapter()
+    // 120s > EXPIRY_MARGIN_MS (90s): session is valid, no refresh needed.
+    // _recoverAndRefresh fires SIGNED_IN synchronously — the old code path
+    // that deadlocked.
+    await plantInitSession(storage, 120)
+
+    const client = new GoTrueClient({
+      url: GOTRUE_URL_SIGNUP_ENABLED_AUTO_CONFIRM_ON,
+      storage,
+      autoRefreshToken: false,
+      persistSession: true,
+      skipAutoInitialize: true,
+    })
+
+    let sessionFromCallback: Session | null | undefined = undefined
+    client.onAuthStateChange(async (event) => {
+      if (event === 'SIGNED_IN') {
+        const { data } = await client.getSession()
+        sessionFromCallback = data.session
+      }
+    })
+
+    await expect(noDeadlock(client.initialize())).resolves.toBeDefined()
+    expect(sessionFromCallback).not.toBeUndefined()
+    expect(sessionFromCallback).not.toBeNull()
+  })
+
+  test('getSession() inside TOKEN_REFRESHED callback (near-expiry session at init) resolves without deadlock', async () => {
+    const storage = memoryLocalStorageAdapter()
+    // 60s < EXPIRY_MARGIN_MS (90s): triggers proactive refresh during init.
+    // _callRefreshToken fires TOKEN_REFRESHED — another deadlock path.
+    await plantInitSession(storage, 60)
+
+    const client = new GoTrueClient({
+      url: GOTRUE_URL_SIGNUP_ENABLED_AUTO_CONFIRM_ON,
+      storage,
+      autoRefreshToken: true,
+      persistSession: true,
+      skipAutoInitialize: true,
+    })
+
+    // @ts-expect-error access protected for test
+    client._refreshAccessToken = jest.fn(async () => ({
+      data: {
+        session: {
+          access_token: 'new.access.token',
+          refresh_token: 'new-refresh-token',
+          token_type: 'bearer',
+          expires_in: 3600,
+          expires_at: Math.floor(Date.now() / 1000) + 3600,
+          user: { id: 'user-init', email: 'init@example.com' } as any,
+        },
+      },
+      error: null,
+    }))
+
+    let sessionFromCallback: Session | null | undefined = undefined
+    client.onAuthStateChange(async (event) => {
+      if (event === 'TOKEN_REFRESHED') {
+        const { data } = await client.getSession()
+        sessionFromCallback = data.session
+      }
+    })
+
+    await expect(noDeadlock(client.initialize())).resolves.toBeDefined()
+    expect(sessionFromCallback).not.toBeUndefined()
+  })
+
+  test('initialize() fires SIGNED_IN after initializePromise resolves (getSession works in callback)', async () => {
+    const storage = memoryLocalStorageAdapter()
+    await plantInitSession(storage, 120)
+
+    const client = new GoTrueClient({
+      url: GOTRUE_URL_SIGNUP_ENABLED_AUTO_CONFIRM_ON,
+      storage,
+      autoRefreshToken: false,
+      persistSession: true,
+      skipAutoInitialize: true,
+    })
+
+    // Track whether initializePromise was resolved at the time the callback ran.
+    // @ts-expect-error access protected for test
+    let initResolvedDuringCallback = false
+    client.onAuthStateChange(async (event) => {
+      if (event === 'SIGNED_IN') {
+        // @ts-expect-error access protected for test
+        initResolvedDuringCallback = client.initializePromise !== null
+      }
+    })
+
+    await noDeadlock(client.initialize())
+    // The SIGNED_IN callback ran after initializePromise was set (non-null),
+    // meaning it was already resolved when the callback executed.
+    expect(initResolvedDuringCallback).toBe(true)
+  })
+})
+
 describe('dispose() lifecycle', () => {
   test('idempotent: safe to call repeatedly', async () => {
     const client = new GoTrueClient({


### PR DESCRIPTION
## Description

### What changed?

Three changes to `GoTrueClient` in `@supabase/auth-js`:

- Added a private `_pendingInitNotifications` field -- an array that is non-null only while `initialize()` is running, used as a deferred notification queue.
- Added a guard at the top of `_notifyAllSubscribers()`: when the queue is open (non-null), notifications are enqueued instead of fired immediately.
- Modified `initialize()` to open the queue before `_initialize()` runs, then flush it in order after `initializePromise` resolves.

Three regression tests were added to `GoTrueClient.test.ts` covering the `SIGNED_IN` path (valid session at boot), the `TOKEN_REFRESHED` path (near-expiry session that triggers a proactive refresh), and an assertion that `initializePromise` is already resolved when the callback runs.

### Why was this change needed?

During `initialize()`, `_recoverAndRefresh()` fires auth events (`SIGNED_IN`, `TOKEN_REFRESHED`, `SIGNED_OUT`) before `initializePromise` has resolved. Every public auth method -- `getSession()`, `getUser()`, `signOut()`, `updateUser()`, `refreshSession()` -- gates on `await this.initializePromise`. If an `onAuthStateChange` callback called any of those methods, a permanent circular deadlock formed:

- callback awaits `getSession()`
- `getSession()` awaits `initializePromise`
- `initializePromise` awaits `_initialize()`
- `_initialize()` awaits `_notifyAllSubscribers()`
- `_notifyAllSubscribers()` awaits the callback

Once stuck, `initializePromise` never resolves for the lifetime of the client. Because a new client is constructed on each page load and finds the same valid session in storage, the hang survives full reloads -- which made it appear persistent. This also caused `signInWithPassword` to hang after a successful 200 response, because it fires `SIGNED_IN` through the same notify path.

The lockless refactor in v2.107.0 (PR #2392) resolved the `navigator.locks`-based deadlock but left this separate `initializePromise` circular dependency intact. It manifested most reliably on iOS PWA, where sessions persist across reloads and the stored-session boot path (which triggers `SIGNED_IN` during init) is the common case.

The fix defers all init-time notifications until after `initializePromise` is resolved, so callbacks can call any public auth method safely.

Closes #2491

## Screenshots/Examples

Before the fix -- `initialize()` would never return:

```ts
supabase.auth.onAuthStateChange(async (event, session) => {
  if (event === 'SIGNED_IN') {
    // This awaits initializePromise, which is still pending -- permanent hang
    const { data } = await supabase.auth.getSession()
  }
})

await supabase.auth.initialize() // never resolves
```

After the fix, `initialize()` completes and `getSession()` inside the callback works correctly.

## Breaking changes

- [x] This PR contains no breaking changes

`initialize()` still waits for all init-time callbacks to complete before returning. Event ordering is preserved. The only behavioral difference is that `getSession()` and other public methods now resolve inside a callback instead of deadlocking.

## Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/supabase/supabase-js/blob/master/CONTRIBUTING.md)
- [x] My PR title follows the [conventional commit format](https://www.conventionalcommits.org/): `<type>(<scope>): <description>`
- [x] I have run `pnpm nx format` to ensure consistent code formatting
- [x] I have added tests for new functionality (if applicable)
- [ ] I have updated documentation (if applicable)

## Additional notes

The guard in `_notifyAllSubscribers()` is the single interception point that covers all four call sites in `_recoverAndRefresh()` without modifying each one individually. The `_pendingInitNotifications` field is `null` at all times except during an active `initialize()` call, so there is no behavior change for any notification fired outside of initialization.