### PR TITLE
fix(auth): downgrade aborted/transient fetch failures from console.error to warn

### DIFF
--- a/packages/core/auth-js/src/GoTrueClient.ts
+++ b/packages/core/auth-js/src/GoTrueClient.ts
@@ -4290,7 +4290,10 @@ export default class GoTrueClient {
       } catch (err) {
         await this.stateChangeEmitters.get(id)?.callback('INITIAL_SESSION', null)
         this._debug('INITIAL_SESSION', 'callback id', id, 'error', err)
-        if (isAuthSessionMissingError(err)) {
+        if (isAuthSessionMissingError(err) || isAuthRetryableFetchError(err)) {
+          // A missing session or a transient/aborted network failure (e.g. a
+          // superseded page navigation cancelling the in-flight request) is
+          // not an application error — warn rather than surface it raw.
           console.warn(err)
         } else {
           console.error(err)
@@ -4866,7 +4869,15 @@ export default class GoTrueClient {
     } catch (err) {
       this._debug(debugName, 'error', err)
 
-      console.error(err)
+      if (isAuthRetryableFetchError(err)) {
+        // Transient/aborted network failure during session recovery (e.g. a
+        // superseded page navigation cancelling the in-flight request). Warn
+        // rather than surface it raw; the session is untouched and recovery
+        // will run again on the next load.
+        console.warn(err)
+      } else {
+        console.error(err)
+      }
       return
     } finally {
       this._debug(debugName, 'end')

--- a/packages/core/auth-js/src/lib/fetch.ts
+++ b/packages/core/auth-js/src/lib/fetch.ts
@@ -224,9 +224,10 @@ async function _handleRequest(
       ...requestParams,
     })
   } catch (e) {
-    console.error(e)
-
-    // fetch failed, likely due to a network or CORS error
+    // fetch failed (network / CORS / aborted request) — surfaced to the
+    // caller as a retryable error below. Deliberately not logged here: an
+    // aborted in-flight request (e.g. a superseded page navigation) is a
+    // transient condition, and logging the raw error pollutes the console.
     throw new AuthRetryableFetchError(_getErrorMessage(e), 0)
   }
 

--- a/packages/core/auth-js/test/GoTrueClient.test.ts
+++ b/packages/core/auth-js/test/GoTrueClient.test.ts
@@ -4833,7 +4833,7 @@ describe('Refresh-token lifecycle (proactive/reactive, cooldown)', () => {
     })
   })
 
