### PR TITLE
fix(storage): expose service error codes

### DIFF
--- a/packages/core/storage-js/src/lib/common/errors.ts
+++ b/packages/core/storage-js/src/lib/common/errors.ts
@@ -13,6 +13,8 @@ export class StorageError extends Error {
   protected namespace: ErrorNamespace
   status: number | undefined
   statusCode: string | undefined
+  code?: string
+  error?: string
 
   constructor(
     message: string,
@@ -32,12 +34,16 @@ export class StorageError extends Error {
     message: string
     status: number | undefined
     statusCode: string | undefined
+    code?: string
+    error?: string
   } {
     return {
       name: this.name,
       message: this.message,
       status: this.status,
       statusCode: this.statusCode,
+      ...(this.code !== undefined ? { code: this.code } : {}),
+      ...(this.error !== undefined ? { error: this.error } : {}),
     }
   }
 }
@@ -63,12 +69,16 @@ export class StorageApiError extends StorageError {
     message: string,
     status: number,
     statusCode: string,
-    namespace: ErrorNamespace = 'storage'
+    namespace: ErrorNamespace = 'storage',
+    code?: string,
+    error?: string
   ) {
     super(message, namespace, status, statusCode)
     this.name = namespace === 'vectors' ? 'StorageVectorsApiError' : 'StorageApiError'
     this.status = status
     this.statusCode = statusCode
+    if (code !== undefined) this.code = code
+    if (error !== undefined) this.error = error
   }
 
   toJSON(): {
@@ -76,6 +86,8 @@ export class StorageApiError extends StorageError {
     message: string
     status: number | undefined
     statusCode: string | undefined
+    code?: string
+    error?: string
   } {
     return {
       ...super.toJSON(),

--- a/packages/core/storage-js/src/lib/common/fetch.ts
+++ b/packages/core/storage-js/src/lib/common/fetch.ts
@@ -76,7 +76,18 @@ const handleError = async (
       .then(
         (err: { statusCode?: string; code?: string; error?: string; message?: string } | null) => {
           const statusCode = err?.statusCode || err?.code || status + ''
-          reject(new StorageApiError(_getErrorMessage(err), status, statusCode, namespace))
+          const errorCode = typeof err?.error === 'string' ? err.error : undefined
+          const code = err?.code || errorCode
+          reject(
+            new StorageApiError(
+              _getErrorMessage(err),
+              status,
+              statusCode,
+              namespace,
+              code,
+              errorCode || code
+            )
+          )
         }
       )
       .catch(() => {

--- a/packages/core/storage-js/test/common/errors.test.ts
+++ b/packages/core/storage-js/test/common/errors.test.ts
@@ -59,13 +59,15 @@ describe('Common Errors', () => {
     })
 
     it('should serialize to JSON correctly', () => {
-      const error = new StorageApiError('API error', 500, 'InternalError')
+      const error = new StorageApiError('API error', 500, '500', 'storage', 'Code', 'Error')
       const json = error.toJSON()
       expect(json).toEqual({
         name: 'StorageApiError',
         message: 'API error',
         status: 500,
-        statusCode: 'InternalError',
+        statusCode: '500',
+        code: 'Code',
+        error: 'Error',
       })
     })
 

--- a/packages/core/storage-js/test/common/fetch.test.ts
+++ b/packages/core/storage-js/test/common/fetch.test.ts
@@ -591,8 +591,12 @@ describe('Common Fetch', () => {
       }
     })
 
-    it('should extract status code from statusCode field', async () => {
-      const errorResponse = { message: 'Error', statusCode: 'CustomErrorCode' }
+    it('should extract status and error codes from their response fields', async () => {
+      const errorResponse = {
+        message: 'Error',
+        statusCode: 'CustomErrorCode',
+        error: 'NoSuchKey',
+      }
       mockFetch.mockResolvedValue(
         new MockResponse(JSON.stringify(errorResponse), {
           status: 400,
@@ -604,6 +608,8 @@ describe('Common Fetch', () => {
         await get(mockFetch, 'http://test.com/api')
       } catch (error: any) {
         expect(error.statusCode).toBe('CustomErrorCode')
+        expect(error.code).toBe('NoSuchKey')
+        expect(error.error).toBe('NoSuchKey')
       }
     })
 
@@ -620,6 +626,8 @@ describe('Common Fetch', () => {
         await get(mockFetch, 'http://test.com/api')
       } catch (error: any) {
         expect(error.statusCode).toBe('CustomCode')
+        expect(error.code).toBe('CustomCode')
+        expect(error.error).toBe('CustomCode')
       }
     })
   })

--- a/packages/core/storage-js/test/common/fetch.test.ts
+++ b/packages/core/storage-js/test/common/fetch.test.ts
@@ -591,12 +591,8 @@ describe('Common Fetch', () => {
       }
     })
 
-    it('should extract status and error codes from their response fields', async () => {
-      const errorResponse = {
-        message: 'Error',
-        statusCode: 'CustomErrorCode',
-        error: 'NoSuchKey',
-      }
+    it('should extract status code from statusCode field', async () => {
+      const errorResponse = { message: 'Error', statusCode: 'CustomErrorCode' }
       mockFetch.mockResolvedValue(
         new MockResponse(JSON.stringify(errorResponse), {
           status: 400,
@@ -608,9 +604,27 @@ describe('Common Fetch', () => {
         await get(mockFetch, 'http://test.com/api')
       } catch (error: any) {
         expect(error.statusCode).toBe('CustomErrorCode')
-        expect(error.code).toBe('NoSuchKey')
-        expect(error.error).toBe('NoSuchKey')
       }
+    })
+
+    it('should expose the Storage API error code from the error field', async () => {
+      const errorResponse = {
+        message: 'Object not found',
+        statusCode: '404',
+        error: 'NoSuchKey',
+      }
+      mockFetch.mockResolvedValue(
+        new MockResponse(JSON.stringify(errorResponse), {
+          status: 404,
+          statusText: 'Not Found',
+        })
+      )
+
+      await expect(get(mockFetch, 'http://test.com/api')).rejects.toMatchObject({
+        statusCode: '404',
+        code: 'NoSuchKey',
+        error: 'NoSuchKey',
+      })
     })
 
     it('should use code field as statusCode if statusCode is not present', async () => {

--- a/packages/core/storage-js/test/storageFileApi.test.ts
+++ b/packages/core/storage-js/test/storageFileApi.test.ts
@@ -523,6 +523,11 @@ describe('Object API', () => {
       expect(blobResponse.data?.size).toBeGreaterThan(0)
       expect(blobResponse.data?.type).toEqual('text/plain;charset=utf-8')
 
+      const missingResponse = await storage.from(bucketName).download('non-existent-file')
+      expect(missingResponse.error?.statusCode).toBe('404')
+      expect(missingResponse.error?.code).toEqual(expect.any(String))
+      expect(missingResponse.error?.error).toEqual(expect.any(String))
+
       // throws when .throwOnError is enabled
       await expect(
         storage.from(bucketName).throwOnError().download('non-existent-file')


### PR DESCRIPTION
## TL;DR

Expose Storage service error codes on `StorageError`

pass through the canonical `code` field while supporting the legacy `error` response field
 used by older and self-hosted versions (BC)

## Ref

- Closes #2536
- https://supabase.com/docs/guides/storage/debugging/error-codes