### PR TITLE
ci(repo): pass build-command and spec-glob to SDK compliance workflow

### DIFF
--- a/.github/workflows/validate-capabilities.yml
+++ b/.github/workflows/validate-capabilities.yml
@@ -10,4 +10,8 @@ jobs:
   validate:
     uses: supabase/sdk/.github/workflows/validate-sdk-compliance-javascript.yml@main
     with:
-      typedoc-packages: packages/core/auth-js,packages/core/functions-js,packages/core/postgrest-js,packages/core/realtime-js,packages/core/storage-js,packages/core/supabase-js
+      build-command: |
+        corepack enable
+        pnpm install --frozen-lockfile
+        pnpm nx run-many --target=docs:json --output-style=stream
+      spec-glob: packages/core/*/docs/v2/spec.json


### PR DESCRIPTION
## What

Updates the SDK-compliance CI caller for the new build-agnostic reusable workflow. Replaces the `typedoc-packages` input with:

- `build-command` — `corepack enable` + `pnpm install --frozen-lockfile` + `pnpm nx run-many --target=docs:json`
- `spec-glob` — `packages/core/*/docs/v2/spec.json`

## Why

The central compliance workflow no longer hardcodes how supabase-js builds its TypeDoc docs. This repo now owns that definition, so future build changes here don't require a change in the registry repo.

## Coordination

Depends on the reusable-workflow change in supabase/sdk#57 (which drops `typedoc-packages`). Since we pin `@main`, this must land together with that PR.
