### PR TITLE
fix(postgrest): type hinted self-referencing embeds as arrays

### DIFF
--- a/packages/core/postgrest-js/src/select-query-parser/result.ts
+++ b/packages/core/postgrest-js/src/select-query-parser/result.ts
@@ -459,18 +459,17 @@ type ProcessEmbeddedResourceResult<
                   : ProcessedChildren | null
                 : ProcessedChildren | null
               : ProcessedChildren[]
-          : // If the relation is a self-reference it'll always be considered as reverse relationship
+          : // If the relation is a self-reference it'll always be considered as a reverse relationship.
+            // PostgREST returns arrays for a self-reference when using the table name
+            // (collections(*)) or any hint (collections!parent_id(*)), and a single object
+            // only when using the column name directly (parent_id(*)).
+            // See https://github.com/PostgREST/postgrest/blob/8776ece7d5fd612fad44151f9be4dffd855b28f0/src/PostgREST/Plan.hs#L633-L644
             Resolved['relation']['referencedRelation'] extends CurrentTableOrView
-            ? // When an explicit hint is used to embed a self-reference (eg: collections!parent_id(*)
-              // or collections!collections_parent_id_fkey(*)), PostgREST only ever resolves the
-              // one-to-many direction, so the result is always an array. See PostgREST's `findRel`
-              // `relIsSelf`/`Just hint` branch, which has no many-to-one/one-to-one match for
-              // self-relationships. This holds regardless of what the hint matched (column name,
-              // fk constraint name, or referenced relation), so it must be checked before `match`.
+            ? // An explicit hint must be checked before `match: 'col'`, since a hinted
+              // self-reference is always an array (eg: collections!parent_id(*)).
               Resolved['relation'] extends { hint: string }
               ? ProcessedChildren[]
-              : // Without a hint it can either be a reverse reference via a column inclusion
-                // (eg: parent_id(*)) in such case the result will be a single object
+              : // Without a hint, a column inclusion (eg: parent_id(*)) is a single object.
                 Resolved['relation']['match'] extends 'col'
                 ? IsRelationNullable<
                     TablesAndViews<Schema>[CurrentTableOrView],
@@ -478,8 +477,7 @@ type ProcessEmbeddedResourceResult<
                   > extends true
                   ? ProcessedChildren | null
                   : ProcessedChildren
-                : // Or it can be a reference via the reference relation (eg: collections(*))
-                  // in such case, the result will be an array of all the values (all collection with parent_id being the current id)
+                : // The table name (eg: collections(*)) is an array of children.
                   ProcessedChildren[]
             : // Otherwise if it's a non self-reference reverse relationship it's a single object
               IsRelationNullable<

--- a/packages/core/postgrest-js/src/select-query-parser/result.ts
+++ b/packages/core/postgrest-js/src/select-query-parser/result.ts
@@ -461,18 +461,26 @@ type ProcessEmbeddedResourceResult<
               : ProcessedChildren[]
           : // If the relation is a self-reference it'll always be considered as reverse relationship
             Resolved['relation']['referencedRelation'] extends CurrentTableOrView
-            ? // It can either be a reverse reference via a column inclusion (eg: parent_id(*))
-              // in such case the result will be a single object
-              Resolved['relation']['match'] extends 'col'
-              ? IsRelationNullable<
-                  TablesAndViews<Schema>[CurrentTableOrView],
-                  Resolved['relation']
-                > extends true
-                ? ProcessedChildren | null
-                : ProcessedChildren
-              : // Or it can be a reference via the reference relation (eg: collections(*))
-                // in such case, the result will be an array of all the values (all collection with parent_id being the current id)
-                ProcessedChildren[]
+            ? // When an explicit hint is used to embed a self-reference (eg: collections!parent_id(*)
+              // or collections!collections_parent_id_fkey(*)), PostgREST only ever resolves the
+              // one-to-many direction, so the result is always an array. See PostgREST's `findRel`
+              // `relIsSelf`/`Just hint` branch, which has no many-to-one/one-to-one match for
+              // self-relationships. This holds regardless of what the hint matched (column name,
+              // fk constraint name, or referenced relation), so it must be checked before `match`.
+              Resolved['relation'] extends { hint: string }
+              ? ProcessedChildren[]
+              : // Without a hint it can either be a reverse reference via a column inclusion
+                // (eg: parent_id(*)) in such case the result will be a single object
+                Resolved['relation']['match'] extends 'col'
+                ? IsRelationNullable<
+                    TablesAndViews<Schema>[CurrentTableOrView],
+                    Resolved['relation']
+                  > extends true
+                  ? ProcessedChildren | null
+                  : ProcessedChildren
+                : // Or it can be a reference via the reference relation (eg: collections(*))
+                  // in such case, the result will be an array of all the values (all collection with parent_id being the current id)
+                  ProcessedChildren[]
             : // Otherwise if it's a non self-reference reverse relationship it's a single object
               IsRelationNullable<
                   TablesAndViews<Schema>[CurrentTableOrView],

