### PR TITLE
fix(functions): match response Content-Type case-insensitively

### DIFF
--- a/packages/core/functions-js/src/FunctionsClient.ts
+++ b/packages/core/functions-js/src/FunctionsClient.ts
@@ -298,7 +298,12 @@ export class FunctionsClient {
         throw new FunctionsHttpError(response)
       }
 
-      let responseType = (response.headers.get('Content-Type') ?? 'text/plain').split(';')[0].trim()
+      // HTTP media types are case-insensitive (RFC 9110), so normalize before
+      // matching — otherwise an "Application/JSON" response falls through to text.
+      let responseType = (response.headers.get('Content-Type') ?? 'text/plain')
+        .split(';')[0]
+        .trim()
+        .toLowerCase()
       let data: any
       if (responseType === 'application/json') {
         data = await response.json()

--- a/packages/core/functions-js/test/spec/response-content-type.spec.ts
+++ b/packages/core/functions-js/test/spec/response-content-type.spec.ts
@@ -1,0 +1,42 @@
+import 'jest'
+
+import { FunctionsClient } from '../../src/index'
+
+/**
+ * Unit tests (no relay) for response body parsing based on the response
+ * Content-Type header. HTTP media types are case-insensitive (RFC 9110), so the
+ * client must match them regardless of casing.
+ */
+describe('response Content-Type parsing', () => {
+  const makeClient = (contentType: string, body: string) => {
+    const customFetch = jest.fn(
+      async () =>
+        new Response(body, {
+          status: 200,
+          headers: { 'Content-Type': contentType },
+        })
+    ) as any
+    return new FunctionsClient('http://localhost', { customFetch })
+  }
+
+  test('parses JSON when Content-Type is lowercase', async () => {
+    const client = makeClient('application/json', JSON.stringify({ foo: 'bar' }))
+    const { data, error } = await client.invoke('fn', {})
+    expect(error).toBeNull()
+    expect(data).toEqual({ foo: 'bar' })
+  })
+
+  test('parses JSON when Content-Type has mixed casing', async () => {
+    const client = makeClient('Application/JSON; charset=utf-8', JSON.stringify({ foo: 'bar' }))
+    const { data, error } = await client.invoke('fn', {})
+    expect(error).toBeNull()
+    expect(data).toEqual({ foo: 'bar' })
+  })
+
+  test('parses JSON when Content-Type is uppercase', async () => {
+    const client = makeClient('APPLICATION/JSON', JSON.stringify({ foo: 'bar' }))
+    const { data, error } = await client.invoke('fn', {})
+    expect(error).toBeNull()
+    expect(data).toEqual({ foo: 'bar' })
+  })
+})


### PR DESCRIPTION
## 🔍 Description

### What changed?

`FunctionsClient.invoke()` matched the response `Content-Type` case-sensitively when deciding how to parse the body (`responseType === 'application/json'`, etc.). This normalizes the media type to lower case before matching.

### Why was this change needed?

HTTP media types are case-insensitive ([RFC 9110 §8.3.1](https://www.rfc-editor.org/rfc/rfc9110#name-media-type)). If an Edge Function responds with `Content-Type: Application/JSON` (or `APPLICATION/JSON`), the client currently falls through to the `text` branch and returns the raw, unparsed string instead of the parsed JSON object.

It's also inconsistent with the **request** side, which already detects the caller's `Content-Type` case-insensitively (`key.toLowerCase() === 'content-type'`); only the response side wasn't.

## 🔄 Breaking changes

- [x] This PR contains no breaking changes

The compared media types are all lower case already, so lower-casing the incoming value only makes matching more tolerant.

## 📋 Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/supabase/supabase-js/blob/master/CONTRIBUTING.md)
- [x] My PR title follows the [conventional commit format](https://www.conventionalcommits.org/)
- [x] I have run `pnpm nx format` to ensure consistent code formatting
- [x] I have added tests for new functionality (if applicable)
- [ ] I have updated documentation (if applicable)

## 📝 Additional notes

Added `test/spec/response-content-type.spec.ts` — a unit test (no relay) using a mocked `customFetch` asserting that lowercase, mixed-case, and uppercase `application/json` responses all parse as JSON. Verified locally: the mixed/upper cases fail without the change and pass with it; `jest` (new spec) → 3 passed, `tsc --noEmit` → clean, `prettier --check` → clean.
