### PR TITLE
fix(storage): encode metadata as UTF-8 in browsers without Buffer

### DIFF
--- a/packages/core/storage-js/src/packages/StorageFileApi.ts
+++ b/packages/core/storage-js/src/packages/StorageFileApi.ts
@@ -1489,7 +1489,9 @@ export default class StorageFileApi extends BaseApiClient<StorageError> {
     if (typeof Buffer !== 'undefined') {
       return Buffer.from(data).toString('base64')
     }
-    return btoa(data)
+    // `btoa` operates on Latin-1: it throws on code points > 255 and mangles
+    // 128-255, so encode to UTF-8 bytes first to match the `Buffer` path above.
+    return btoa(String.fromCharCode(...new TextEncoder().encode(data)))
   }
 
   private _getFinalPath(path: string) {

--- a/packages/core/storage-js/src/packages/StorageFileApi.ts
+++ b/packages/core/storage-js/src/packages/StorageFileApi.ts
@@ -1498,7 +1498,15 @@ export default class StorageFileApi extends BaseApiClient<StorageError> {
     }
     // `btoa` operates on Latin-1: it throws on code points > 255 and mangles
     // 128-255, so encode to UTF-8 bytes first to match the `Buffer` path above.
-    return btoa(String.fromCharCode(...new TextEncoder().encode(data)))
+    const bytes = new TextEncoder().encode(data)
+    // Spreading the whole array into String.fromCharCode overflows the call stack
+    // for metadata approaching the 1 MiB limit, so build the string in chunks.
+    const CHUNK_SIZE = 0x8000
+    let binary = ''
+    for (let i = 0; i < bytes.length; i += CHUNK_SIZE) {
+      binary += String.fromCharCode(...bytes.subarray(i, i + CHUNK_SIZE))
+    }
+    return btoa(binary)
   }
 
   private _getFinalPath(path: string) {

--- a/packages/core/storage-js/src/packages/StorageFileApi.ts
+++ b/packages/core/storage-js/src/packages/StorageFileApi.ts
@@ -1496,7 +1496,9 @@ export default class StorageFileApi extends BaseApiClient<StorageError> {
     if (typeof Buffer !== 'undefined') {
       return Buffer.from(data).toString('base64')
     }
-    return btoa(data)
+    // `btoa` operates on Latin-1: it throws on code points > 255 and mangles
+    // 128-255, so encode to UTF-8 bytes first to match the `Buffer` path above.
+    return btoa(String.fromCharCode(...new TextEncoder().encode(data)))
   }
 
   private _getFinalPath(path: string) {

--- a/packages/core/storage-js/test/storageFileApi.test.ts
+++ b/packages/core/storage-js/test/storageFileApi.test.ts
@@ -1362,6 +1362,29 @@ describe('StorageFileApi Edge Cases', () => {
       )
     })
 
+    test('toBase64 encodes non-ASCII metadata as UTF-8 in environments without Buffer (browser/Deno)', () => {
+      const fileApi = storage.from('test-bucket')
+      const input = JSON.stringify({ title: 'café', emoji: '🎉' })
+
+      // Node path (Buffer available) is the reference encoding.
+      const withBuffer = fileApi.toBase64(input)
+
+      // Simulate a runtime where Buffer is undefined so the `btoa` branch runs.
+      const originalBuffer = globalThis.Buffer
+      ;(globalThis as any).Buffer = undefined
+      let withoutBuffer: string
+      try {
+        withoutBuffer = fileApi.toBase64(input)
+      } finally {
+        ;(globalThis as any).Buffer = originalBuffer
+      }
+
+      // The browser branch must match the Node branch and round-trip cleanly.
+      // Without the UTF-8 encoding, `btoa` throws on the emoji (or mangles 'café').
+      expect(withoutBuffer).toBe(withBuffer)
+      expect(Buffer.from(withoutBuffer, 'base64').toString('utf8')).toBe(input)
+    })
+
     test('uploadToSignedUrl passes headers', async () => {
       const testFormData = new FormData()
       testFormData.append('file', 'test content')

--- a/packages/core/storage-js/test/storageFileApi.test.ts
+++ b/packages/core/storage-js/test/storageFileApi.test.ts
@@ -1404,6 +1404,29 @@ describe('StorageFileApi Edge Cases', () => {
       )
     })
 
+    test('toBase64 encodes non-ASCII metadata as UTF-8 in environments without Buffer (browser/Deno)', () => {
+      const fileApi = storage.from('test-bucket')
+      const input = JSON.stringify({ title: 'café', emoji: '🎉' })
+
+      // Node path (Buffer available) is the reference encoding.
+      const withBuffer = fileApi.toBase64(input)
+
+      // Simulate a runtime where Buffer is undefined so the `btoa` branch runs.
+      const originalBuffer = globalThis.Buffer
+      ;(globalThis as any).Buffer = undefined
+      let withoutBuffer: string
+      try {
+        withoutBuffer = fileApi.toBase64(input)
+      } finally {
+        ;(globalThis as any).Buffer = originalBuffer
+      }
+
+      // The browser branch must match the Node branch and round-trip cleanly.
+      // Without the UTF-8 encoding, `btoa` throws on the emoji (or mangles 'café').
+      expect(withoutBuffer).toBe(withBuffer)
+      expect(Buffer.from(withoutBuffer, 'base64').toString('utf8')).toBe(input)
+    })
+
     test('uploadToSignedUrl passes headers', async () => {
       const testFormData = new FormData()
       testFormData.append('file', 'test content')

--- a/packages/core/storage-js/test/storageFileApi.test.ts
+++ b/packages/core/storage-js/test/storageFileApi.test.ts
@@ -1427,6 +1427,27 @@ describe('StorageFileApi Edge Cases', () => {
       expect(Buffer.from(withoutBuffer, 'base64').toString('utf8')).toBe(input)
     })
 
+    test('toBase64 handles metadata large enough to overflow a spread call', () => {
+      const fileApi = storage.from('test-bucket')
+      // Well past the ~64k argument ceiling of String.fromCharCode, and in the
+      // range the Storage API still accepts (metadata limit is 1 MiB).
+      const input = JSON.stringify({ note: 'é'.repeat(200_000) })
+
+      const withBuffer = fileApi.toBase64(input)
+
+      const originalBuffer = globalThis.Buffer
+      ;(globalThis as any).Buffer = undefined
+      let withoutBuffer: string
+      try {
+        withoutBuffer = fileApi.toBase64(input)
+      } finally {
+        ;(globalThis as any).Buffer = originalBuffer
+      }
+
+      expect(withoutBuffer).toBe(withBuffer)
+      expect(Buffer.from(withoutBuffer, 'base64').toString('utf8')).toBe(input)
+    })
+
     test('uploadToSignedUrl passes headers', async () => {
       const testFormData = new FormData()
       testFormData.append('file', 'test content')


### PR DESCRIPTION
## What

`StorageFileApi.toBase64` falls back to `btoa(data)` when `Buffer` is unavailable (browsers, Deno, some edge runtimes). `btoa` operates on Latin-1, so it:

- **throws** on any code point > 255 — an `upload`/`uploadToSignedUrl` with metadata containing an emoji (e.g. `{ emoji: '🎉' }`) fails outright with `InvalidCharacterError`;
- **mangles** code points 128–255 — accented metadata (e.g. `{ title: 'café' }`) is stored corrupted.

The `Buffer` branch (Node) encodes the same input as UTF-8, so the two runtimes disagree for identical metadata sent via the `x-metadata` header.

## Fix

Encode the string to UTF-8 bytes before `btoa`, so the browser branch produces the same base64 as the Node branch:

```ts
return btoa(String.fromCharCode(...new TextEncoder().encode(data)))
```

## Test

Adds a unit test that runs the no-`Buffer` branch with non-ASCII metadata and asserts it matches the Node path and round-trips cleanly. It fails on `master` (`InvalidCharacterError: Invalid character` on the emoji) and passes with the fix.