### PR TITLE
fix(postgrest): pin tstyche target off floating latest

### DIFF
--- a/packages/core/postgrest-js/package.json
+++ b/packages/core/postgrest-js/package.json
@@ -48,7 +48,7 @@
     "test:run": "jest --runInBand --coverage -u",
     "test:smoke": "node test/smoke.cjs && node test/smoke.mjs",
     "test:types": "tstyche",
-    "test:types:ci": "tstyche --target '4.7,5.5,latest'",
+    "test:types:ci": "tstyche --target '4.7,5.5,6.0'",
     "test:types:watch": "chokidar 'src/**/*.ts' 'test/**/*.ts' -c 'npm run test:types'",
     "type-check": "tsc --noEmit --project tsconfig.json",
     "type-check:test": "tsc --noEmit --project tsconfig.test.json"


### PR DESCRIPTION
## Description

Pins the postgrest-js type-testing matrix off the floating `latest` target so CI stops failing on the newly released TypeScript 7.

### What changed?

- `packages/core/postgrest-js/package.json`: the `test:types:ci` script target changed from `'4.7,5.5,latest'` to `'4.7,5.5,6.0'`.

### Why was this change needed?

TypeScript 7.0 (the native Go compiler) reached GA on 2026-07-08. As soon as it landed, tstyche's `latest` target began resolving to `typescript@7.0.2`, which ships without a bundled `lib/typescript.js` (TS 7.0 has no programmatic API until 7.1). tstyche loads the compiler through that API, so it crashed on download:

```
Error: ENOENT: no such file or directory, open '.../TSTyche/typescript@7.0.2/lib/typescript.js'
```

This broke `@supabase/postgrest-js:test:types:ci` on every PR against `master`, regardless of the PR's contents.

The top of the matrix is now pinned to the `6.0` line (currently 6.0.3). TypeScript 6.0 is the last release built on the JavaScript codebase, so it still bundles the programmatic API that tstyche needs, while carrying the stricter TypeScript 7 era semantics. That gives newer type-checking coverage than the previous `latest` behaviour actually delivered, on a compiler tstyche can load. The `4.7` floor is unchanged, so the range of consumer TypeScript versions we verify is unaffected.

## Breaking changes

- [x] This PR contains no breaking changes

Build-tooling only. No source, emitted output, or public types change; consumer-facing behavior is identical.

## Checklist

- [ ] I have read the [Contributing Guidelines](https://github.com/supabase/supabase-js/blob/master/CONTRIBUTING.md)
- [x] My PR title follows the [conventional commit format](https://www.conventionalcommits.org/): `<type>(<scope>): <description>`
- [x] I have run `pnpm nx format` to ensure consistent code formatting
- [ ] I have added tests for new functionality (if applicable)
- [ ] I have updated documentation (if applicable)

## Additional notes

The `6.0` pin replaces the previously floating `latest` target. The top target should return to `latest` (or a pinned `7.x`) once TypeScript 7.1 restores the programmatic API and tstyche adds support for it. Adopting the native TS7 compiler for type-checking is tracked separately.