### PR TITLE
fix(storage): wrap non-StorageError exceptions in StorageUnknownError

### DIFF
--- a/packages/core/storage-js/src/lib/common/BaseApiClient.ts
+++ b/packages/core/storage-js/src/lib/common/BaseApiClient.ts
@@ -1,4 +1,4 @@
-import { ErrorNamespace, isStorageError, StorageError } from './errors'
+import { ErrorNamespace, isStorageError, StorageError, StorageUnknownError } from './errors'
 import { Fetch } from './fetch'
 import { normalizeHeaders, setHeader as setHeaderUtil } from './headers'
 import { resolveFetch } from './helpers'
@@ -98,7 +98,10 @@ export default abstract class BaseApiClient<TError extends StorageError = Storag
       if (isStorageError(error)) {
         return { data: null, error: error as TError }
       }
-      throw error
+      return {
+        data: null,
+        error: new StorageUnknownError(_getErrorMessage(error), error) as unknown as TError,
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

`handleOperation`'s documented contract is to always return `{ data, error }` tuples. However, when the operation threw a non-StorageError exception (JSON parse failure, TypeError from missing fetch, etc.), the error was re-thrown instead of being wrapped.

**Fix:** Wrap non-StorageError exceptions in `StorageUnknownError` and return `{ data: null, error }`.