### PR TITLE
fix(postgrest): use POST for rpc() with get:true and object args

### DIFF
--- a/packages/core/postgrest-js/src/PostgrestClient.ts
+++ b/packages/core/postgrest-js/src/PostgrestClient.ts
@@ -400,7 +400,7 @@ export default class PostgrestClient<
     // objects/arrays-of-objects can't be serialized to URL params, use POST + return=minimal instead
     const _isObject = (v: unknown): boolean =>
       v !== null && typeof v === 'object' && (!Array.isArray(v) || v.some(_isObject))
-    const _hasObjectArg = head && Object.values(args as object).some(_isObject)
+    const _hasObjectArg = (head || get) && Object.values(args as object).some(_isObject)
     if (_hasObjectArg) {
       method = 'POST'
       body = args
@@ -421,7 +421,7 @@ export default class PostgrestClient<
     }
 
     const headers = new Headers(this.headers)
-    if (_hasObjectArg) {
+    if (_hasObjectArg && head) {
       headers.set('Prefer', count ? `count=${count},return=minimal` : 'return=minimal')
     } else if (count) {
       headers.set('Prefer', `count=${count}`)

--- a/packages/core/postgrest-js/test/rpc-get-object-args.test.ts
+++ b/packages/core/postgrest-js/test/rpc-get-object-args.test.ts
@@ -1,0 +1,88 @@
+import { PostgrestClient } from '../src/index'
+import { Database } from './types.override'
+
+const REST_URL = 'http://localhost:54321/rest/v1'
+const API_KEY = 'sb_publishable_ACJWlzQHlZjBrEguHvfOxg_3BJgxAaH'
+
+const postgrest = new PostgrestClient<Database>(REST_URL, {
+  headers: { apikey: API_KEY, Authorization: `Bearer ${API_KEY}` },
+})
+
+/**
+ * E2E tests for rpc() request construction when args contain objects.
+ *
+ * Objects/arrays-of-objects can't be serialized to URL params, so rpc() must
+ * fall back to POST + JSON body. The `_hasObjectArg` guard previously only
+ * checked `head`, not `get` — so `get: true` with an object arg silently
+ * serialized the object as `[object Object]` in the URL.
+ *
+ * The first two tests use a mock fetch to inspect the wire (method/body/headers)
+ * because the test DB has no function that accepts a jsonb arg. The third test
+ * hits the real server to confirm the primitive-arg path is unchanged.
+ */
+
+describe('E2E: rpc() with get:true and object args', () => {
+  test('get:true with object arg sends POST (not [object Object] in URL)', async () => {
+    const captured: { method?: string; url: string; body?: string } = { url: '' }
+    const spyFetch = jest.fn().mockImplementation((url: string, init: any) => {
+      captured.url = url
+      captured.method = init?.method
+      captured.body = init?.body
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        text: () => Promise.resolve('"ok"'),
+      })
+    })
+    const client = new PostgrestClient<Database>(REST_URL, {
+      headers: { apikey: API_KEY },
+      fetch: spyFetch as any,
+    })
+
+    await (client as any).rpc('echo_json', { data: { key: 'value' } }, { get: true })
+
+    // Must be POST (not GET), body must be JSON (not [object Object] in URL)
+    expect(captured.method).toBe('POST')
+    expect(captured.url).not.toContain('[object')
+    expect(captured.body).toContain('"key"')
+    // get:true wants data back → must NOT set return=minimal
+    const init = spyFetch.mock.calls[0][1]
+    const headers = init.headers
+    const prefer = headers['Prefer'] ?? headers['prefer']
+    expect(prefer).toBeUndefined()
+  })
+
+  test('head:true with object arg still uses POST + return=minimal (unchanged)', async () => {
+    const captured: { method?: string; body?: string } = {}
+    const spyFetch = jest.fn().mockImplementation((_url: string, init: any) => {
+      captured.method = init?.method
+      captured.body = init?.body
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        text: () => Promise.resolve(''),
+      })
+    })
+    const client = new PostgrestClient<Database>(REST_URL, {
+      headers: { apikey: API_KEY },
+      fetch: spyFetch as any,
+    })
+
+    await (client as any).rpc('echo_json', { data: { key: 'value' } }, { head: true })
+
+    expect(captured.method).toBe('POST')
+    expect(captured.body).toContain('"key"')
+    const init = spyFetch.mock.calls[0][1]
+    const prefer = init.headers['Prefer'] ?? init.headers['prefer']
+    expect(prefer).toContain('return=minimal')
+  })
+
+  test('get:true with primitive args still uses GET (unchanged, real server)', async () => {
+    const res = await postgrest.rpc('get_status', { name_param: 'supabot' }, { get: true })
+    expect(res.error).toBeNull()
+    expect(res.status).toBe(200)
+    expect(res.data).toBeDefined()
+  })
+})


### PR DESCRIPTION
## 🔍 Description

### What changed?

`rpc()` has a guard (`_hasObjectArg`) that falls back to `POST` + JSON body when an argument is an object or array-of-objects, because objects cannot be serialized into URL query params. This guard previously only checked `head` — it now checks `head || get`.

The `Prefer: return=minimal` header is now only set when `head` is true (a `get: true` call wants the response data back, so it must not request a minimal response).

### Why was this change needed?

A call like:

```ts
await supabase.rpc("fn", { data: { key: "value" } }, { get: true })
```

fell into the `GET` branch because `_hasObjectArg` was `head && ...` (false when `head` is false). The object was then serialized into the URL as `[object Object]` — silently corrupting the request. PostgREST would receive `?data=[object Object]` instead of the intended JSON body.

The `head: true` path was already correct (it triggered the POST fallback and set `return=minimal`). This PR extends the same behavior to `get: true`, minus the `return=minimal` header (since `get` wants the response payload).

## 📸 Screenshots/Examples

```ts
// Before: GET /rpc/fn?data=[object Object]  — silently broken
// After:  POST /rpc/fn  body={"data":{"key":"value"}}  — correct
await supabase.rpc("fn", { data: { key: "value" } }, { get: true })
```

## 🔄 Breaking changes

- [x] This PR contains no breaking changes

Calls with primitive args (strings, numbers, arrays of primitives) are unaffected — they still use `GET` with URL params as before.

## 📋 Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/supabase/supabase-js/blob/master/CONTRIBUTING.md)
- [x] My PR title follows the [conventional commit format](https://www.conventionalcommits.org/): `fix(postgrest): ...`
- [x] I have run `pnpm nx format` to ensure consistent code formatting
- [x] I have added tests for new functionality (if applicable)
- [ ] I have updated documentation (if applicable)

## 📝 Additional notes

Validated E2E: 3/3 tests pass. The first two tests inspect the wire (method/body/headers) via a mock fetch since the test DB has no function that accepts a jsonb arg; the third test hits the real PostgREST server to confirm the primitive-arg `get: true` path is unchanged.

Local checks: `jest test/rpc-get-object-args.test.ts` → 3 passed, `tsc --noEmit` → clean, `prettier --check` → clean.