### PR TITLE
fix(auth): downgrade stale refresh token console noise

### DIFF
--- a/packages/core/auth-js/src/GoTrueClient.ts
+++ b/packages/core/auth-js/src/GoTrueClient.ts
@@ -4290,10 +4290,18 @@ export default class GoTrueClient {
       } catch (err) {
         await this.stateChangeEmitters.get(id)?.callback('INITIAL_SESSION', null)
         this._debug('INITIAL_SESSION', 'callback id', id, 'error', err)
-        if (isAuthSessionMissingError(err) || isAuthRetryableFetchError(err)) {
-          // A missing session or a transient/aborted network failure (e.g. a
-          // superseded page navigation cancelling the in-flight request) is
-          // not an application error — warn rather than surface it raw.
+        if (
+          isAuthSessionMissingError(err) ||
+          isAuthRetryableFetchError(err) ||
+          (isAuthApiError(err) &&
+            (err.code === 'refresh_token_not_found' ||
+              err.code === 'refresh_token_already_used' ||
+              err.code === 'session_expired'))
+        ) {
+          // A missing session, a transient/aborted network failure (e.g. a
+          // superseded page navigation cancelling the in-flight request), or
+          // a dead refresh token (e.g. stale SSR cookies) is not an
+          // application error — warn rather than surface it raw.
           console.warn(err)
         } else {
           console.error(err)

--- a/packages/core/auth-js/test/GoTrueClient.test.ts
+++ b/packages/core/auth-js/test/GoTrueClient.test.ts
@@ -4875,6 +4875,36 @@ describe('Refresh-token lifecycle (proactive/reactive, cooldown)', () => {
       warnSpy.mockRestore()
     })
 
+    test('_emitInitialSession downgrades an expired/rotated refresh token to console.warn', async () => {
+      const storage = memoryLocalStorageAdapter()
+      await plantSession(storage, { secondsUntilExpiry: -60 })
+
+      const client = new GoTrueClient({
+        url: GOTRUE_URL_SIGNUP_ENABLED_AUTO_CONFIRM_ON,
+        storage,
+        autoRefreshToken: false,
+        persistSession: true,
+        skipAutoInitialize: true,
+      })
+      stubInvalidGrant(client)
+
+      await client.initialize()
+
+      const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+
+      // Drive the INITIAL_SESSION emission directly so the assertion doesn't
+      // race the fire-and-forget emission scheduled by onAuthStateChange.
+      // @ts-expect-error access private for test
+      await client._emitInitialSession(Symbol('test-invalid-grant-init'))
+
+      expect(errorSpy).not.toHaveBeenCalled()
+      expect(warnSpy).toHaveBeenCalled()
+
+      errorSpy.mockRestore()
+      warnSpy.mockRestore()
+    })
+
     test('_recoverAndRefresh downgrades a retryable failure in its outer catch to console.warn', async () => {
       // Defensive guard: if any step of session recovery throws a transient
       // network error (rather than returning it), the outer catch must warn


### PR DESCRIPTION
## TL;DR 

`_emitInitialSession` already warns instead of erroring for a missing session or a `retryable `fetch failure. 
a dead refresh token
`(refresh_token_not_found, refresh_token_already_used, session_expired)` still hit raw `console.error` even 
though it's the same kind of expected outcome on page load....

this just widens that same check to cover those three codes too. 
## ref: 
- closes #2558
- somewhat the same idea: 
#2214 
 #2428 