### PR TITLE
fix(functions): stop sending API key in Authorization header for function calls

### DIFF
--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -4,6 +4,21 @@ Cross-cutting migration notes for the Supabase JavaScript SDK. One H2 section pe
 
 > **Per-package migrations** (changes scoped to a single SDK like `@supabase/auth-js`) live alongside the package they affect, under `packages/core/<package>/migrations/`. The notes in this file cover changes that span multiple packages or the workspace as a whole.
 
+## Edge Functions auth headers
+
+Edge Function calls (`supabase.functions.invoke()`) now keep the `apikey` and `Authorization` headers distinct, matching the Server SDK pattern:
+
+- The API key is always sent in the **`apikey`** header.
+- **`Authorization`** carries the signed-in user's JWT (or a custom auth token). When there is no user session, a **new-format API key** (`sb_publishable_…` / `sb_secret_…`) is **no longer sent as `Authorization: Bearer <key>`** — new-format keys are not JWTs, and the gateway now accepts `apikey`-only requests (including for `verify_jwt=true` functions).
+
+This does **not** affect other services (Database/PostgREST, Storage, Realtime), and **legacy JWT keys are unchanged** (they are still sent in `Authorization` for backward compatibility).
+
+### What to do
+
+Nothing for the vast majority of users — authenticated calls still send the user's JWT, and unauthenticated calls continue to work via the `apikey` header.
+
+The only impacted case is code that **reads the API key out of the `Authorization` header inside an Edge Function** (e.g. a server-side check on `Bearer sb_...`). Those cases should read the `apikey` header instead, or migrate to [`@supabase/server`](https://supabase.com/blog/introducing-supabase-server) for edge functions.
+
 ## Node.js 18 support dropped (v2.79.0, 2025-10-31)
 
 Starting with version `2.79.0`, all Supabase JavaScript libraries require **Node.js 20 or later**. The `@supabase/node-fetch` polyfill has been removed and native `fetch` is now required.

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -19,6 +19,10 @@ Nothing for the vast majority of users — authenticated calls still send the us
 
 The only impacted case is code that **reads the API key out of the `Authorization` header inside an Edge Function** (e.g. a server-side check on `Bearer sb_...`). Those cases should read the `apikey` header instead, or migrate to [`@supabase/server`](https://supabase.com/blog/introducing-supabase-server) for edge functions.
 
+### Unrecognized API key formats now throw
+
+To keep the header handling correct as the `sb_` key family grows, `createClient()` now validates the key format at construction. A key that starts with `sb_` but is **not** a recognized subtype (`sb_publishable_…` / `sb_secret_…`) throws immediately, indicating that `@supabase/supabase-js` must be upgraded to a version that supports the new key type. Legacy JWT keys (which do not start with `sb_`) are unaffected.
+
 ## Node.js 18 support dropped (v2.79.0, 2025-10-31)
 
 Starting with version `2.79.0`, all Supabase JavaScript libraries require **Node.js 20 or later**. The `@supabase/node-fetch` polyfill has been removed and native `fetch` is now required.

--- a/packages/core/functions-js/src/FunctionsClient.ts
+++ b/packages/core/functions-js/src/FunctionsClient.ts
@@ -88,7 +88,9 @@ export class FunctionsClient {
    * @category Edge Functions
    *
    * @remarks
-   * - Requires an Authorization header.
+   * - The API key is sent in the `apikey` header. The `Authorization` header is reserved
+   *   for the signed-in user's JWT (or a custom auth token) — when there is no session, a
+   *   new-format API key (`sb_publishable_…` / `sb_secret_…`) is not sent as a Bearer token.
    * - Invoke params generally match the [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) spec.
    * - When you pass in a body to your function, we automatically attach the Content-Type header for `Blob`, `ArrayBuffer`, `File`, `FormData` and `String`. If it doesn't match any of these types we assume the payload is `json`, serialize it and attach the `Content-Type` header as `application/json`. You can override this behavior by passing in a `Content-Type` header of your own.
    * - Responses are automatically parsed as `json`, `blob` and `form-data` depending on the `Content-Type` header sent by your function. Responses are parsed as `text` by default.

--- a/packages/core/supabase-js/src/SupabaseClient.ts
+++ b/packages/core/supabase-js/src/SupabaseClient.ts
@@ -89,6 +89,7 @@ export default class SupabaseClient<
   protected rest: PostgrestClient<Database, ClientOptions, SchemaName>
   protected storageKey: string
   protected fetch?: Fetch
+  protected functionsFetch?: Fetch
   protected changedAccessToken?: string
   protected accessToken?: () => Promise<string | null>
 
@@ -364,6 +365,17 @@ export default class SupabaseClient<
       settings.global.fetch,
       settings.tracePropagation
     )
+    // Edge Functions use a dedicated fetch that reserves the Authorization header for a
+    // real user/custom session token — it never falls back to a new-format API key
+    // (that key travels only in the `apikey` header). Other services keep `this.fetch`.
+    this.functionsFetch = fetchWithAuth(
+      supabaseKey,
+      supabaseUrl,
+      this._getAccessToken.bind(this),
+      settings.global.fetch,
+      settings.tracePropagation,
+      { isFunctionsClient: true }
+    )
     this.realtime = this._initRealtimeClient({
       headers: this.headers,
       accessToken: this._getAccessToken.bind(this),
@@ -404,7 +416,7 @@ export default class SupabaseClient<
   get functions(): FunctionsClient {
     return new FunctionsClient(this.functionsUrl.href, {
       headers: this.headers,
-      customFetch: this.fetch,
+      customFetch: this.functionsFetch,
     })
   }
 

--- a/packages/core/supabase-js/src/SupabaseClient.ts
+++ b/packages/core/supabase-js/src/SupabaseClient.ts
@@ -20,7 +20,7 @@ import {
   DEFAULT_REALTIME_OPTIONS,
   DEFAULT_TRACE_PROPAGATION_OPTIONS,
 } from './lib/constants'
-import { fetchWithAuth } from './lib/fetch'
+import { assertSupportedApiKey, fetchWithAuth } from './lib/fetch'
 import {
   applySettingDefaults,
   validateSupabaseUrl,
@@ -315,6 +315,7 @@ export default class SupabaseClient<
   ) {
     const baseUrl = validateSupabaseUrl(supabaseUrl)
     if (!supabaseKey) throw new Error('supabaseKey is required.')
+    assertSupportedApiKey(supabaseKey)
 
     this.realtimeUrl = new URL('realtime/v1', baseUrl)
     this.realtimeUrl.protocol = this.realtimeUrl.protocol.replace('http', 'ws')
@@ -358,23 +359,24 @@ export default class SupabaseClient<
       })
     }
 
+    // The fetch wrappers receive the raw session token (null when there is no session) and
+    // decide the `Authorization` fallback themselves, so the API-key fallback lives in one place.
     this.fetch = fetchWithAuth(
       supabaseKey,
       supabaseUrl,
-      this._getAccessToken.bind(this),
+      this._getSessionToken.bind(this),
       settings.global.fetch,
       settings.tracePropagation
     )
-    // Edge Functions use a dedicated fetch that reserves the Authorization header for a
-    // real user/custom session token — it never falls back to a new-format API key
-    // (that key travels only in the `apikey` header). Other services keep `this.fetch`.
+    // Edge Functions use a dedicated fetch that never falls back to a new-format API key in
+    // the Authorization header (see `isNewApiKey` in ./lib/fetch). Other services use `this.fetch`.
     this.functionsFetch = fetchWithAuth(
       supabaseKey,
       supabaseUrl,
-      this._getAccessToken.bind(this),
+      this._getSessionToken.bind(this),
       settings.global.fetch,
       settings.tracePropagation,
-      { isFunctionsClient: true }
+      { omitApiKeyAsBearer: true }
     )
     this.realtime = this._initRealtimeClient({
       headers: this.headers,
@@ -580,14 +582,23 @@ export default class SupabaseClient<
     return this.realtime.removeAllChannels()
   }
 
-  private async _getAccessToken() {
+  /**
+   * The raw session token — the custom `accessToken` result or the signed-in user's JWT —
+   * or `null` when there is no session. Unlike {@link _getAccessToken} it does not fall back
+   * to `supabaseKey`, so callers can distinguish "no session" from "has session".
+   */
+  private async _getSessionToken(): Promise<string | null> {
     if (this.accessToken) {
       return await this.accessToken()
     }
 
     const { data } = await this.auth.getSession()
 
-    return data.session?.access_token ?? this.supabaseKey
+    return data.session?.access_token ?? null
+  }
+
+  private async _getAccessToken() {
+    return (await this._getSessionToken()) ?? this.supabaseKey
   }
 
   private _initSupabaseAuthClient(

--- a/packages/core/supabase-js/src/lib/fetch.ts
+++ b/packages/core/supabase-js/src/lib/fetch.ts
@@ -24,10 +24,28 @@ export const resolveHeadersConstructor = () => {
 /**
  * New-format Supabase API keys (`sb_publishable_…` / `sb_secret_…`) are not JWTs and
  * must never be sent as a Bearer token — they belong only in the `apikey` header.
- * Legacy (JWT) keys predate this format and keep their existing behavior.
+ * Legacy (JWT) keys predate this format (they don't start with `sb_`) and keep their
+ * existing behavior. Any other `sb_`-prefixed key is an unrecognized future subtype;
+ * see {@link assertSupportedApiKey}.
  */
 const isNewApiKey = (key: string): boolean =>
   key.startsWith('sb_publishable_') || key.startsWith('sb_secret_')
+
+/**
+ * Fail fast on an `sb_`-family key whose subtype this SDK version does not recognize, so a
+ * future key type can never be silently mistreated as a legacy JWT and sent as a Bearer
+ * token. Recognized new-format keys and legacy JWT keys (no `sb_` prefix) pass through.
+ * The key itself is never included in the message to avoid leaking secret keys.
+ */
+export const assertSupportedApiKey = (key: string): void => {
+  if (key.startsWith('sb_') && !isNewApiKey(key)) {
+    throw new Error(
+      '@supabase/supabase-js: Unrecognized Supabase API key format. Expected a legacy JWT key ' +
+        'or a new-format key (sb_publishable_… / sb_secret_…). This "sb_" key type is not ' +
+        'supported by this version of the SDK — please upgrade @supabase/supabase-js.'
+    )
+  }
+}
 
 export const fetchWithAuth = (
   supabaseKey: string,
@@ -35,7 +53,7 @@ export const fetchWithAuth = (
   getAccessToken: () => Promise<string | null>,
   customFetch?: Fetch,
   tracePropagationOptions?: TracePropagationOptions,
-  options?: { isFunctionsClient?: boolean }
+  options?: { omitApiKeyAsBearer?: boolean }
 ): Fetch => {
   const fetch = resolveFetch(customFetch)
   const HeadersConstructor = resolveHeadersConstructor()
@@ -48,8 +66,13 @@ export const fetchWithAuth = (
     ? getDefaultPropagationTargets(supabaseUrl)
     : null
 
+  // Whether the API key may be used as the `Authorization` Bearer fallback when there is no
+  // session token. Disabled for Edge Functions with a new-format key (see `isNewApiKey`).
+  // Static per instance, so it is computed once here rather than on every request.
+  const allowKeyAsBearer = !(options?.omitApiKeyAsBearer && isNewApiKey(supabaseKey))
+
   return async (input, init) => {
-    const accessToken = (await getAccessToken()) ?? supabaseKey
+    const realToken = await getAccessToken()
     let headers = new HeadersConstructor(init?.headers)
 
     if (!headers.has('apikey')) {
@@ -57,14 +80,9 @@ export const fetchWithAuth = (
     }
 
     if (!headers.has('Authorization')) {
-      // Edge Functions: a new-format API key must never be sent as a Bearer token —
-      // it belongs only in the `apikey` header. Reserve Authorization for a real user
-      // or custom session token. `accessToken === supabaseKey` means there is no such
-      // token (getAccessToken falls back to the key). Legacy JWT keys are unchanged.
-      const omitKeyInAuth =
-        options?.isFunctionsClient && accessToken === supabaseKey && isNewApiKey(supabaseKey)
-      if (!omitKeyInAuth) {
-        headers.set('Authorization', `Bearer ${accessToken}`)
+      const bearer = realToken ?? (allowKeyAsBearer ? supabaseKey : null)
+      if (bearer) {
+        headers.set('Authorization', `Bearer ${bearer}`)
       }
     }
 

--- a/packages/core/supabase-js/src/lib/fetch.ts
+++ b/packages/core/supabase-js/src/lib/fetch.ts
@@ -21,12 +21,21 @@ export const resolveHeadersConstructor = () => {
   return Headers
 }
 
+/**
+ * New-format Supabase API keys (`sb_publishable_…` / `sb_secret_…`) are not JWTs and
+ * must never be sent as a Bearer token — they belong only in the `apikey` header.
+ * Legacy (JWT) keys predate this format and keep their existing behavior.
+ */
+const isNewApiKey = (key: string): boolean =>
+  key.startsWith('sb_publishable_') || key.startsWith('sb_secret_')
+
 export const fetchWithAuth = (
   supabaseKey: string,
   supabaseUrl: string,
   getAccessToken: () => Promise<string | null>,
   customFetch?: Fetch,
-  tracePropagationOptions?: TracePropagationOptions
+  tracePropagationOptions?: TracePropagationOptions,
+  options?: { isFunctionsClient?: boolean }
 ): Fetch => {
   const fetch = resolveFetch(customFetch)
   const HeadersConstructor = resolveHeadersConstructor()
@@ -48,7 +57,15 @@ export const fetchWithAuth = (
     }
 
     if (!headers.has('Authorization')) {
-      headers.set('Authorization', `Bearer ${accessToken}`)
+      // Edge Functions: a new-format API key must never be sent as a Bearer token —
+      // it belongs only in the `apikey` header. Reserve Authorization for a real user
+      // or custom session token. `accessToken === supabaseKey` means there is no such
+      // token (getAccessToken falls back to the key). Legacy JWT keys are unchanged.
+      const omitKeyInAuth =
+        options?.isFunctionsClient && accessToken === supabaseKey && isNewApiKey(supabaseKey)
+      if (!omitKeyInAuth) {
+        headers.set('Authorization', `Bearer ${accessToken}`)
+      }
     }
 
     if (traceTargets) {

--- a/packages/core/supabase-js/test/unit/SupabaseClient.test.ts
+++ b/packages/core/supabase-js/test/unit/SupabaseClient.test.ts
@@ -488,6 +488,38 @@ describe('SupabaseClient', () => {
         expect(options.headers.get('Authorization')).toBe(`Bearer ${KEY}`)
         expect(options.headers.get('apikey')).toBe(KEY)
       })
+
+      test('functions omit Authorization for a new-format key without a session, other services do not', async () => {
+        const NEW_KEY = 'sb_publishable_test123'
+        const mockFetch = jest.fn().mockResolvedValue({
+          ok: true,
+          status: 200,
+          statusText: 'OK',
+          text: () => Promise.resolve('{}'),
+          headers: new Headers(),
+          json: () => Promise.resolve({}),
+        })
+
+        const client = createClient(URL, NEW_KEY, {
+          global: { fetch: mockFetch },
+        })
+
+        client.auth.getSession = jest.fn().mockResolvedValue({
+          data: { session: null },
+        })
+
+        // Functions: no session + new-format key → apikey only, no Authorization.
+        await client.functions.invoke('test-function')
+        const [, functionsOptions] = mockFetch.mock.calls[0]
+        expect(functionsOptions.headers.get('apikey')).toBe(NEW_KEY)
+        expect(functionsOptions.headers.get('Authorization')).toBeNull()
+
+        // Other services stay uniform: the key is still sent in Authorization.
+        await client.from('test').select('*')
+        const [, restOptions] = mockFetch.mock.calls[1]
+        expect(restOptions.headers.get('Authorization')).toBe(`Bearer ${NEW_KEY}`)
+        expect(restOptions.headers.get('apikey')).toBe(NEW_KEY)
+      })
     })
   })
 })

--- a/packages/core/supabase-js/test/unit/SupabaseClient.test.ts
+++ b/packages/core/supabase-js/test/unit/SupabaseClient.test.ts
@@ -29,6 +29,17 @@ describe('SupabaseClient', () => {
     expect(() => createClient(URL, '')).toThrow('supabaseKey is required.')
   })
 
+  test('should validate the API key format', () => {
+    // Unrecognized sb_ subtype → fail fast, signalling an SDK upgrade is needed.
+    expect(() => createClient(URL, 'sb_unknown_abc123')).toThrow(
+      'Unrecognized Supabase API key format'
+    )
+    // Recognized new-format keys and legacy JWT keys are accepted.
+    expect(() => createClient(URL, 'sb_publishable_abc123')).not.toThrow()
+    expect(() => createClient(URL, 'sb_secret_abc123')).not.toThrow()
+    expect(() => createClient(URL, KEY)).not.toThrow()
+  })
+
   test('should validate supabaseUrl', () => {
     expect(() => createClient('https://xyz123.supabase.co', KEY)).not.toThrow()
     expect(() => createClient('http://localhost:54321', KEY)).not.toThrow()

--- a/packages/core/supabase-js/test/unit/fetch.test.ts
+++ b/packages/core/supabase-js/test/unit/fetch.test.ts
@@ -147,6 +147,107 @@ describe('fetch module', () => {
       expect(mockSet).not.toHaveBeenCalledWith('Authorization', expect.stringContaining('Bearer'))
     })
 
+    describe('isFunctionsClient option', () => {
+      const setupHeaders = (existing: string[] = []) => {
+        const mockSet = jest.fn()
+        const mockHeadersImpl = jest.fn().mockReturnValue({
+          has: jest.fn().mockImplementation((key) => existing.includes(key)),
+          set: mockSet,
+        })
+        ;(global as any).fetch = jest.fn().mockResolvedValue({ ok: true })
+        ;(global as any).Headers = mockHeadersImpl
+        return mockSet
+      }
+
+      test('omits Authorization for a new-format key when there is no session', async () => {
+        const mockSet = setupHeaders()
+        const supabaseKey = 'sb_publishable_abc123'
+        const getAccessToken = jest.fn().mockResolvedValue(null)
+
+        const authFetch = fetchWithAuth(
+          supabaseKey,
+          'https://myproject.supabase.co',
+          getAccessToken,
+          undefined,
+          undefined,
+          { isFunctionsClient: true }
+        )
+        await authFetch('https://example.com')
+
+        expect(mockSet).toHaveBeenCalledWith('apikey', supabaseKey)
+        expect(mockSet).not.toHaveBeenCalledWith('Authorization', expect.stringContaining('Bearer'))
+      })
+
+      test('sends Authorization for a new-format key when a session token exists', async () => {
+        const mockSet = setupHeaders()
+        const supabaseKey = 'sb_publishable_abc123'
+        const getAccessToken = jest.fn().mockResolvedValue('user-jwt')
+
+        const authFetch = fetchWithAuth(
+          supabaseKey,
+          'https://myproject.supabase.co',
+          getAccessToken,
+          undefined,
+          undefined,
+          { isFunctionsClient: true }
+        )
+        await authFetch('https://example.com')
+
+        expect(mockSet).toHaveBeenCalledWith('Authorization', 'Bearer user-jwt')
+      })
+
+      test('keeps sending a legacy (JWT) key in Authorization when there is no session', async () => {
+        const mockSet = setupHeaders()
+        const supabaseKey = 'header.payload.signature'
+        const getAccessToken = jest.fn().mockResolvedValue(null)
+
+        const authFetch = fetchWithAuth(
+          supabaseKey,
+          'https://myproject.supabase.co',
+          getAccessToken,
+          undefined,
+          undefined,
+          { isFunctionsClient: true }
+        )
+        await authFetch('https://example.com')
+
+        expect(mockSet).toHaveBeenCalledWith('Authorization', `Bearer ${supabaseKey}`)
+      })
+
+      test('preserves a caller-supplied Authorization header', async () => {
+        const mockSet = setupHeaders(['Authorization'])
+        const supabaseKey = 'sb_publishable_abc123'
+        const getAccessToken = jest.fn().mockResolvedValue('user-jwt')
+
+        const authFetch = fetchWithAuth(
+          supabaseKey,
+          'https://myproject.supabase.co',
+          getAccessToken,
+          undefined,
+          undefined,
+          { isFunctionsClient: true }
+        )
+        await authFetch('https://example.com')
+
+        expect(mockSet).not.toHaveBeenCalledWith('Authorization', expect.anything())
+      })
+
+      test('non-functions fetch still sends a new-format key in Authorization (scoping guard)', async () => {
+        const mockSet = setupHeaders()
+        const supabaseKey = 'sb_publishable_abc123'
+        const getAccessToken = jest.fn().mockResolvedValue(null)
+
+        const authFetch = fetchWithAuth(
+          supabaseKey,
+          'https://myproject.supabase.co',
+          getAccessToken
+        )
+        await authFetch('https://example.com')
+
+        expect(mockSet).toHaveBeenCalledWith('Authorization', `Bearer ${supabaseKey}`)
+      })
+    })
+
     describe('trace propagation', () => {
       test('should not inject trace headers by default (no options)', async () => {
         const mockResponse = { ok: true }

--- a/packages/core/supabase-js/test/unit/fetch.test.ts
+++ b/packages/core/supabase-js/test/unit/fetch.test.ts
@@ -1,4 +1,9 @@
-import { resolveFetch, resolveHeadersConstructor, fetchWithAuth } from '../../src/lib/fetch'
+import {
+  resolveFetch,
+  resolveHeadersConstructor,
+  fetchWithAuth,
+  assertSupportedApiKey,
+} from '../../src/lib/fetch'
 
 jest.mock('@supabase/tracing', () => {
   const actual = jest.requireActual('@supabase/tracing')
@@ -147,7 +152,7 @@ describe('fetch module', () => {
       expect(mockSet).not.toHaveBeenCalledWith('Authorization', expect.stringContaining('Bearer'))
     })
 
-    describe('isFunctionsClient option', () => {
+    describe('omitApiKeyAsBearer option', () => {
       const setupHeaders = (existing: string[] = []) => {
         const mockSet = jest.fn()
         const mockHeadersImpl = jest.fn().mockReturnValue({
@@ -170,7 +175,7 @@ describe('fetch module', () => {
           getAccessToken,
           undefined,
           undefined,
-          { isFunctionsClient: true }
+          { omitApiKeyAsBearer: true }
         )
         await authFetch('https://example.com')
 
@@ -189,7 +194,7 @@ describe('fetch module', () => {
           getAccessToken,
           undefined,
           undefined,
-          { isFunctionsClient: true }
+          { omitApiKeyAsBearer: true }
         )
         await authFetch('https://example.com')
 
@@ -207,7 +212,7 @@ describe('fetch module', () => {
           getAccessToken,
           undefined,
           undefined,
-          { isFunctionsClient: true }
+          { omitApiKeyAsBearer: true }
         )
         await authFetch('https://example.com')
 
@@ -225,14 +230,14 @@ describe('fetch module', () => {
           getAccessToken,
           undefined,
           undefined,
-          { isFunctionsClient: true }
+          { omitApiKeyAsBearer: true }
         )
         await authFetch('https://example.com')
 
         expect(mockSet).not.toHaveBeenCalledWith('Authorization', expect.anything())
       })
 
-      test('non-functions fetch still sends a new-format key in Authorization (scoping guard)', async () => {
+      test('without the option, a new-format key is still sent in Authorization (scoping guard)', async () => {
         const mockSet = setupHeaders()
         const supabaseKey = 'sb_publishable_abc123'
         const getAccessToken = jest.fn().mockResolvedValue(null)
@@ -245,6 +250,33 @@ describe('fetch module', () => {
         await authFetch('https://example.com')
 
         expect(mockSet).toHaveBeenCalledWith('Authorization', `Bearer ${supabaseKey}`)
+      })
+    })
+
+    describe('assertSupportedApiKey', () => {
+      test('throws for an unrecognized sb_ key subtype', () => {
+        expect(() => assertSupportedApiKey('sb_unknown_abc123')).toThrow(
+          /Unrecognized Supabase API key format/
+        )
+      })
+
+      test('never includes the key in the error message', () => {
+        const key = 'sb_futuretype_supersecretvalue'
+        expect.assertions(1)
+        try {
+          assertSupportedApiKey(key)
+        } catch (err) {
+          expect((err as Error).message).not.toContain(key)
+        }
+      })
+
+      test.each([
+        'sb_publishable_abc123',
+        'sb_secret_abc123',
+        'header.payload.signature',
+        'anon-key',
+      ])('accepts recognized / legacy key %p', (key) => {
+        expect(() => assertSupportedApiKey(key)).not.toThrow()
       })
     })
 


### PR DESCRIPTION
## Description

Edge Function calls (`supabase.functions.invoke()`) no longer put the project API key in the `Authorization` header when there is no user session. The key is sent only in the `apikey` header, and `Authorization` is reserved for a real user (or custom) session token, matching the Server SDK pattern.

### What changed?

- `packages/core/supabase-js/src/lib/fetch.ts`: `fetchWithAuth` accepts a new optional `{ isFunctionsClient }` flag. When set, it no longer falls back to sending the API key as `Authorization: Bearer <key>`, but only for new-format keys (`sb_publishable_...` / `sb_secret_...`). A real session/custom token is still sent, and the `apikey` header is unchanged.
- `packages/core/supabase-js/src/SupabaseClient.ts`: added a dedicated `functionsFetch` built with `{ isFunctionsClient: true }`. The `functions` getter uses it; REST (PostgREST), Storage, and Realtime keep the shared `fetch` and are unaffected.
- `packages/core/functions-js/src/FunctionsClient.ts`: updated the `invoke` JSDoc to describe the `apikey` vs `Authorization` header semantics.
- `docs/MIGRATION.md`: added an "Edge Functions auth headers" section documenting the behavior and the one edge case that is affected.
- Tests: added unit coverage in `fetch.test.ts` for the `isFunctionsClient` option and an integration case in `SupabaseClient.test.ts` proving functions omit `Authorization` for a new-format key with no session while other services do not.

### Why was this change needed?

New-format API keys (`sb_publishable_...` / `sb_secret_...`) are not JWTs, so sending them as `Authorization: Bearer <key>` caused the gateway to reject the request with "invalid token format." A platform apikey-compatibility patch (now GA) lets `verify_jwt=true` functions be called with only the `apikey` header, so the SDK no longer needs to duplicate the key into `Authorization`. This aligns Functions with the Server SDK convention: `Authorization` is for user/custom tokens only.

Closes SDK-1050.

## Screenshots/Examples

Unauthenticated function call with a new-format key:

Before:
```
apikey: sb_publishable_...
Authorization: Bearer sb_publishable_...   # rejected as "invalid token format"
```

After:
```
apikey: sb_publishable_...
# no Authorization header
```

Authenticated call (unchanged):
```
apikey: sb_publishable_...
Authorization: Bearer <user_jwt>
```

## Breaking changes

The change is scoped to Edge Functions only, and legacy JWT keys keep their existing behavior (still sent in `Authorization` for backward compatibility), so this is not a breaking change in practice. The only impacted case is code that reads the API key out of the `Authorization` header inside an Edge Function; those should read the `apikey` header instead, or migrate to `@supabase/server`.

- [x] This PR contains no breaking changes

## Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/supabase/supabase-js/blob/master/CONTRIBUTING.md)
- [x] My PR title follows the [conventional commit format](https://www.conventionalcommits.org/): `<type>(<scope>): <description>`
- [ ] I have run `pnpm nx format` to ensure consistent code formatting
- [x] I have added tests for new functionality (if applicable)
- [x] I have updated documentation (if applicable)

## Additional notes

Scope is intentionally limited to new-format keys so there is zero regression risk for self-hosted or legacy-key users on older gateways. Moving to an unconditional drop for all key types later is a one-line change (removing the key-format guard in `fetch.ts`), best done on v3 or once apikey-compatibility is universal.