### PR TITLE
ci: grant pull-requests write to SDK compliance caller

### DIFF
--- a/.github/workflows/validate-capabilities.yml
+++ b/.github/workflows/validate-capabilities.yml
@@ -5,6 +5,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   validate:


### PR DESCRIPTION
## What

Adds `pull-requests: write` to the SDK Compliance workflow's top-level `permissions` so the reusable workflow it calls can run.

## Why

Every PR run of this workflow has failed with `startup_failure` since 2026-07-15. It is not caused by any individual PR.

The workflow calls the `@main`-pinned reusable workflow `supabase/sdk/.github/workflows/validate-sdk-compliance-javascript.yml`. In supabase/sdk #60 (commit `45dba43`), the reusable workflow's `check` job started requesting `pull-requests: write` so it can post the capability matrix drift comment.

A called reusable workflow's `GITHUB_TOKEN` permissions can only be equal to or more restrictive than the caller's. This caller only granted `contents: read`, so the reusable workflow requesting a scope the caller does not have makes GitHub reject the run at compile time, before any job starts.

Granting `pull-requests: write` in the caller lets the token be passed down so the drift comment step can post.

## Notes

- Same fix already applied for supabase-flutter in supabase/supabase-flutter#1611; all consumers of these reusable workflows need it.
- The drift check posts/updates a sticky PR comment; it is best-effort and swallows 403s on fork PRs.