### PR TITLE
fix(storage): expose service error code on StorageApiError

### DIFF
--- a/packages/core/storage-js/src/lib/common/errors.ts
+++ b/packages/core/storage-js/src/lib/common/errors.ts
@@ -58,17 +58,26 @@ export function isStorageError(error: unknown): error is StorageError {
 export class StorageApiError extends StorageError {
   override status: number
   override statusCode: string
+  /**
+   * Service-specific error code from the Storage API response body, such as
+   * `NoSuchKey`, `AccessDenied` or `ResourceAlreadyExists`. Use this to branch
+   * on the specific error rather than parsing the message.
+   * @see https://supabase.com/docs/guides/storage/debugging/error-codes
+   */
+  code: string | undefined
 
   constructor(
     message: string,
     status: number,
     statusCode: string,
-    namespace: ErrorNamespace = 'storage'
+    namespace: ErrorNamespace = 'storage',
+    code?: string
   ) {
     super(message, namespace, status, statusCode)
     this.name = namespace === 'vectors' ? 'StorageVectorsApiError' : 'StorageApiError'
     this.status = status
     this.statusCode = statusCode
+    this.code = code
   }
 
   toJSON(): {
@@ -76,9 +85,11 @@ export class StorageApiError extends StorageError {
     message: string
     status: number | undefined
     statusCode: string | undefined
+    code: string | undefined
   } {
     return {
       ...super.toJSON(),
+      code: this.code,
     }
   }
 }

--- a/packages/core/storage-js/src/lib/common/fetch.ts
+++ b/packages/core/storage-js/src/lib/common/fetch.ts
@@ -76,7 +76,9 @@ const handleError = async (
       .then(
         (err: { statusCode?: string; code?: string; error?: string; message?: string } | null) => {
           const statusCode = err?.statusCode || err?.code || status + ''
-          reject(new StorageApiError(_getErrorMessage(err), status, statusCode, namespace))
+          reject(
+            new StorageApiError(_getErrorMessage(err), status, statusCode, namespace, err?.code)
+          )
         }
       )
       .catch(() => {

--- a/packages/core/storage-js/test/common/errors.test.ts
+++ b/packages/core/storage-js/test/common/errors.test.ts
@@ -79,6 +79,28 @@ describe('Common Errors', () => {
         statusCode: 'InternalError',
       })
     })
+
+    it('should expose the service error code when provided', () => {
+      const error = new StorageApiError('Object not found', 404, '404', 'storage', 'NoSuchKey')
+      expect(error.code).toBe('NoSuchKey')
+      expect(error.statusCode).toBe('404')
+    })
+
+    it('should leave code undefined when not provided', () => {
+      const error = new StorageApiError('API error', 404, 'NotFound')
+      expect(error.code).toBeUndefined()
+    })
+
+    it('should include code in JSON when present', () => {
+      const error = new StorageApiError('Access denied', 403, '403', 'storage', 'AccessDenied')
+      expect(error.toJSON()).toEqual({
+        name: 'StorageApiError',
+        message: 'Access denied',
+        status: 403,
+        statusCode: '403',
+        code: 'AccessDenied',
+      })
+    })
   })
 
   describe('StorageUnknownError', () => {

--- a/packages/core/storage-js/test/common/fetch.test.ts
+++ b/packages/core/storage-js/test/common/fetch.test.ts
@@ -99,7 +99,8 @@ describe('Common Fetch', () => {
       })
 
       it('should expose the service error code from the response body', async () => {
-        const errorResponse = { code: 'NoSuchKey', message: 'Object not found' }
+        // Mirror a real Storage payload, which sends both `statusCode` and `code`
+        const errorResponse = { statusCode: '404', code: 'NoSuchKey', message: 'Object not found' }
         mockFetch.mockResolvedValue(
           new MockResponse(JSON.stringify(errorResponse), {
             status: 404,
@@ -110,6 +111,7 @@ describe('Common Fetch', () => {
         await expect(get(mockFetch, 'http://test.com/api')).rejects.toMatchObject({
           name: 'StorageApiError',
           status: 404,
+          statusCode: '404',
           code: 'NoSuchKey',
         })
       })

--- a/packages/core/storage-js/test/common/fetch.test.ts
+++ b/packages/core/storage-js/test/common/fetch.test.ts
@@ -98,6 +98,22 @@ describe('Common Fetch', () => {
         })
       })
 
+      it('should expose the service error code from the response body', async () => {
+        const errorResponse = { code: 'NoSuchKey', message: 'Object not found' }
+        mockFetch.mockResolvedValue(
+          new MockResponse(JSON.stringify(errorResponse), {
+            status: 404,
+            statusText: 'Not Found',
+          })
+        )
+
+        await expect(get(mockFetch, 'http://test.com/api')).rejects.toMatchObject({
+          name: 'StorageApiError',
+          status: 404,
+          code: 'NoSuchKey',
+        })
+      })
+
       it('should throw StorageUnknownError on network error', async () => {
         mockFetch.mockRejectedValue(new Error('Network error'))
 

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -554,6 +554,11 @@ features:
     status: implemented
     symbols:
       - default.listBuckets
+  storage.errors.error_codes:
+    status: implemented
+    symbols:
+      - StorageApiError.code
+      - StorageVectorsApiError.code
   storage.file_buckets.access_bucket:
     status: implemented
     symbols:


### PR DESCRIPTION
## 🔍 Description

### What changed?

`StorageApiError` now carries the service error code (`NoSuchKey`, `AccessDenied`, `ResourceAlreadyExists`, etc.) on a dedicated `code` property, and includes it in `toJSON()`.

The response body already contains this in `err.code` — `handleError` in `storage-js/src/lib/common/fetch.ts` was only using it as a fallback for `statusCode` and otherwise dropping it, so it never reached the error object. Now it is passed through to the new field. `statusCode` is unchanged.

### Why was this change needed?

The [Storage error-codes docs](https://supabase.com/docs/guides/storage/debugging/error-codes) tell you to branch on codes like `AccessDenied` / `NoSuchKey`, but the thrown `StorageApiError` never exposed them — it only had `status` and `statusCode` — so that pattern was impossible to implement without parsing the message string. This closes that gap.

Closes #2536

## 📸 Screenshots/Examples

```ts
const { error } = await supabase.storage.from("bucket").download("missing.png")
if (error && error.name === "StorageApiError" && error.code === "NoSuchKey") {
  // handle the specific case
}
```

## 🔄 Breaking changes

- [x] This PR contains no breaking changes

Additive only — a new optional constructor arg and a new field. `code` is `undefined` when the response has no code, and existing `status` / `statusCode` behaviour is untouched.

## 📋 Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/supabase/supabase-js/blob/master/CONTRIBUTING.md)
- [x] My PR title follows the [conventional commit format](https://www.conventionalcommits.org/): `<type>(<scope>): <description>`
- [x] I have run `pnpm nx format` to ensure consistent code formatting
- [x] I have added tests for new functionality (if applicable)
- [ ] I have updated documentation (if applicable)

## 📝 Additional notes

Added unit tests in both `errors.test.ts` (the `code` field + `toJSON`) and `fetch.test.ts` (that a `code` in the response body reaches the error) — they fail without the change and pass with it.