### PR TITLE
docs(postgrest): fix outdated `cross-fetch` guidance

### DIFF
--- a/packages/core/auth-js/README.md
+++ b/packages/core/auth-js/README.md
@@ -67,7 +67,7 @@ const auth = new AuthClient({ url: GOTRUE_URL })
 
 ### Custom `fetch` implementation
 
-`auth-js` uses the [`cross-fetch`](https://www.npmjs.com/package/cross-fetch) library to make HTTP requests, but an alternative `fetch` implementation can be provided as an option. This is most useful in environments where `cross-fetch` is not compatible, for instance Cloudflare Workers:
+`auth-js` uses the runtime's global `fetch` to make HTTP requests, but an alternative `fetch` implementation can be provided as an option. This is useful in environments where the global `fetch` is unavailable or where you want to customize request behavior:
 
 ```js
 import { AuthClient } from '@supabase/auth-js'

--- a/packages/core/postgrest-js/README.md
+++ b/packages/core/postgrest-js/README.md
@@ -54,7 +54,7 @@ const postgrest = new PostgrestClient(REST_URL)
 
 #### Custom `fetch` implementation
 
-`postgrest-js` uses the [`cross-fetch`](https://www.npmjs.com/package/cross-fetch) library to make HTTP requests, but an alternative `fetch` implementation can be provided as an option. This is most useful in environments where `cross-fetch` is not compatible, for instance Cloudflare Workers:
+`postgrest-js` uses the runtime's global `fetch` to make HTTP requests, but an alternative `fetch` implementation can be provided as an option. This is useful in environments where the global `fetch` is unavailable or where you want to customize request behavior:
 
 ```js
 import { PostgrestClient } from '@supabase/postgrest-js'

--- a/packages/core/supabase-js/README.md
+++ b/packages/core/supabase-js/README.md
@@ -97,7 +97,7 @@ import { createClient } from 'jsr:@supabase/supabase-js@2'
 
 ### Custom `fetch` implementation
 
-`supabase-js` uses the [`cross-fetch`](https://www.npmjs.com/package/cross-fetch) library to make HTTP requests, but an alternative `fetch` implementation can be provided as an option. This is most useful in environments where `cross-fetch` is not compatible, for instance Cloudflare Workers:
+`supabase-js` uses the runtime's global `fetch` to make HTTP requests, but an alternative `fetch` implementation can be provided as an option. This is useful in environments where the global `fetch` is unavailable or where you want to customize request behavior:
 
 ```js
 import { createClient } from '@supabase/supabase-js'

--- a/packages/core/supabase-js/src/SupabaseClient.ts
+++ b/packages/core/supabase-js/src/SupabaseClient.ts
@@ -165,9 +165,9 @@ export default class SupabaseClient<
    * ```
    *
    * @exampleDescription Custom fetch implementation
-   * `supabase-js` uses the [`cross-fetch`](https://www.npmjs.com/package/cross-fetch) library to make HTTP requests,
+   * `supabase-js` uses the runtime's global `fetch` to make HTTP requests,
    * but an alternative `fetch` implementation can be provided as an option.
-   * This is most useful in environments where `cross-fetch` is not compatible (for instance Cloudflare Workers).
+   * This is useful in environments where the global `fetch` is unavailable or where you want to customize request behavior.
    *
    * @example Custom fetch implementation
    * ```js


### PR DESCRIPTION
<!-- Your PR title should follow the conventional commit format:
<type>(<scope>): <description> -->

## 🔍 Description

Was looking into using `@supabase/postgrest-js` for my dogfooding project and noticed that the docs referenced `cross-fetch`. Looked through the repo and didn't see any fetch polyfills (yay!) so I updated the docs to reflect this.



### What changed?

(see above)

### Why was this change needed?

To accurately reflect the dependencies the repo uses

## 📸 Screenshots/Examples

(skipping this)

## 🔄 Breaking changes

<!-- If this PR contains breaking changes, describe them here -->

- [x] This PR contains no breaking changes

## 📋 Checklist

<!-- Ensure all items are checked before submitting -->

- [x] I have read the [Contributing Guidelines](https://github.com/supabase/supabase-js/blob/master/CONTRIBUTING.md)
- [x] My PR title follows the [conventional commit format](https://www.conventionalcommits.org/): `<type>(<scope>): <description>`
- [x] I have run `pnpm nx format` to ensure consistent code formatting
- [x] I have added tests for new functionality (if applicable) (none are applicable)
- [x] I have updated documentation (if applicable)

## 📝 Additional notes

<!-- Add any additional notes, context, or concerns for reviewers -->

<!-- Thank you for contributing to Supabase! 💚 -->
