### PR TITLE
fix(postgrest): use POST fallback for rpc get:true with object args

### DIFF
--- a/packages/core/postgrest-js/src/PostgrestClient.ts
+++ b/packages/core/postgrest-js/src/PostgrestClient.ts
@@ -397,10 +397,10 @@ export default class PostgrestClient<
     let method: 'HEAD' | 'GET' | 'POST'
     const url = new URL(`${this.url}/rpc/${fn}`)
     let body: unknown | undefined
-    // objects/arrays-of-objects can't be serialized to URL params, use POST + return=minimal instead
+    // objects/arrays-of-objects can't be serialized to URL params, fall back to POST
     const _isObject = (v: unknown): boolean =>
       v !== null && typeof v === 'object' && (!Array.isArray(v) || v.some(_isObject))
-    const _hasObjectArg = head && Object.values(args as object).some(_isObject)
+    const _hasObjectArg = (head || get) && Object.values(args as object).some(_isObject)
     if (_hasObjectArg) {
       method = 'POST'
       body = args
@@ -421,7 +421,7 @@ export default class PostgrestClient<
     }
 
     const headers = new Headers(this.headers)
-    if (_hasObjectArg) {
+    if (head && _hasObjectArg) {
       headers.set('Prefer', count ? `count=${count},return=minimal` : 'return=minimal')
     } else if (count) {
       headers.set('Prefer', `count=${count}`)

--- a/packages/core/postgrest-js/test/fetch-errors.test.ts
+++ b/packages/core/postgrest-js/test/fetch-errors.test.ts
@@ -189,6 +189,29 @@ describe('Fetch error handling', () => {
     expect(options.headers['prefer']).toContain('return=minimal')
   })
 
+  test('rpc with get: true and object args uses POST and returns the body', async () => {
+    const mockFetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      headers: new Headers(),
+      json: async () => null,
+      text: async () => '',
+    })
+
+    const postgrest = new PostgrestClient<Database>('https://example.com', {
+      fetch: mockFetch as any,
+    })
+
+    await postgrest.rpc('my_func' as any, { obj_arg: { nested: 'value' } }, { get: true })
+
+    const [url, options] = mockFetch.mock.calls[0]
+    expect(options.method).toBe('POST')
+    expect(JSON.parse(options.body)).toEqual({ obj_arg: { nested: 'value' } })
+    expect(url).not.toContain('object')
+    expect(options.headers['prefer'] ?? '').not.toContain('return=minimal')
+  })
+
   test('PostgrestError serializes message with JSON.stringify', () => {
     const err = new PostgrestError({
       message: 'RLS denied',


### PR DESCRIPTION
## Description

Fixes #2691.

`rpc(fn, args, { get: true })` silently corrupts the request when any argument is an object (or an array containing objects): the object is stringified into the query string as the literal `[object Object]`.

The `rpc` method already has a fallback that routes object-valued args to `POST` (objects can't be serialized into URL params), but the guard only checked `head`:

```ts
const _hasObjectArg = head && Object.values(args as object).some(_isObject)
```

Since `head` and `get` share the same URL-serialization branch (`else if (head || get)`), a `get: true` call with an object arg skipped the fallback and hit `` `${value}` `` → `"[object Object]"`. The sibling `head: true` path handled it correctly.

### Reproduction

```ts
supabase.rpc('fn', { filter: { a: 1 } }, { get: true })
// GET /rest/v1/rpc/fn?filter=%5Bobject+Object%5D   ❌
```

## Fix

Extend the POST fallback to `get` as well, and keep `return=minimal` head-only so a `get` caller still receives the function result:

```ts
const _hasObjectArg = (head || get) && Object.values(args as object).some(_isObject)
// ...
if (head && _hasObjectArg) {
  headers.set('Prefer', count ? `count=${count},return=minimal` : 'return=minimal')
}
```

`head && _hasObjectArg` is equivalent to the original head-only condition, so the existing `head` behavior is unchanged. `get: true` with an object arg now sends `POST` with the args as the body and returns the function result.

## Type of Change

- [x] Bug fix (fix)

## Testing

- [x] Unit test added (`test/fetch-errors.test.ts`) asserting `get: true` + object args produces `POST`, the body carries the args, the URL contains no `[object Object]`, and `return=minimal` is not set (so the body is returned).
- [x] Verified the test fails on the pre-fix code (`Received: "GET"`) and passes after the fix.
- [x] All existing `get: true` tests (scalar / array / empty args) are unaffected; no test relied on the old behavior.

## Checklist

- [x] Code formatted (`nx format:check` passes)
- [x] Builds passing (`nx affected --target=build`)
- [x] Type tests passing (`nx test:types postgrest-js`)
- [x] Common types in sync (`codegen:check`)
- [x] Conventional commit

