### PR TITLE
fix(realtime): trigger set auth on INITIAL_SESSION event

### DIFF
--- a/packages/core/supabase-js/src/SupabaseClient.ts
+++ b/packages/core/supabase-js/src/SupabaseClient.ts
@@ -669,7 +669,7 @@ export default class SupabaseClient<
     token?: string
   ) {
     if (
-      (event === 'TOKEN_REFRESHED' || event === 'SIGNED_IN') &&
+      (event === 'TOKEN_REFRESHED' || event === 'SIGNED_IN' || event === 'INITIAL_SESSION') &&
       this.changedAccessToken !== token
     ) {
       this.changedAccessToken = token

--- a/packages/core/supabase-js/test/unit/SupabaseClient.test.ts
+++ b/packages/core/supabase-js/test/unit/SupabaseClient.test.ts
@@ -384,6 +384,15 @@ describe('SupabaseClient', () => {
         expect(setAuthSpy).toHaveBeenCalledWith()
       })
 
+      test('should call setAuth() on INITIAL_SESSION event', async () => {
+        const client = createClient(URL, KEY)
+        const setAuthSpy = jest.spyOn(client.realtime, 'setAuth')
+
+        // @ts-ignore - accessing private method for testing
+        client._handleTokenChanged('INITIAL_SESSION', 'CLIENT', 'initial-token')
+        expect(setAuthSpy).toHaveBeenCalledWith('initial-token')
+      })
+
       test('should update token in realtime client when setAuth is called', async () => {
         const client = createClient(URL, KEY)
         const testToken = 'test-realtime-token'


### PR DESCRIPTION
## 🔍 Description

https://linear.app/supabase/issue/REAL-897/handle-initial-session-event-in-handletokenchanged-to-call 

