### PR TITLE
fix(storage): url-encode object key in CDN purge methods

### DIFF
--- a/packages/core/storage-js/src/lib/common/helpers.ts
+++ b/packages/core/storage-js/src/lib/common/helpers.ts
@@ -144,3 +144,16 @@ export const validateVectorDimension = (
     )
   }
 }
+
+/**
+ * Percent-encodes each segment of a storage path so URL delimiters within a
+ * key (e.g. `?`, `#`) can't be interpreted as a querystring/fragment start.
+ *
+ * Splits on `/` so real path separators stay literal — the storage server
+ * routes on them and decodes each segment back to the original key.
+ *
+ * @param path - A bucket id or `bucketId/objectKey` path
+ * @returns The path with each `/`-delimited segment percent-encoded
+ */
+export const encodeStoragePath = (path: string): string =>
+  path.split('/').map(encodeURIComponent).join('/')

--- a/packages/core/storage-js/src/packages/StorageBucketApi.ts
+++ b/packages/core/storage-js/src/packages/StorageBucketApi.ts
@@ -1,6 +1,7 @@
 import { DEFAULT_HEADERS } from '../lib/constants'
 import { StorageError } from '../lib/common/errors'
 import { Fetch, get, post, put, remove } from '../lib/common/fetch'
+import { encodeStoragePath } from '../lib/common/helpers'
 import BaseApiClient from '../lib/common/BaseApiClient'
 import {
   Bucket,
@@ -455,7 +456,7 @@ export default class StorageBucketApi extends BaseApiClient<StorageError> {
 
       return await remove(
         this.fetch,
-        `${this.url}/cdn/${id}${queryString ? `?${queryString}` : ''}`,
+        `${this.url}/cdn/${encodeStoragePath(id)}${queryString ? `?${queryString}` : ''}`,
         {},
         { headers: this.headers },
         parameters

--- a/packages/core/storage-js/src/packages/StorageFileApi.ts
+++ b/packages/core/storage-js/src/packages/StorageFileApi.ts
@@ -6,7 +6,7 @@ import {
 } from '../lib/common/errors'
 import { get, head, post, put, remove, Fetch } from '../lib/common/fetch'
 import { setHeader } from '../lib/common/headers'
-import { recursiveToCamel } from '../lib/common/helpers'
+import { encodeStoragePath, recursiveToCamel } from '../lib/common/helpers'
 import BaseApiClient from '../lib/common/BaseApiClient'
 import {
   FileObject,
@@ -1216,7 +1216,7 @@ export default class StorageFileApi extends BaseApiClient<StorageError> {
       }
   > {
     return this.handleOperation(async () => {
-      const _path = this._getFinalPath(path)
+      const _path = encodeStoragePath(this._getFinalPath(path))
       const query = new URLSearchParams()
       if (options?.transformations) {
         query.set('transformations', 'true')

--- a/packages/core/storage-js/test/storageBucketApi.test.ts
+++ b/packages/core/storage-js/test/storageBucketApi.test.ts
@@ -650,5 +650,24 @@ describe('Bucket API Error Handling', () => {
         expect.objectContaining({ method: 'DELETE', signal: controller.signal })
       )
     })
+
+    it('percent-encodes URL delimiters in the bucket id', async () => {
+      const fetchMock = jest.fn().mockResolvedValue(
+        new Response(JSON.stringify({ message: 'success' }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      )
+      global.fetch = fetchMock
+
+      const client = new StorageClient(PURGE_URL, { apikey: 'service-role-token' })
+      const { error } = await client.purgeBucketCache('my?bucket')
+
+      expect(error).toBeNull()
+      expect(fetchMock).toHaveBeenCalledWith(
+        `${PURGE_URL}/cdn/my%3Fbucket`,
+        expect.objectContaining({ method: 'DELETE' })
+      )
+    })
   })
 })

--- a/packages/core/storage-js/test/storageFileApi.test.ts
+++ b/packages/core/storage-js/test/storageFileApi.test.ts
@@ -1133,6 +1133,48 @@ describe('purgeCache', () => {
       expect.objectContaining({ method: 'DELETE', signal: controller.signal })
     )
   })
+
+  it('percent-encodes URL delimiters in the key while keeping path separators literal', async () => {
+    const fetchMock = jest.fn().mockResolvedValue(
+      new Response(JSON.stringify({ message: 'success' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    )
+    global.fetch = fetchMock
+
+    const client = new StorageClient(PURGE_URL, { apikey: 'service-role-token' })
+    const { error } = await client.from(BUCKET).purgeCache('folder/a?b#c.png')
+
+    expect(error).toBeNull()
+    // `?` and `#` are encoded so they can't be parsed as querystring/fragment,
+    // but `/` stays literal so the server still routes on the real path segments.
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${PURGE_URL}/cdn/${BUCKET}/folder/a%3Fb%23c.png`,
+      expect.objectContaining({ method: 'DELETE' })
+    )
+  })
+
+  it('appends the transformations query after an encoded key', async () => {
+    const fetchMock = jest.fn().mockResolvedValue(
+      new Response(JSON.stringify({ message: 'success' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    )
+    global.fetch = fetchMock
+
+    const client = new StorageClient(PURGE_URL, { apikey: 'service-role-token' })
+    const { error } = await client.from(BUCKET).purgeCache('folder/a?b.png', {
+      transformations: true,
+    })
+
+    expect(error).toBeNull()
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${PURGE_URL}/cdn/${BUCKET}/folder/a%3Fb.png?transformations=true`,
+      expect.objectContaining({ method: 'DELETE' })
+    )
+  })
 })
 
 describe('StorageFileApi Edge Cases', () => {


### PR DESCRIPTION
`purgeCache` and `purgeBucketCache` interpolated the key into the URL raw, so a `?` or `#` was parsed as a querystring/fragment start and purged the wrong cache key. Encode each path segment before the request.