### PR TITLE
fix(supabase): skip Node warning in Deno

### DIFF
--- a/packages/core/supabase-js/src/index.ts
+++ b/packages/core/supabase-js/src/index.ts
@@ -71,8 +71,8 @@ export const createClient = <
 
 // Check for Node.js <= 20 deprecation
 function shouldShowDeprecationWarning(): boolean {
-  // Skip in browser environments
-  if (typeof window !== 'undefined') {
+  // Skip in browser and Deno environments
+  if (typeof window !== 'undefined' || (globalThis as any)['Deno'] !== undefined) {
     return false
   }
 

--- a/packages/core/supabase-js/test/unit/deprecation.test.ts
+++ b/packages/core/supabase-js/test/unit/deprecation.test.ts
@@ -8,6 +8,7 @@ export {}
 describe('Node.js deprecation warning', () => {
   const originalProcess = global.process
   const originalWindow = global.window
+  const originalDeno = (globalThis as any).Deno
   const originalConsoleWarn = console.warn
 
   beforeEach(() => {
@@ -21,6 +22,7 @@ describe('Node.js deprecation warning', () => {
     // Restore original values
     global.process = originalProcess
     global.window = originalWindow
+    ;(globalThis as any).Deno = originalDeno
     console.warn = originalConsoleWarn
     jest.resetModules()
   })
@@ -28,6 +30,19 @@ describe('Node.js deprecation warning', () => {
   it('should not show warning in browser environment', () => {
     // Simulate browser environment
     global.window = {} as any
+
+    require('../../src/index')
+
+    expect(console.warn).not.toHaveBeenCalled()
+  })
+
+  it('should not show warning in Deno environment with Node compatibility process', () => {
+    Object.defineProperty(global.process, 'version', {
+      value: 'v20.11.1',
+      configurable: true,
+    })
+    ;(globalThis as any).Deno = {}
+    delete (global as any).window
 
     require('../../src/index')
 

--- a/packages/core/supabase-js/test/unit/deprecation.test.ts
+++ b/packages/core/supabase-js/test/unit/deprecation.test.ts
@@ -7,6 +7,7 @@ export {}
 
 describe('Node.js deprecation warning', () => {
   const originalProcess = global.process
+  const originalProcessVersion = Object.getOwnPropertyDescriptor(global.process, 'version')
   const originalWindow = global.window
   const originalDeno = (globalThis as any).Deno
   const originalConsoleWarn = console.warn
@@ -21,6 +22,9 @@ describe('Node.js deprecation warning', () => {
   afterEach(() => {
     // Restore original values
     global.process = originalProcess
+    if (originalProcessVersion) {
+      Object.defineProperty(global.process, 'version', originalProcessVersion)
+    }
     global.window = originalWindow
     ;(globalThis as any).Deno = originalDeno
     console.warn = originalConsoleWarn


### PR DESCRIPTION
## TL;DR

avoid showing the Node 20 deprecation warning in Edge Functions
 Edge Runtime exposes a Node 20 compatibility shim alongside Deno so the SDK treated it as a real Node runtime

basically this skips the warning when Deno is present while keeping it 
unchanged for actual Node 20 and below..

## Ref

- closes #2540
- closes #2539