### PR TITLE
fix(auth): clear local session on signout failures

### DIFF
--- a/packages/core/auth-js/src/GoTrueClient.ts
+++ b/packages/core/auth-js/src/GoTrueClient.ts
@@ -3963,6 +3963,10 @@ export default class GoTrueClient {
     { scope }: SignOut = { scope: 'global' }
   ): Promise<{ error: AuthError | null }> {
     return await this._useSession(async (result) => {
+      const removeCurrentSession = async () => {
+        await this._removeSession()
+        await removeItemAsync(this.storage, `${this.storageKey}-code-verifier`)
+      }
       const { data, error: sessionError } = result
       if (sessionError && !isAuthSessionMissingError(sessionError)) {
         return this._returnResult({ error: sessionError })
@@ -3980,13 +3984,15 @@ export default class GoTrueClient {
               isAuthSessionMissingError(error)
             )
           ) {
+            if (scope !== 'others') {
+              await removeCurrentSession()
+            }
             return this._returnResult({ error })
           }
         }
       }
       if (scope !== 'others') {
-        await this._removeSession()
-        await removeItemAsync(this.storage, `${this.storageKey}-code-verifier`)
+        await removeCurrentSession()
       }
       return this._returnResult({ error: null })
     })

--- a/packages/core/auth-js/test/GoTrueClient.signOut.test.ts
+++ b/packages/core/auth-js/test/GoTrueClient.signOut.test.ts
@@ -1,0 +1,78 @@
+import GoTrueClient from '../src/GoTrueClient'
+import { memoryLocalStorageAdapter } from '../src/lib/local-storage'
+
+const createStoredSession = () => ({
+  access_token: 'test-access-token',
+  refresh_token: 'test-refresh-token',
+  token_type: 'bearer',
+  expires_in: 3600,
+  expires_at: Math.floor(Date.now() / 1000) + 3600,
+  user: {
+    id: 'test-user-id',
+    aud: 'authenticated',
+    role: 'authenticated',
+    email: 'user@example.com',
+    app_metadata: {},
+    user_metadata: {},
+    created_at: new Date(0).toISOString(),
+  },
+})
+
+describe('GoTrueClient signOut offline cleanup', () => {
+  let consoleErrorSpy: jest.SpyInstance
+
+  beforeEach(() => {
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore()
+  })
+
+  test.each(['global', 'local'] as const)(
+    'removes the local session when %s signOut cannot reach the auth server',
+    async (scope) => {
+      const storageKey = `test-signout-offline-${scope}`
+      const storage = memoryLocalStorageAdapter({
+        [storageKey]: JSON.stringify(createStoredSession()),
+        [`${storageKey}-code-verifier`]: 'test-code-verifier',
+      })
+      const mockFetch = jest.fn().mockRejectedValue(new Error('offline'))
+      const client = new GoTrueClient({
+        url: 'http://localhost:9999',
+        autoRefreshToken: false,
+        persistSession: true,
+        storage,
+        storageKey,
+        fetch: mockFetch,
+      })
+
+      const { error } = await client.signOut({ scope })
+
+      expect(error?.name).toBe('AuthRetryableFetchError')
+      expect(await storage.getItem(storageKey)).toBeNull()
+      expect(await storage.getItem(`${storageKey}-code-verifier`)).toBeNull()
+    }
+  )
+
+  test('keeps the current session for others scope when remote signOut fails', async () => {
+    const storageKey = 'test-signout-offline-others'
+    const storage = memoryLocalStorageAdapter({
+      [storageKey]: JSON.stringify(createStoredSession()),
+    })
+    const mockFetch = jest.fn().mockRejectedValue(new Error('offline'))
+    const client = new GoTrueClient({
+      url: 'http://localhost:9999',
+      autoRefreshToken: false,
+      persistSession: true,
+      storage,
+      storageKey,
+      fetch: mockFetch,
+    })
+
+    const { error } = await client.signOut({ scope: 'others' })
+
+    expect(error?.name).toBe('AuthRetryableFetchError')
+    expect(await storage.getItem(storageKey)).not.toBeNull()
+  })
+})


### PR DESCRIPTION
Replaces #2503, which was closed when the fork branch was renamed from `codex/...` to `fix/...`.

## Description

Fixes supabase/supabase-js#2501.

`signOut()` previously returned immediately when the remote logout request produced a retryable/network auth error. For `global` and `local` sign-out scopes that meant the persisted browser/device session remained in storage, so an offline sign-out could reject while leaving the user locally authenticated.

This PR keeps the existing `others` semantics, but ensures `global` and `local` scopes always clear the current local session before returning the remote logout error.

## Testing

- `pnpm install --frozen-lockfile`
- `pnpm --dir packages/core/auth-js exec jest --config jest.config.js test/GoTrueClient.signOut.test.ts --runInBand --silent=false`
- `pnpm nx build auth-js`
- `pnpm prettier --check packages/core/auth-js/src/GoTrueClient.ts packages/core/auth-js/test/GoTrueClient.signOut.test.ts`
- `pnpm exec eslint packages/core/auth-js/test/GoTrueClient.signOut.test.ts`
- `git diff --check`

Note: `pnpm exec eslint packages/core/auth-js/src/GoTrueClient.ts ...` is currently blocked by pre-existing lint errors in `GoTrueClient.ts` (unused variables / no-empty-object-type outside this diff), so I linted the new test file directly and relied on `pnpm nx build auth-js` for the changed source file.
