### PR TITLE
fix(postgrest): escape " and \ inside quoted filter values

### DIFF
--- a/packages/core/postgrest-js/src/PostgrestFilterBuilder.ts
+++ b/packages/core/postgrest-js/src/PostgrestFilterBuilder.ts
@@ -548,7 +548,12 @@ export default class PostgrestFilterBuilder<
   ): this
   likeAllOf(column: string, patterns: readonly string[]): this
   likeAllOf(column: string, patterns: readonly string[]): this {
-    this.url.searchParams.append(column, `like(all).{${patterns.join(',')}}`)
+    const cleanedPatterns = patterns.map((s) => {
+      if (typeof s === 'string' && PostgrestReservedCharsRegexp.test(s))
+        return `"${s.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`
+      return `${s}`
+    })
+    this.url.searchParams.append(column, `like(all).{${cleanedPatterns.join(',')}}`)
     return this
   }
 
@@ -567,7 +572,12 @@ export default class PostgrestFilterBuilder<
   ): this
   likeAnyOf(column: string, patterns: readonly string[]): this
   likeAnyOf(column: string, patterns: readonly string[]): this {
-    this.url.searchParams.append(column, `like(any).{${patterns.join(',')}}`)
+    const cleanedPatterns = patterns.map((s) => {
+      if (typeof s === 'string' && PostgrestReservedCharsRegexp.test(s))
+        return `"${s.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`
+      return `${s}`
+    })
+    this.url.searchParams.append(column, `like(any).{${cleanedPatterns.join(',')}}`)
     return this
   }
 
@@ -637,7 +647,12 @@ export default class PostgrestFilterBuilder<
   ): this
   ilikeAllOf(column: string, patterns: readonly string[]): this
   ilikeAllOf(column: string, patterns: readonly string[]): this {
-    this.url.searchParams.append(column, `ilike(all).{${patterns.join(',')}}`)
+    const cleanedPatterns = patterns.map((s) => {
+      if (typeof s === 'string' && PostgrestReservedCharsRegexp.test(s))
+        return `"${s.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`
+      return `${s}`
+    })
+    this.url.searchParams.append(column, `ilike(all).{${cleanedPatterns.join(',')}}`)
     return this
   }
 
@@ -656,7 +671,12 @@ export default class PostgrestFilterBuilder<
   ): this
   ilikeAnyOf(column: string, patterns: readonly string[]): this
   ilikeAnyOf(column: string, patterns: readonly string[]): this {
-    this.url.searchParams.append(column, `ilike(any).{${patterns.join(',')}}`)
+    const cleanedPatterns = patterns.map((s) => {
+      if (typeof s === 'string' && PostgrestReservedCharsRegexp.test(s))
+        return `"${s.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`
+      return `${s}`
+    })
+    this.url.searchParams.append(column, `ilike(any).{${cleanedPatterns.join(',')}}`)
     return this
   }
 
@@ -838,8 +858,9 @@ export default class PostgrestFilterBuilder<
     const cleanedValues = Array.from(new Set(values))
       .map((s) => {
         // handle postgrest reserved characters
-        // https://postgrest.org/en/v7.0.0/api.html#reserved-characters
-        if (typeof s === 'string' && PostgrestReservedCharsRegexp.test(s)) return `"${s}"`
+        // https://postgrest.org/en/stable/references/api/url_grammar.html#reserved-characters
+        if (typeof s === 'string' && PostgrestReservedCharsRegexp.test(s))
+          return `"${s.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`
         else return `${s}`
       })
       .join(',')
@@ -866,8 +887,9 @@ export default class PostgrestFilterBuilder<
     const cleanedValues = Array.from(new Set(values))
       .map((s) => {
         // handle postgrest reserved characters
-        // https://postgrest.org/en/v7.0.0/api.html#reserved-characters
-        if (typeof s === 'string' && PostgrestReservedCharsRegexp.test(s)) return `"${s}"`
+        // https://postgrest.org/en/stable/references/api/url_grammar.html#reserved-characters
+        if (typeof s === 'string' && PostgrestReservedCharsRegexp.test(s))
+          return `"${s.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`
         else return `${s}`
       })
       .join(',')

