### PR TITLE
docs(realtime): clarify presence.enabled semantics

### DIFF
--- a/packages/core/realtime-js/README.md
+++ b/packages/core/realtime-js/README.md
@@ -178,6 +178,13 @@ channel.subscribe(async (status) => {
 })
 ```
 
+> `config.presence.enabled` (set automatically if you add an `.on('presence', ...)` listener)
+> controls whether _this_ client receives presence state and updates from other clients —
+> without it, `presenceState()` stays empty for you. It does not affect whether other clients
+> see you: calling `track()` always makes you visible to subscribers that do have presence
+> enabled. On RLS-protected channels, receiving presence updates additionally requires the
+> `presence.read` policy to authorize this client.
+
 ## Postgres CDC
 
 Receive database changes on the client.

--- a/packages/core/realtime-js/src/RealtimeChannel.ts
+++ b/packages/core/realtime-js/src/RealtimeChannel.ts
@@ -47,6 +47,18 @@ export type RealtimeChannelOptions = {
     }
     /**
      * key option is used to track presence payload across clients
+     *
+     * enabled controls whether this client receives presence state and updates from other
+     * clients — set it to true (or add an `.on('presence', ...)` listener, which enables it
+     * automatically) if you want to see who else is present. Without it, this client's
+     * `presenceState()` stays empty and no `presence` events fire for you, because the
+     * underlying presence state machine buffers incoming updates until it has received an
+     * initial snapshot, which is only requested when this flag is set.
+     *
+     * It does not gate the other direction: calling `track()` always makes this client
+     * visible to other subscribers that have presence enabled, regardless of this client's
+     * own `enabled` setting. On RLS-protected (private) channels, receiving presence updates
+     * additionally requires the `presence.read` policy to authorize this client.
      */
     presence?: { key?: string; enabled?: boolean }
     /**
@@ -488,6 +500,11 @@ export default class RealtimeChannel {
   /**
    * Sends the supplied payload to the presence tracker so other subscribers can see that this
    * client is online. Use `untrack` to stop broadcasting presence for the same key.
+   *
+   * Tracking makes this client visible to other subscribers immediately, regardless of this
+   * channel's `config.presence.enabled` setting or whether it has a `presence` listener — that
+   * flag only affects whether *this* client receives presence updates from others (and, on
+   * RLS-protected channels, whether it's authorized to do so).
    *
    * @category Realtime
    */


### PR DESCRIPTION
Clarifies `presence.enabled` semantics in the JSDoc for `RealtimeChannelOptions.config.presence`, `track()`, and the realtime-js README. The flag controls whether *this* client receives presence state and updates from others (it stays empty without it, since diffs are buffered until an initial snapshot arrives); it does not gate whether this client's own `track()` calls are visible to other subscribers, which happens regardless. Docs-only change, no logic modified.

Related: #1536, #2453