### PR TITLE
fix(realtime): encode broadcast header fields as UTF-8

### DIFF
--- a/packages/core/realtime-js/src/lib/serializer.ts
+++ b/packages/core/realtime-js/src/lib/serializer.ts
@@ -62,19 +62,24 @@ export default class Serializer {
     encodingType: number,
     encodedPayload: ArrayBuffer
   ) {
-    const topic = message.topic
-    const ref = message.ref ?? ''
-    const joinRef = message.join_ref ?? ''
-    const userEvent = message.payload.event
+    // Encode each header field as UTF-8. The length prefixes are byte counts and
+    // the decode side uses TextDecoder (UTF-8), so measuring with String.length
+    // and writing with charCodeAt would corrupt any multi-byte character (e.g.
+    // accents or emoji) and desynchronize the buffer.
+    const encoder = new TextEncoder()
+    const topic = encoder.encode(message.topic)
+    const ref = encoder.encode(message.ref ?? '')
+    const joinRef = encoder.encode(message.join_ref ?? '')
+    const userEvent = encoder.encode(message.payload.event)
 
     // Filter metadata based on allowed keys
     const rest = this.allowedMetadataKeys
       ? this._pick(message.payload, this.allowedMetadataKeys)
       : {}
 
-    const metadata = Object.keys(rest).length === 0 ? '' : JSON.stringify(rest)
+    const metadata = encoder.encode(Object.keys(rest).length === 0 ? '' : JSON.stringify(rest))
 
-    // Validate lengths don't exceed uint8 max value (255)
+    // Validate byte lengths don't exceed uint8 max value (255)
     if (joinRef.length > 255) {
       throw new Error(`joinRef length ${joinRef.length} exceeds maximum of 255`)
     }
@@ -100,7 +105,8 @@ export default class Serializer {
       metadata.length
 
     const header = new ArrayBuffer(this.HEADER_LENGTH + metaLength)
-    let view = new DataView(header)
+    const view = new DataView(header)
+    const bytes = new Uint8Array(header)
     let offset = 0
 
     view.setUint8(offset++, this.KINDS.userBroadcastPush) // kind
@@ -110,11 +116,16 @@ export default class Serializer {
     view.setUint8(offset++, userEvent.length)
     view.setUint8(offset++, metadata.length)
     view.setUint8(offset++, encodingType)
-    Array.from(joinRef, (char) => view.setUint8(offset++, char.charCodeAt(0)))
-    Array.from(ref, (char) => view.setUint8(offset++, char.charCodeAt(0)))
-    Array.from(topic, (char) => view.setUint8(offset++, char.charCodeAt(0)))
-    Array.from(userEvent, (char) => view.setUint8(offset++, char.charCodeAt(0)))
-    Array.from(metadata, (char) => view.setUint8(offset++, char.charCodeAt(0)))
+    bytes.set(joinRef, offset)
+    offset += joinRef.length
+    bytes.set(ref, offset)
+    offset += ref.length
+    bytes.set(topic, offset)
+    offset += topic.length
+    bytes.set(userEvent, offset)
+    offset += userEvent.length
+    bytes.set(metadata, offset)
+    offset += metadata.length
 
     var combined = new Uint8Array(header.byteLength + encodedPayload.byteLength)
     combined.set(new Uint8Array(header), 0)

--- a/packages/core/realtime-js/test/serializer.test.ts
+++ b/packages/core/realtime-js/test/serializer.test.ts
@@ -103,6 +103,38 @@ describe('binary', () => {
     expect(decoder.decode(result as ArrayBuffer)).toBe(bin)
   })
 
+  it('encodes a non-ASCII user event as UTF-8', async () => {
+    const serializer = new Serializer()
+    const event = 'café-🎉'
+
+    const result = (await encodeAsync(serializer, {
+      join_ref: '10',
+      ref: '1',
+      topic: 'top',
+      event: 'broadcast',
+      payload: {
+        type: 'broadcast',
+        event,
+        payload: { a: 'b' },
+      },
+    })) as ArrayBuffer
+
+    const view = new DataView(result)
+    const joinRefLen = view.getUint8(1)
+    const refLen = view.getUint8(2)
+    const topicLen = view.getUint8(3)
+    const userEventLen = view.getUint8(4)
+
+    // The length prefix must be the UTF-8 byte length, not the JS string length.
+    const expectedBytes = new TextEncoder().encode(event)
+    expect(userEventLen).toBe(expectedBytes.length)
+
+    // The written bytes must round-trip through TextDecoder, as the decode side does.
+    const eventOffset = 1 + 6 + joinRefLen + refLen + topicLen
+    const eventBytes = new Uint8Array(result, eventOffset, userEventLen)
+    expect(new TextDecoder().decode(eventBytes)).toBe(event)
+  })
+
   it('encodes user broadcast push with JSON payload with allowed metadata', async () => {
     const serializer = new Serializer(['extra'])
 


### PR DESCRIPTION
## 🔍 Description

### What changed?

In the binary broadcast serializer, the header fields (`join_ref`, `ref`, `topic`, `event`, `metadata`) are now length-prefixed and written as **UTF-8 bytes**, instead of using `String.length` for the size prefix and `charCodeAt(0)` for the bytes.

### Why was this change needed?

The decode side reads these fields with `TextDecoder` (UTF-8), but the encode side measured them with `String.length` (UTF-16 code units) and wrote them with `char.charCodeAt(0)` (one truncated byte per code unit). For any non-ASCII value — e.g. a broadcast `event` name like `café` or an emoji — this:

- writes the wrong length prefix (`café` → `4` instead of `5` UTF-8 bytes),
- corrupts multi-byte characters (`café` decodes back as `caf�`),
- desynchronizes the whole buffer for characters outside the BMP (`String.length` counts 2 code units for `🎉`, but `Array.from(...)` iterated 1 code point, so the declared size and the bytes written disagreed).

Using `TextEncoder` + `Uint8Array.set()` makes the encode side byte-accurate and consistent with the UTF-8 decode. ASCII values are unaffected (UTF-8 bytes equal the char codes and byte length equals string length), so the existing tests are unchanged.

## 🔄 Breaking changes

- [x] This PR contains no breaking changes

## 📋 Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/supabase/supabase-js/blob/master/CONTRIBUTING.md)
- [x] My PR title follows the [conventional commit format](https://www.conventionalcommits.org/)
- [x] I have run `pnpm nx format` to ensure consistent code formatting
- [x] I have added tests for new functionality (if applicable)
- [ ] I have updated documentation (if applicable)

## 📝 Additional notes

Added a `binary` test that encodes a non-ASCII event (`café-🎉`) and asserts the length prefix equals the UTF-8 byte length and that the written bytes round-trip through `TextDecoder`. The test fails on `master` (`expected 7 to be 10`) and passes with this change. Verified locally: `vitest run test/serializer.test.ts` → 24 passed, `tsc --noEmit` → clean, `prettier --check` → clean.