--- a/packages/core/postgrest-js/test/filter-encoding.test.ts
+++ b/packages/core/postgrest-js/test/filter-encoding.test.ts
@@ -1,0 +1,135 @@
+import { PostgrestClient } from '../src/index'
+import { Database } from './types.override'
+
+const REST_URL = 'http://localhost:54321/rest/v1'
+const API_KEY = 'sb_publishable_ACJWlzQHlZjBrEguHvfOxg_3BJgxAaH'
+
+const postgrest = new PostgrestClient<Database>(REST_URL, {
+  headers: { apikey: API_KEY, Authorization: `Bearer ${API_KEY}` },
+})
+
+/**
+ * E2E tests for PostgREST filter reserved-character escaping.
+ *
+ * These run against a REAL PostgREST server (Supabase CLI local, port 54321)
+ * and prove the escaping survives the full pipeline: URL → PostgREST parser →
+ * PostgreSQL. A wrong escape would either be rejected by PostgREST (HTTP 4xx)
+ * or match the wrong rows.
+ *
+ * PostgREST reserved chars: , . : ( ) — must be wrapped in double quotes.
+ * Inside double quotes, " is escaped with backslash \", and \ with \\.
+ * https://postgrest.org/en/stable/references/api/url_grammar.html#reserved-characters
+ */
+
+describe('E2E: in() filter with reserved chars and double quotes', () => {
+  const testUsernames = ['a"b,c', 'plain', 'x(y)', 'with"quote']
+
+  beforeAll(async () => {
+    // Insert rows with tricky usernames (upsert with onConflict for PK)
+    await postgrest
+      .from('users')
+      .upsert(
+        testUsernames.map((u) => ({ username: u })),
+        { onConflict: 'username' }
+      )
+      .select()
+  })
+
+  afterAll(async () => {
+    await postgrest.from('users').delete().in('username', testUsernames)
+  })
+
+  test('in() matches a value containing both " and ,', async () => {
+    const res = await postgrest.from('users').select('username').in('username', ['a"b,c'])
+    expect(res.error).toBeNull()
+    expect(res.data).toEqual([{ username: 'a"b,c' }])
+  })
+
+  test('in() matches a value containing ( )', async () => {
+    const res = await postgrest.from('users').select('username').in('username', ['x(y)'])
+    expect(res.error).toBeNull()
+    expect(res.data).toEqual([{ username: 'x(y)' }])
+  })
+
+  test('in() matches multiple values, some with reserved chars', async () => {
+    const res = await postgrest
+      .from('users')
+      .select('username')
+      .in('username', ['a"b,c', 'plain', 'x(y)'])
+    expect(res.error).toBeNull()
+    const names = (res.data as any[]).map((r) => r.username).sort()
+    expect(names).toEqual(['a"b,c', 'plain', 'x(y)'])
+  })
+
+  test('notIn() excludes a value containing " and ,', async () => {
+    const res = await postgrest
+      .from('users')
+      .select('username')
+      .in('username', ['a"b,c', 'plain', 'x(y)', 'with"quote'])
+      .notIn('username', ['a"b,c'])
+    expect(res.error).toBeNull()
+    const names = (res.data as any[]).map((r) => r.username).sort()
+    expect(names).toEqual(['plain', 'with"quote', 'x(y)'])
+  })
+})
+
+describe('E2E: likeAllOf/likeAnyOf with comma in pattern', () => {
+  const tricky = ['foo,bar', 'foobar', 'foo,baz']
+
+  beforeAll(async () => {
+    await postgrest
+      .from('users')
+      .upsert(
+        tricky.map((u) => ({ username: u })),
+        { onConflict: 'username' }
+      )
+      .select()
+  })
+
+  afterAll(async () => {
+    await postgrest.from('users').delete().in('username', tricky)
+  })
+
+  test('likeAllOf with comma pattern matches the literal-comma row only', async () => {
+    // %foo,bar% must be treated as ONE pattern containing a comma.
+    // Without quoting, PostgREST splits on , → patterns %foo and bar%,
+    // which matches nothing (or the wrong rows).
+    const res = await postgrest
+      .from('users')
+      .select('username')
+      .likeAllOf('username', ['%foo,bar%'])
+    expect(res.error).toBeNull()
+    const names = (res.data as any[]).map((r) => r.username).sort()
+    expect(names).toEqual(['foo,bar'])
+  })
+
+  test('likeAnyOf with comma pattern matches literal-comma rows only', async () => {
+    const res = await postgrest
+      .from('users')
+      .select('username')
+      .likeAnyOf('username', ['%foo,bar%', '%foo,baz%'])
+    expect(res.error).toBeNull()
+    const names = (res.data as any[]).map((r) => r.username).sort()
+    expect(names).toEqual(['foo,bar', 'foo,baz'])
+  })
+
+  test('ilikeAllOf with comma pattern matches literal-comma row only', async () => {
+    const res = await postgrest
+      .from('users')
+      .select('username')
+      .ilikeAllOf('username', ['%FOO,BAR%'])
+    expect(res.error).toBeNull()
+    const names = (res.data as any[]).map((r) => r.username).sort()
+    expect(names).toEqual(['foo,bar'])
+  })
+
+  test('ilikeAnyOf with comma pattern matches literal-comma rows only', async () => {
+    const res = await postgrest
+      .from('users')
+      .select('username')
+      .ilikeAnyOf('username', ['%FOO,BAR%', '%FOO,BAZ%'])
+    expect(res.error).toBeNull()
+    const names = (res.data as any[]).map((r) => r.username).sort()
+    expect(names).toEqual(['foo,bar', 'foo,baz'])
+  })
+})


