### PR TITLE
fix(supabase): warn instead of throw for unrecognized sb_ API key subtypes

### DIFF
--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -19,10 +19,6 @@ Nothing for the vast majority of users — authenticated calls still send the us
 
 The only impacted case is code that **reads the API key out of the `Authorization` header inside an Edge Function** (e.g. a server-side check on `Bearer sb_...`). Those cases should read the `apikey` header instead, or migrate to [`@supabase/server`](https://supabase.com/blog/introducing-supabase-server) for edge functions.
 
-### Unrecognized API key formats now throw
-
-To keep the header handling correct as the `sb_` key family grows, `createClient()` now validates the key format at construction. A key that starts with `sb_` but is **not** a recognized subtype (`sb_publishable_…` / `sb_secret_…`) throws immediately, indicating that `@supabase/supabase-js` must be upgraded to a version that supports the new key type. Legacy JWT keys (which do not start with `sb_`) are unaffected.
-
 ## Node.js 18 support dropped (v2.79.0, 2025-10-31)
 
 Starting with version `2.79.0`, all Supabase JavaScript libraries require **Node.js 20 or later**. The `@supabase/node-fetch` polyfill has been removed and native `fetch` is now required.

--- a/packages/core/supabase-js/src/SupabaseClient.ts
+++ b/packages/core/supabase-js/src/SupabaseClient.ts
@@ -20,7 +20,7 @@ import {
   DEFAULT_REALTIME_OPTIONS,
   DEFAULT_TRACE_PROPAGATION_OPTIONS,
 } from './lib/constants'
-import { assertSupportedApiKey, fetchWithAuth } from './lib/fetch'
+import { checkApiKeyFormat, fetchWithAuth } from './lib/fetch'
 import {
   applySettingDefaults,
   validateSupabaseUrl,
@@ -315,7 +315,7 @@ export default class SupabaseClient<
   ) {
     const baseUrl = validateSupabaseUrl(supabaseUrl)
     if (!supabaseKey) throw new Error('supabaseKey is required.')
-    assertSupportedApiKey(supabaseKey)
+    checkApiKeyFormat(supabaseKey)
 
     this.realtimeUrl = new URL('realtime/v1', baseUrl)
     this.realtimeUrl.protocol = this.realtimeUrl.protocol.replace('http', 'ws')

--- a/packages/core/supabase-js/src/lib/fetch.ts
+++ b/packages/core/supabase-js/src/lib/fetch.ts
@@ -43,7 +43,7 @@ export const checkApiKeyFormat = (key: string): void => {
   if (!key.startsWith('sb_') || isNewApiKey(key) || key.startsWith(TEMP_KEY_PREFIX)) {
     return
   }
-  const subtype = key.match(/^sb_[a-zA-Z0-9]+_/)?.[0] ?? key
+  const subtype = key.match(/^sb_[a-zA-Z0-9]+_/)?.[0] ?? 'unknown'
   if (warnedKeySubtypes.has(subtype)) {
     return
   }

--- a/packages/core/supabase-js/src/lib/fetch.ts
+++ b/packages/core/supabase-js/src/lib/fetch.ts
@@ -24,27 +24,35 @@ export const resolveHeadersConstructor = () => {
 /**
  * New-format Supabase API keys (`sb_publishable_…` / `sb_secret_…`) are not JWTs and
  * must never be sent as a Bearer token — they belong only in the `apikey` header.
- * Legacy (JWT) keys predate this format (they don't start with `sb_`) and keep their
- * existing behavior. Any other `sb_`-prefixed key is an unrecognized future subtype;
- * see {@link assertSupportedApiKey}.
+ * All other keys (legacy JWT keys, `sb_temp_…` temporary keys, unrecognized `sb_`
+ * subtypes) keep the Bearer fallback.
  */
 const isNewApiKey = (key: string): boolean =>
   key.startsWith('sb_publishable_') || key.startsWith('sb_secret_')
 
+const TEMP_KEY_PREFIX = 'sb_temp_'
+
+const warnedKeySubtypes = new Set<string>()
+
 /**
- * Fail fast on an `sb_`-family key whose subtype this SDK version does not recognize, so a
- * future key type can never be silently mistreated as a legacy JWT and sent as a Bearer
- * token. Recognized new-format keys and legacy JWT keys (no `sb_` prefix) pass through.
- * The key itself is never included in the message to avoid leaking secret keys.
+ * Warn (once per subtype) when an `sb_` key isn't a subtype this SDK version recognizes.
+ * Never throws — the server, not the SDK, decides key validity. The key value is never
+ * included in the message.
  */
-export const assertSupportedApiKey = (key: string): void => {
-  if (key.startsWith('sb_') && !isNewApiKey(key)) {
-    throw new Error(
-      '@supabase/supabase-js: Unrecognized Supabase API key format. Expected a legacy JWT key ' +
-        'or a new-format key (sb_publishable_… / sb_secret_…). This "sb_" key type is not ' +
-        'supported by this version of the SDK — please upgrade @supabase/supabase-js.'
-    )
+export const checkApiKeyFormat = (key: string): void => {
+  if (!key.startsWith('sb_') || isNewApiKey(key) || key.startsWith(TEMP_KEY_PREFIX)) {
+    return
   }
+  const subtype = key.match(/^sb_[a-zA-Z0-9]+_/)?.[0] ?? key
+  if (warnedKeySubtypes.has(subtype)) {
+    return
+  }
+  warnedKeySubtypes.add(subtype)
+  console.warn(
+    '@supabase/supabase-js: Unrecognized Supabase API key format. The client will proceed ' +
+      'and send this key as-is; if you see authentication errors you may need to upgrade ' +
+      '@supabase/supabase-js to a version that recognizes this key type.'
+  )
 }
 
 export const fetchWithAuth = (

--- a/packages/core/supabase-js/test/unit/SupabaseClient.test.ts
+++ b/packages/core/supabase-js/test/unit/SupabaseClient.test.ts
@@ -29,15 +29,27 @@ describe('SupabaseClient', () => {
     expect(() => createClient(URL, '')).toThrow('supabaseKey is required.')
   })
 
-  test('should validate the API key format', () => {
-    // Unrecognized sb_ subtype → fail fast, signalling an SDK upgrade is needed.
-    expect(() => createClient(URL, 'sb_unknown_abc123')).toThrow(
-      'Unrecognized Supabase API key format'
-    )
-    // Recognized new-format keys and legacy JWT keys are accepted.
-    expect(() => createClient(URL, 'sb_publishable_abc123')).not.toThrow()
-    expect(() => createClient(URL, 'sb_secret_abc123')).not.toThrow()
-    expect(() => createClient(URL, KEY)).not.toThrow()
+  test('should check the API key format without ever throwing', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      // Platform-issued temporary keys are accepted silently.
+      expect(() => createClient(URL, 'sb_temp_nonce123_payload456')).not.toThrow()
+      // Recognized new-format keys and legacy JWT keys are accepted silently.
+      expect(() => createClient(URL, 'sb_publishable_abc123')).not.toThrow()
+      expect(() => createClient(URL, 'sb_secret_abc123')).not.toThrow()
+      expect(() => createClient(URL, KEY)).not.toThrow()
+      expect(warnSpy).not.toHaveBeenCalled()
+
+      // Unrecognized sb_ subtype → the client is still created; a one-time warning
+      // signals that an SDK upgrade may be needed.
+      expect(createClient(URL, 'sb_unknown_abc123')).toBeInstanceOf(SupabaseClient)
+      expect(warnSpy).toHaveBeenCalledTimes(1)
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringMatching(/Unrecognized Supabase API key format/)
+      )
+    } finally {
+      warnSpy.mockRestore()
+    }
   })
 
   test('should validate supabaseUrl', () => {

--- a/packages/core/supabase-js/test/unit/fetch.test.ts
+++ b/packages/core/supabase-js/test/unit/fetch.test.ts
@@ -341,13 +341,15 @@ describe('fetch module', () => {
         expect(warnSpy).not.toHaveBeenCalled()
       })
 
-      test.each(['sb_', 'sb_unknowntype'])(
-        'warns for malformed sb_ key %p without throwing',
-        (key) => {
-          expect(() => checkApiKeyFormat(key)).not.toThrow()
-          expect(warnSpy).toHaveBeenCalledTimes(1)
-        }
-      )
+      test('warns once for all sb_ keys without a parseable subtype', () => {
+        // Keys with no second underscore share one dedup bucket ('unknown'), so the
+        // full key value is never stored for deduplication.
+        expect(() => checkApiKeyFormat('sb_')).not.toThrow()
+        expect(warnSpy).toHaveBeenCalledTimes(1)
+
+        expect(() => checkApiKeyFormat('sb_unknowntype')).not.toThrow()
+        expect(warnSpy).toHaveBeenCalledTimes(1)
+      })
     })
 
     describe('trace propagation', () => {

--- a/packages/core/supabase-js/test/unit/fetch.test.ts
+++ b/packages/core/supabase-js/test/unit/fetch.test.ts
@@ -2,7 +2,7 @@ import {
   resolveFetch,
   resolveHeadersConstructor,
   fetchWithAuth,
-  assertSupportedApiKey,
+  checkApiKeyFormat,
 } from '../../src/lib/fetch'
 
 jest.mock('@supabase/tracing', () => {
@@ -251,33 +251,103 @@ describe('fetch module', () => {
 
         expect(mockSet).toHaveBeenCalledWith('Authorization', `Bearer ${supabaseKey}`)
       })
+
+      test('sends a temporary key as apikey AND Bearer fallback on the regular path', async () => {
+        const mockSet = setupHeaders()
+        const supabaseKey = 'sb_temp_nonce123_payload456'
+        const getAccessToken = jest.fn().mockResolvedValue(null)
+
+        const authFetch = fetchWithAuth(
+          supabaseKey,
+          'https://myproject.supabase.co',
+          getAccessToken
+        )
+        await authFetch('https://example.com')
+
+        expect(mockSet).toHaveBeenCalledWith('apikey', supabaseKey)
+        expect(mockSet).toHaveBeenCalledWith('Authorization', `Bearer ${supabaseKey}`)
+      })
+
+      test('omitApiKeyAsBearer does not suppress Bearer for a temporary key', async () => {
+        // Bearer omission is scoped to new-format keys; temp keys keep the legacy fallback.
+        const mockSet = setupHeaders()
+        const supabaseKey = 'sb_temp_nonce123_payload456'
+        const getAccessToken = jest.fn().mockResolvedValue(null)
+
+        const authFetch = fetchWithAuth(
+          supabaseKey,
+          'https://myproject.supabase.co',
+          getAccessToken,
+          undefined,
+          undefined,
+          { omitApiKeyAsBearer: true }
+        )
+        await authFetch('https://example.com')
+
+        expect(mockSet).toHaveBeenCalledWith('Authorization', `Bearer ${supabaseKey}`)
+      })
     })
 
-    describe('assertSupportedApiKey', () => {
-      test('throws for an unrecognized sb_ key subtype', () => {
-        expect(() => assertSupportedApiKey('sb_unknown_abc123')).toThrow(
-          /Unrecognized Supabase API key format/
+    describe('checkApiKeyFormat', () => {
+      // NOTE: warn deduplication is per subtype and module-scoped, so every test in this
+      // block must use a key subtype not used anywhere else in this file.
+      let warnSpy: jest.SpyInstance
+
+      beforeEach(() => {
+        warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+      })
+
+      afterEach(() => {
+        warnSpy.mockRestore()
+      })
+
+      test('accepts a temporary key silently', () => {
+        expect(() => checkApiKeyFormat('sb_temp_nonce123_payload456')).not.toThrow()
+        expect(warnSpy).not.toHaveBeenCalled()
+      })
+
+      test('warns, but does not throw, for an unrecognized sb_ key subtype', () => {
+        expect(() => checkApiKeyFormat('sb_unknown_abc123')).not.toThrow()
+        expect(warnSpy).toHaveBeenCalledTimes(1)
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.stringMatching(/Unrecognized Supabase API key format/)
         )
       })
 
-      test('never includes the key in the error message', () => {
+      test('never includes the key in the warning message', () => {
         const key = 'sb_futuretype_supersecretvalue'
-        expect.assertions(1)
-        try {
-          assertSupportedApiKey(key)
-        } catch (err) {
-          expect((err as Error).message).not.toContain(key)
-        }
+        checkApiKeyFormat(key)
+        expect(warnSpy).toHaveBeenCalledTimes(1)
+        expect(warnSpy).not.toHaveBeenCalledWith(expect.stringContaining(key))
+      })
+
+      test('warns only once per subtype', () => {
+        checkApiKeyFormat('sb_once_key1')
+        checkApiKeyFormat('sb_once_key2')
+        expect(warnSpy).toHaveBeenCalledTimes(1)
+
+        checkApiKeyFormat('sb_other_key1')
+        expect(warnSpy).toHaveBeenCalledTimes(2)
       })
 
       test.each([
         'sb_publishable_abc123',
         'sb_secret_abc123',
+        'sb_temp_abc123',
         'header.payload.signature',
         'anon-key',
-      ])('accepts recognized / legacy key %p', (key) => {
-        expect(() => assertSupportedApiKey(key)).not.toThrow()
+      ])('accepts recognized / legacy key %p without warning', (key) => {
+        expect(() => checkApiKeyFormat(key)).not.toThrow()
+        expect(warnSpy).not.toHaveBeenCalled()
       })
+
+      test.each(['sb_', 'sb_unknowntype'])(
+        'warns for malformed sb_ key %p without throwing',
+        (key) => {
+          expect(() => checkApiKeyFormat(key)).not.toThrow()
+          expect(warnSpy).toHaveBeenCalledTimes(1)
+        }
+      )
     })
 
     describe('trace propagation', () => {


### PR DESCRIPTION
## Description

Relaxes the API key format check in `createClient()` so that it never throws. Temporary keys (`sb_temp_...`) are now recognized and accepted silently, and any other unrecognized `sb_` key subtype logs a one-time `console.warn` instead of failing client construction.

### What changed?

- `packages/core/supabase-js/src/lib/fetch.ts`: replaced `assertSupportedApiKey()` (which threw for any `sb_` key other than `sb_publishable_...` / `sb_secret_...`) with `checkApiKeyFormat()`:
  - `sb_temp_...` keys are accepted silently.
  - Any other unrecognized `sb_` subtype logs a one-time `console.warn` (deduplicated per subtype) suggesting an SDK upgrade, and the client proceeds. The key value is never included in the warning.
  - Legacy JWT keys and `sb_publishable_...` / `sb_secret_...` keys are unaffected.
- `packages/core/supabase-js/src/SupabaseClient.ts`: constructor call site updated to the new function. An empty key still throws (`supabaseKey is required.`).
- Header behavior from #2511 is unchanged: new-format keys are still never sent as `Authorization: Bearer` on Edge Function calls. Temporary and unrecognized `sb_` subtypes keep the legacy behavior (`apikey` header plus `Authorization: Bearer` fallback), which is what these keys relied on before the validation was introduced.
- Tests: rewrote the format-check unit tests (warn instead of throw, silent acceptance of temporary keys, warn deduplication, key value never present in the message) and added header pins proving temporary keys are sent as `apikey` plus `Authorization: Bearer` fallback on both the regular and the Edge Functions fetch paths.
- `docs/MIGRATION.md`: removed the "Unrecognized API key formats now throw" section. With the throw gone there is no user action to document; the rest of the "Edge Functions auth headers" section from #2511 still applies and is untouched.

### Why was this change needed?

Versions `2.110.4` and `2.110.5` threw synchronously in the `SupabaseClient` constructor for any `sb_` key that was not `sb_publishable_...` / `sb_secret_...` (a future-proofing guard added in #2511). The `sb_` key family can grow beyond what any released SDK version knows about, so hard-failing at construction breaks clients that are given valid keys of a newer subtype, such as the temporary `sb_temp_...` keys. The SDK is not the authority on key validity: with this change, an unrecognized and genuinely invalid key surfaces as an auth error from the server, while an unrecognized but valid key keeps working, with a one-time console warning that an SDK upgrade may be needed.

## Screenshots/Examples

Before (`2.110.4` and `2.110.5`):

```ts
createClient(url, 'sb_temp_...')
// throws: "Unrecognized Supabase API key format. ... please upgrade @supabase/supabase-js."
```

After:

```ts
createClient(url, 'sb_temp_...') // works, no warning
createClient(url, 'sb_futuretype_...') // works, one-time console.warn suggesting an SDK upgrade
```

## Breaking changes

None. This removes a constructor throw, so it strictly widens the set of accepted inputs. Keys that worked before continue to work identically.

- [x] This PR contains no breaking changes

## Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/supabase/supabase-js/blob/master/CONTRIBUTING.md)
- [x] My PR title follows the [conventional commit format](https://www.conventionalcommits.org/): `<type>(<scope>): <description>`
- [x] I have run `pnpm nx format` to ensure consistent code formatting
- [x] I have added tests for new functionality (if applicable)
- [x] I have updated documentation (if applicable)

## Additional notes

- `assertSupportedApiKey` was exported from `src/lib/fetch.ts` but never re-exported from the package entry point, so renaming it to `checkApiKeyFormat` does not change the public API.
- The warning message intentionally does not enumerate the recognized key prefixes, so future key subtypes will not require message updates.
- The Supabase dashboard downgraded to `@supabase/supabase-js` 2.110.1 in supabase/supabase#47945 to avoid this throw; that pin can be lifted once this fix is in a stable release.
