### PR TITLE
refactor(auth): build PKCE verifier from a Uint8Array and drop deprecated substr

### DIFF
--- a/packages/core/auth-js/src/lib/helpers.ts
+++ b/packages/core/auth-js/src/lib/helpers.ts
@@ -259,13 +259,12 @@ export function retryable<T>(
 }
 
 function dec2hex(dec: number) {
-  return ('0' + dec.toString(16)).substr(-2)
+  return ('0' + dec.toString(16)).slice(-2)
 }
 
 // Functions below taken from: https://stackoverflow.com/questions/63309409/creating-a-code-verifier-and-challenge-for-pkce-auth-on-spotify-api-in-reactjs
 export function generatePKCEVerifier() {
   const verifierLength = 56
-  const array = new Uint32Array(verifierLength)
   if (typeof crypto === 'undefined') {
     const charSet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~'
     const charSetLen = charSet.length
@@ -275,6 +274,11 @@ export function generatePKCEVerifier() {
     }
     return verifier
   }
+  // Each byte maps to two hex characters, so a 56-byte buffer yields a
+  // 112-character verifier (within RFC 7636's 43-128 range). A Uint8Array
+  // requests exactly the entropy consumed; a Uint32Array would draw 4x the
+  // bytes and discard three of every four.
+  const array = new Uint8Array(verifierLength)
   crypto.getRandomValues(array)
   return Array.from(array, dec2hex).join('')
 }

--- a/packages/core/auth-js/test/helpers.test.ts
+++ b/packages/core/auth-js/test/helpers.test.ts
@@ -4,6 +4,7 @@ import {
   decodeJWT,
   generateCallbackId,
   generatePKCEFlowId,
+  generatePKCEVerifier,
   getAlgorithm,
   getItemAsync,
   parseParametersFromURL,
@@ -272,6 +273,24 @@ describe('getAlgorithm', () => {
   })
   it('should throw if invalid alg claim', () => {
     expect(() => getAlgorithm('EdDSA' as any)).toThrow(new Error('Invalid alg claim'))
+  })
+})
+
+describe('generatePKCEVerifier', () => {
+  it('should generate a verifier within the RFC 7636 length range', () => {
+    const verifier = generatePKCEVerifier()
+    expect(verifier.length).toBeGreaterThanOrEqual(43)
+    expect(verifier.length).toBeLessThanOrEqual(128)
+  })
+
+  it('should only use RFC 7636 unreserved characters', () => {
+    const verifier = generatePKCEVerifier()
+    // unreserved = ALPHA / DIGIT / "-" / "." / "_" / "~"
+    expect(verifier).toMatch(/^[A-Za-z0-9\-._~]+$/)
+  })
+
+  it('should generate a unique verifier on each call', () => {
+    expect(generatePKCEVerifier()).not.toEqual(generatePKCEVerifier())
   })
 })
 


### PR DESCRIPTION
## 🔍 Description

### What changed?

`generatePKCEVerifier()` built the PKCE code verifier from a `Uint32Array(56)` but kept only the low byte of each element (via `dec2hex`). This switches it to a `Uint8Array(56)` and replaces the deprecated `String.prototype.substr` with `slice`. The typed-array allocation was also moved inside the `crypto` branch so the no-WebCrypto fallback no longer allocates an unused buffer.

### Why was this change needed?

- **Over-allocation of CSPRNG output:** `new Uint32Array(56)` draws 224 bytes from `crypto.getRandomValues`, but `dec2hex` (`('0' + dec.toString(16)).substr(-2)`) keeps only the last hex pair — the low byte — discarding 3 of every 4 bytes. A `Uint8Array(56)` requests exactly the 56 bytes actually consumed.
- **Deprecated API:** `String.prototype.substr()` is a [legacy/deprecated feature](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr); `slice(-2)` is the standard equivalent.

**No behavior change.** The output is byte-for-byte equivalent: 56 bytes → two hex chars each → the same 112-character, hex-only verifier (well within RFC 7636's 43–128 range). The low byte of a uniform `Uint32` is itself uniform, so the entropy distribution is identical — this only stops requesting (and discarding) 4× the randomness.

## 🔄 Breaking changes

- [x] This PR contains no breaking changes

## 📋 Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/supabase/supabase-js/blob/master/CONTRIBUTING.md)
- [x] My PR title follows the [conventional commit format](https://www.conventionalcommits.org/): `<type>(<scope>): <description>`
- [x] I have run `pnpm nx format` to ensure consistent code formatting
- [x] I have added tests for new functionality (if applicable)
- [ ] I have updated documentation (if applicable)

## 📝 Additional notes

Added a `generatePKCEVerifier` test block (length within the RFC 7636 range, unreserved charset, uniqueness). Verified locally: `jest test/helpers.test.ts` → 27 passed, `tsc -p tsconfig.json` → clean, `prettier --check` → clean.