-  describe('console noise on transient failures (#2543)', () => {
+  describe('console noise on transient failures', () => {
     const retryableFetchError = () =>
       Object.assign(new AuthError('Failed to fetch', 0), {
         name: 'AuthRetryableFetchError',
@@ -4841,10 +4841,10 @@ describe('Refresh-token lifecycle (proactive/reactive, cooldown)', () => {
       })
 
     test('_emitInitialSession downgrades a retryable network failure to console.warn', async () => {
-      // Repro of #2543: a full page load starts session recovery, the user
-      // navigates away, the in-flight auth request is aborted and surfaces as
-      // an AuthRetryableFetchError. The INITIAL_SESSION emission must warn,
-      // not error, so it doesn't pollute production consoles / break strict
+      // A full page load starts session recovery, the user navigates away,
+      // and the in-flight auth request is aborted, surfacing as an
+      // AuthRetryableFetchError. The INITIAL_SESSION emission must warn, not
+      // error, so it doesn't pollute production consoles or break strict
       // zero-console-error E2E gates.
       const storage = memoryLocalStorageAdapter()
       await plantSession(storage, { secondsUntilExpiry: -60 })
@@ -4866,7 +4866,7 @@ describe('Refresh-token lifecycle (proactive/reactive, cooldown)', () => {
       // Drive the INITIAL_SESSION emission directly so the assertion doesn't
       // race the fire-and-forget emission scheduled by onAuthStateChange.
       // @ts-expect-error access private for test
-      await client._emitInitialSession(Symbol('test-2543'))
+      await client._emitInitialSession(Symbol('test-transient-init'))
 
       expect(errorSpy).not.toHaveBeenCalled()
       expect(warnSpy).toHaveBeenCalled()

--- a/packages/core/auth-js/test/GoTrueClient.test.ts
+++ b/packages/core/auth-js/test/GoTrueClient.test.ts
@@ -4832,4 +4832,94 @@ describe('Refresh-token lifecycle (proactive/reactive, cooldown)', () => {
       expect(signedOutCount).toBe(1)
     })
   })
+
+  describe('console noise on transient failures (#2543)', () => {
+    const retryableFetchError = () =>
+      Object.assign(new AuthError('Failed to fetch', 0), {
+        name: 'AuthRetryableFetchError',
+        __isAuthError: true,
+      })
+
+    test('_emitInitialSession downgrades a retryable network failure to console.warn', async () => {
+      // Repro of #2543: a full page load starts session recovery, the user
+      // navigates away, the in-flight auth request is aborted and surfaces as
+      // an AuthRetryableFetchError. The INITIAL_SESSION emission must warn,
+      // not error, so it doesn't pollute production consoles / break strict
+      // zero-console-error E2E gates.
+      const storage = memoryLocalStorageAdapter()
+      await plantSession(storage, { secondsUntilExpiry: -60 })
+
+      const client = new GoTrueClient({
+        url: GOTRUE_URL_SIGNUP_ENABLED_AUTO_CONFIRM_ON,
+        storage,
+        autoRefreshToken: false,
+        persistSession: true,
+        skipAutoInitialize: true,
+      })
+      stubNetworkError(client)
+
+      await client.initialize()
+
+      const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+
+      // Drive the INITIAL_SESSION emission directly so the assertion doesn't
+      // race the fire-and-forget emission scheduled by onAuthStateChange.
+      // @ts-expect-error access private for test
+      await client._emitInitialSession(Symbol('test-2543'))
+
+      expect(errorSpy).not.toHaveBeenCalled()
+      expect(warnSpy).toHaveBeenCalled()
+
+      errorSpy.mockRestore()
+      warnSpy.mockRestore()
+    })
+
+    test('_recoverAndRefresh downgrades a retryable failure in its outer catch to console.warn', async () => {
+      // Defensive guard: if any step of session recovery throws a transient
+      // network error (rather than returning it), the outer catch must warn
+      // rather than surface it raw. Drive the branch by making the first
+      // storage read throw a retryable error.
+      const storage = memoryLocalStorageAdapter()
+      const client = buildClient(storage)
+      await client.initialize()
+
+      jest.spyOn(storage, 'getItem').mockImplementationOnce(() => {
+        throw retryableFetchError()
+      })
+
+      const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+
+      // @ts-expect-error access private for test
+      await client._recoverAndRefresh()
+
+      expect(errorSpy).not.toHaveBeenCalled()
+      expect(warnSpy).toHaveBeenCalled()
+
+      errorSpy.mockRestore()
+      warnSpy.mockRestore()
+    })
+
+    test('_recoverAndRefresh still logs a genuine (non-retryable) error via console.error', async () => {
+      // Guard the guard: a non-retryable throw must remain a console.error so
+      // we don't silently swallow real problems.
+      const storage = memoryLocalStorageAdapter()
+      const client = buildClient(storage)
+      await client.initialize()
+
+      jest.spyOn(storage, 'getItem').mockImplementationOnce(() => {
+        throw new Error('boom')
+      })
+
+      const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+
+      // @ts-expect-error access private for test
+      await client._recoverAndRefresh()
+
+      expect(errorSpy).toHaveBeenCalled()
+
+      errorSpy.mockRestore()
+    })
+  })
 })

--- a/packages/core/auth-js/test/fetch.test.ts
+++ b/packages/core/auth-js/test/fetch.test.ts
@@ -122,6 +122,31 @@ describe('fetch', () => {
       await server.start()
     })
 
+    test('should not log the raw error to console.error when the fetch fails', async () => {
+      // A network / CORS / aborted fetch is a transient condition surfaced to
+      // the caller as AuthRetryableFetchError. It must not be logged raw here
+      // (see supabase-js#2543) — that pollutes production consoles.
+      const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+
+      const route = server
+        .get('/')
+        .mockImplementationOnce((ctx) => {
+          // abort the request without sending any response
+          ctx.req.destroy()
+        })
+        .mockImplementation((ctx) => {
+          ctx.status = 200
+        })
+
+      const url = server.getURL().toString()
+
+      await expect(_request(fetch, 'GET', url)).rejects.toBeInstanceOf(AuthRetryableFetchError)
+      expect(errorSpy).not.toHaveBeenCalled()
+      expect(route).toHaveBeenCalledTimes(1)
+
+      errorSpy.mockRestore()
+    })
+
     test('should work with custom fetch implementation', async () => {
       const customFetch = (async () => {
         return {

--- a/packages/core/auth-js/test/fetch.test.ts
+++ b/packages/core/auth-js/test/fetch.test.ts
@@ -124,8 +124,8 @@ describe('fetch', () => {
 
     test('should not log the raw error to console.error when the fetch fails', async () => {
       // A network / CORS / aborted fetch is a transient condition surfaced to
-      // the caller as AuthRetryableFetchError. It must not be logged raw here
-      // (see supabase-js#2543) — that pollutes production consoles.
+      // the caller as AuthRetryableFetchError. It must not be logged raw here,
+      // as that pollutes production consoles.
       const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
 
       const route = server


### PR DESCRIPTION
When a page load starts GoTrueClient session recovery and the user navigates away before it settles, the browser aborts the in-flight auth request. The rejection (`TypeError: Failed to fetch`) was logged raw via `console.error`, polluting production consoles and breaking strict zero-console-error E2E gates, even though nothing is actually wrong (the page was simply superseded).

These failures are already modeled as `AuthRetryableFetchError` and treated as transient elsewhere in auth-js. This PR brings the logging in line: it removes the unconditional raw `console.error` in the fetch helper (`_handleRequest`) and downgrades retryable fetch failures to `console.warn` in the `INITIAL_SESSION` emission and `_recoverAndRefresh`, using the existing `isAuthRetryableFetchError` discriminator. Genuine non-retryable errors still log at `console.error`. This is a log-level change only, with no behavior or API change, and adds tests covering all three paths.

Note for reviewers: removing the fetch-helper log affects all failed fetches (not just aborts), so a genuine CORS/network failure during e.g. `signInWithPassword` no longer logs at the fetch layer; it still surfaces to the caller via the returned `error`.

Closes #2543