### PR TITLE
fix: PKCE code challenge double-encoding and storage path URI encoding

### DIFF
--- a/packages/core/auth-js/src/GoTrueClient.ts
+++ b/packages/core/auth-js/src/GoTrueClient.ts
@@ -5595,8 +5595,8 @@ export default class GoTrueClient {
       )
 
       const flowParams = new URLSearchParams({
-        code_challenge: `${encodeURIComponent(codeChallenge)}`,
-        code_challenge_method: `${encodeURIComponent(codeChallengeMethod)}`,
+        code_challenge: `${codeChallenge}`,
+        code_challenge_method: `${codeChallengeMethod}`,
       })
       urlParams.push(flowParams.toString())
     }

--- a/packages/core/storage-js/src/packages/StorageFileApi.ts
+++ b/packages/core/storage-js/src/packages/StorageFileApi.ts
@@ -1493,7 +1493,11 @@ export default class StorageFileApi extends BaseApiClient<StorageError> {
   }
 
   private _getFinalPath(path: string) {
-    return `${this.bucketId}/${path.replace(/^\/+/, '')}`
+    return `${this.bucketId}/${path
+      .split('/')
+      .map((seg) => encodeURIComponent(seg))
+      .join('/')
+      .replace(/^\/+/, '')}`
   }
 
   private _removeEmptyFolders(path: string) {


### PR DESCRIPTION
## Summary

Two encoding fixes in supabase-js.

### 1. PKCE code challenge double-encoding (auth-js)
`URLSearchParams` already applies `encodeURIComponent` to its values internally. The explicit `encodeURIComponent()` call on the code challenge values caused **double-encoding** — `%2B` became `%252B`. This broke PKCE verification on the auth server, silently failing OAuth login flows for all apps using PKCE (the default flow type since v2).

### 2. Storage path segments not URI-encoded (storage-js)
`_getFinalPath` interpolated raw path segments into URLs without `encodeURIComponent`. File names containing `#`, `?`, `&`, or spaces produced broken URLs where the fragment/query boundary truncated the URL before reaching the storage server. Affected every storage operation (`upload`, `download`, `getPublicUrl`, `move`, `copy`, `remove`).