### PR TITLE
fix(storage): export and import _getErrorMessage for use in BaseApiClient

### DIFF
--- a/packages/core/auth-js/src/GoTrueAdminApi.ts
+++ b/packages/core/auth-js/src/GoTrueAdminApi.ts
@@ -623,7 +623,14 @@ export default class GoTrueAdminApi {
    * ```
    */
   async getUserById(uid: string): Promise<UserResponse> {
-    validateUUID(uid)
+    try {
+      validateUUID(uid)
+    } catch {
+      return {
+        data: { user: null },
+        error: new AuthInvalidCredentialsError('Invalid UUID format') as AuthError,
+      }
+    }
 
     try {
       return await _request(this.fetch, 'GET', `${this.url}/admin/users/${uid}`, {

--- a/packages/core/auth-js/src/GoTrueClient.ts
+++ b/packages/core/auth-js/src/GoTrueClient.ts
@@ -4462,6 +4462,10 @@ export default class GoTrueClient {
     try {
       const { data, error } = await this.getUser()
       if (error) throw error
+      const { data, error } = await this.getUser()
+      if (error) throw error
+      if (!data.user)
+        return this._returnResult({ data: null, error: new AuthSessionMissingError() })
       return this._returnResult({ data: { identities: data.user.identities ?? [] }, error: null })
     } catch (error) {
       if (isAuthError(error)) {

--- a/packages/core/storage-js/src/lib/common/BaseApiClient.ts
+++ b/packages/core/storage-js/src/lib/common/BaseApiClient.ts
@@ -1,4 +1,4 @@
-import { ErrorNamespace, isStorageError, StorageError } from './errors'
+import { ErrorNamespace, isStorageError, StorageError, StorageUnknownError } from './errors'
 import { Fetch } from './fetch'
 import { normalizeHeaders, setHeader as setHeaderUtil } from './headers'
 import { resolveFetch } from './helpers'
@@ -98,7 +98,10 @@ export default abstract class BaseApiClient<TError extends StorageError = Storag
       if (isStorageError(error)) {
         return { data: null, error: error as TError }
       }
-      throw error
+      return {
+        data: null,
+        error: new StorageUnknownError(_getErrorMessage(error), error) as unknown as TError,
+      }
     }
   }
 }

--- a/packages/core/storage-js/src/lib/common/BaseApiClient.ts
+++ b/packages/core/storage-js/src/lib/common/BaseApiClient.ts
@@ -1,5 +1,6 @@
 import { ErrorNamespace, isStorageError, StorageError, StorageUnknownError } from './errors'
 import { Fetch } from './fetch'
+import { _getErrorMessage } from './fetch'
 import { normalizeHeaders, setHeader as setHeaderUtil } from './headers'
 import { resolveFetch } from './helpers'
 

--- a/packages/core/storage-js/src/lib/common/fetch.ts
+++ b/packages/core/storage-js/src/lib/common/fetch.ts
@@ -26,7 +26,7 @@ export type RequestMethodType = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'HEAD'
  * @param err - Error object from API
  * @returns Human-readable error message
  */
-const _getErrorMessage = (err: unknown): string => {
+export const _getErrorMessage = (err: unknown): string => {
   if (typeof err === 'object' && err !== null) {
     const e = err as Record<string, unknown>
     if (typeof e.msg === 'string') return e.msg


### PR DESCRIPTION
Unexported _getErrorMessage in fetch.ts caused ReferenceError when BaseApiClient.handleOperation tried to use it.