--- a/packages/core/postgrest-js/test/relationships.test.ts
+++ b/packages/core/postgrest-js/test/relationships.test.ts
@@ -593,9 +593,7 @@ test('self reference relation via hint matching column name', async () => {
 })
 
 // Documents a known PostgREST limitation: a self-referencing embed cannot be
-// disambiguated by its foreign key constraint name. PostgREST's `findRel`
-// `relIsSelf`/`Just hint` branch only matches the hint against a column name
-// (`matchFKRefSingleCol`), never a constraint name (`matchConstraint`), so this
+// disambiguated by its foreign key constraint name, so this
 // query fails at runtime with PGRST200. Use the column name hint instead (see the
 // test above). The inferred type is still (correctly) an array. See
 // https://github.com/supabase/supabase-js/issues/2517

--- a/packages/core/postgrest-js/test/relationships.test.ts
+++ b/packages/core/postgrest-js/test/relationships.test.ts
@@ -541,6 +541,103 @@ test('self reference relation via column', async () => {
   ExpectedSchema.parse(res.data)
 })
 
+test('self reference relation via hint matching column name', async () => {
+  const res = await postgrest
+    .from('collections')
+    .select('*, collections!parent_id(*)')
+    .eq('id', 1)
+    .limit(1)
+    .single()
+  expect(res).toMatchInlineSnapshot(`
+    {
+      "count": null,
+      "data": {
+        "collections": [
+          {
+            "description": "Child of Root",
+            "id": 2,
+            "parent_id": 1,
+          },
+          {
+            "description": "Another Child of Root",
+            "id": 3,
+            "parent_id": 1,
+          },
+        ],
+        "description": "Root Collection",
+        "id": 1,
+        "parent_id": null,
+      },
+      "error": null,
+      "status": 200,
+      "statusText": "OK",
+      "success": true,
+    }
+  `)
+  let result: Exclude<typeof res.data, null>
+  const ExpectedSchema = z.object({
+    id: z.number(),
+    description: z.string().nullable(),
+    parent_id: z.number().nullable(),
+    collections: z.array(
+      z.object({
+        description: z.string().nullable(),
+        id: z.number(),
+        parent_id: z.number().nullable(),
+      })
+    ),
+  })
+  let expected: z.infer<typeof ExpectedSchema>
+  expectType<TypeEqual<typeof result, typeof expected>>(true)
+  ExpectedSchema.parse(res.data)
+})
+
+// Documents a known PostgREST limitation: a self-referencing embed cannot be
+// disambiguated by its foreign key constraint name. PostgREST's `findRel`
+// `relIsSelf`/`Just hint` branch only matches the hint against a column name
+// (`matchFKRefSingleCol`), never a constraint name (`matchConstraint`), so this
+// query fails at runtime with PGRST200. Use the column name hint instead (see the
+// test above). The inferred type is still (correctly) an array. See
+// https://github.com/supabase/supabase-js/issues/2517
+test('self reference relation via hint matching fk constraint name fails at runtime', async () => {
+  const res = await postgrest
+    .from('collections')
+    .select('*, collections!collections_parent_id_fkey(*)')
+    .eq('id', 1)
+    .limit(1)
+    .single()
+  expect(res).toMatchInlineSnapshot(`
+    {
+      "count": null,
+      "data": null,
+      "error": {
+        "code": "PGRST200",
+        "details": "Searched for a foreign key relationship between 'collections' and 'collections' using the hint 'collections_parent_id_fkey' in the schema 'public', but no matches were found.",
+        "hint": null,
+        "message": "Could not find a relationship between 'collections' and 'collections' in the schema cache",
+      },
+      "status": 400,
+      "statusText": "Bad Request",
+      "success": false,
+    }
+  `)
+  let result: Exclude<typeof res.data, null>
+  const ExpectedSchema = z.object({
+    id: z.number(),
+    description: z.string().nullable(),
+    parent_id: z.number().nullable(),
+    collections: z.array(
+      z.object({
+        description: z.string().nullable(),
+        id: z.number(),
+        parent_id: z.number().nullable(),
+      })
+    ),
+  })
+  let expected: z.infer<typeof ExpectedSchema>
+  expectType<TypeEqual<typeof result, typeof expected>>(true)
+})
+
 test('many-to-many with join table', async () => {
   const res = await postgrest.from('products').select('*, categories(*)').eq('id', 1).single()
   expect(res).toMatchInlineSnapshot(`


### PR DESCRIPTION
Self-referencing embeds resolved via an explicit hint (e.g. `collections!parent_id(*)` or `collections!collections_parent_id_fkey(*)`) were incorrectly typed as a single object when the hint matched a column name, while returning an array at runtime.

PostgREST only ever resolves the one-to-many direction for a hinted self-reference, so the result is always an array regardless of what the hint matched. Check for an explicit hint before the `match: 'col'` single-object branch, which now applies only to the no-hint case (`parent_id(*)`). Add regression tests for both hint forms.

Fixes #2517