### PR DESCRIPTION
## 🔍 Description

### What changed?

Six filter methods in `PostgrestFilterBuilder` now correctly escape `"` and `\` inside quoted filter values, per PostgREST's backslash convention:

- **`in()` / `notIn()`**: values that contain both a reserved char (`,()``) and a `"` or `\` are now escaped as `\"` and `\\` inside the wrapping double quotes.
- **`likeAllOf()` / `likeAnyOf()` / `ilikeAllOf()` / `ilikeAnyOf()`**: patterns that contain a reserved char are now wrapped in double quotes (previously they were not quoted at all), with the same `\"` / `\\` escaping.

The stale comment link was also updated to the current PostgREST docs (`/en/stable/references/api/url_grammar.html#reserved-characters`).

### Why was this change needed?

PostgREST's URL grammar treats `,`, `.`, `:`, `()` as reserved characters. When a filter value contains one of these, it must be wrapped in double quotes `%22...%22`. Inside those quotes, `"` is escaped with a backslash `\"` and `\` with `\\` — **not** CSV-style doubling `""`.

**Bug 1 — `in()`/`notIn()`**: the old code wrapped values in `"..."` when they contained a reserved char, but never escaped an inner `"`. So `.in("col", ["a\"b,c"])` produced `in.("a"b,c")`, which PostgREST cannot parse (the quote terminates the value early). Affected any value with both a reserved char and a literal double quote.

**Bug 2 — `likeAllOf`/`likeAnyOf`/`ilikeAllOf`/`ilikeAnyOf`**: the old code did `patterns.join(",")` with no quoting at all. A pattern containing a comma was silently split by PostgREST into multiple patterns — `.likeAllOf("col", ["%foo,bar%"])` produced `like(all).{%foo,bar%}` which PostgREST reads as two patterns (`%foo` and `bar%`), matching the wrong rows or nothing.

PostgREST docs: https://postgrest.org/en/stable/references/api/url_grammar.html#reserved-characters

## 📸 Screenshots/Examples

```ts
// Before: in.("a"b,c")  — broken, PostgREST 400/error
// After:  in.("a\"b,c")  — correct, matches the row
await supabase.from("users").select().in("username", ["a\"b,c"])

// Before: like(all).{%foo,bar%}  — PostgREST reads 2 patterns
// After:  like(all).{"%foo,bar%"} — 1 pattern with a literal comma
await supabase.from("users").select().likeAllOf("username", ["%foo,bar%"])
```

## 🔄 Breaking changes

- [x] This PR contains no breaking changes

Values without reserved characters are unchanged (no quoting added). The escaping only applies when a value already triggers the existing quoting path.

## 📋 Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/supabase/supabase-js/blob/master/CONTRIBUTING.md)
- [x] My PR title follows the [conventional commit format](https://www.conventionalcommits.org/): `fix(postgrest): ...`
- [x] I have run `pnpm nx format` to ensure consistent code formatting
- [x] I have added tests for new functionality (if applicable)
- [ ] I have updated documentation (if applicable)

## 📝 Additional notes

Validated **E2E against a real PostgREST server** (Supabase CLI local, port 54321): the test suite inserts rows whose usernames contain reserved chars and double quotes, then filters by them — confirming the escaping survives the full pipeline (URL → PostgREST parser → PostgreSQL). 8/8 tests pass.

Local checks: `jest test/filter-encoding.test.ts` → 8 passed, `tsc --noEmit` → clean, `prettier --check` → clean.

The initial attempt used CSV-style `""` doubling (inspired by PostgREST v7 docs); E2E testing against the real server caught this — PostgREST expects backslash escaping `\"` / `\\`, confirmed by the current docs and by direct `curl` tests.

## Related

- #2631 covers the sibling gap in `.not(col, 'in', array)` and extracts a shared `cleanFilterValues`. Its author confirmed the four `like`/`ilike` methods are out of that PR's scope and are covered here, so the two are complementary rather than overlapping.
- #2633 asks whether the reserved-character set should be widened beyond `[,()]`. I measured it against PostgREST 16.2: inside `in.(...)`, `.`, `:`, `*`, `!`, `|` and `&` pass through unquoted and only `,`, `(` and `)` break the parse, so `[,()]` is the correct set for these methods and this PR does not change it. Details and reproduction in that issue.
