### PR TITLE
fix(supabase): avoid edge runtime warning

### DIFF
--- a/packages/core/supabase-js/src/lib/constants.ts
+++ b/packages/core/supabase-js/src/lib/constants.ts
@@ -16,8 +16,8 @@ if (typeof Deno !== 'undefined') {
   JS_ENV = 'react-native'
 } else {
   JS_ENV = 'node'
-  JS_RUNTIME_VERSION =
-    typeof process !== 'undefined' ? process.version?.replace(/^v/, '') : undefined
+  const _process = (globalThis as any)['process']
+  JS_RUNTIME_VERSION = _process?.['version']?.replace(/^v/, '')
 }
 
 const _runtimeMeta = [`runtime=${JS_ENV}`]

--- a/packages/core/supabase-js/test/unit/constants.test.ts
+++ b/packages/core/supabase-js/test/unit/constants.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
 import {
   DEFAULT_HEADERS,
   DEFAULT_GLOBAL_OPTIONS,
@@ -115,6 +117,12 @@ describe('constants', () => {
 
       expect(newHeaders['X-Client-Info']).toContain('runtime=node')
       expect(newHeaders['X-Client-Info']).toMatch(/runtime-version=\d+\.\d+\.\d+/)
+    })
+
+    test('should avoid static process.version access for Edge runtimes', () => {
+      const source = readFileSync(join(__dirname, '../../src/lib/constants.ts'), 'utf8')
+
+      expect(source).not.toContain('process.version')
     })
   })
 })


### PR DESCRIPTION
## TL;DR

Avoid Next.js Edge Runtime warnings while keeping Node runtime metadata unchanged

## Prob

`JS_RUNTIME_VERSION` read `process.version` directly so Next.js flagged Supabase when bundled into Edge middleware


basically now it reads the optional Node version through dynamic `globalThis` access and added a regression test

## ref

- closes #2521