### PR TITLE
chore(repo): bump postcss override and fix playwright 1.62 tsconfig failure

### DIFF
--- a/packages/core/supabase-js/test/integration/node-browser/package.json
+++ b/packages/core/supabase-js/test/integration/node-browser/package.json
@@ -7,7 +7,7 @@
     "serve:node-browser": "serve . -p 8004"
   },
   "devDependencies": {
-    "@playwright/test": "^1.40.0",
+    "@playwright/test": "^1.53.0",
     "serve": "^14.2.1"
   }
 }

--- a/packages/core/supabase-js/test/integration/node-browser/tsconfig.json
+++ b/packages/core/supabase-js/test/integration/node-browser/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  // Boundary for Playwright's tsconfig lookup: without this file it walks up
+  // to the package tsconfig, whose directory-form project references its
+  // loader fails to resolve (fatal since playwright 1.62).
+  "compilerOptions": {
+    "allowJs": true,
+    "noEmit": true
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,7 +49,7 @@ catalogs:
 overrides:
   unrun: '>=0.2.39 <0.3.0'
   sharp: '>=0.35.0'
-  postcss: '>=8.5.12'
+  postcss: '>=8.5.18'
   '@babel/core': '>=7.29.1 <8'
 
 importers:
@@ -448,7 +448,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       autoprefixer:
         specifier: ^10.4.20
-        version: 10.5.0(postcss@8.5.16)
+        version: 10.5.0(postcss@8.5.20)
       eslint:
         specifier: ^9
         version: 9.39.4(jiti@1.21.7)
@@ -456,8 +456,8 @@ importers:
         specifier: 15.3.1
         version: 15.3.1(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
       postcss:
-        specifier: '>=8.5.12'
-        version: 8.5.16
+        specifier: '>=8.5.18'
+        version: 8.5.20
       tailwindcss:
         specifier: ^3.4.1
         version: 3.4.19(tsx@4.21.0)(yaml@2.9.0)
@@ -3963,7 +3963,7 @@ packages:
     engines: {node: ^10 || ^12 || >=14}
     hasBin: true
     peerDependencies:
-      postcss: '>=8.5.12'
+      postcss: '>=8.5.18'
 
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
@@ -6802,20 +6802,20 @@ packages:
     resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
-      postcss: '>=8.5.12'
+      postcss: '>=8.5.18'
 
   postcss-js@4.1.0:
     resolution: {integrity: sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==}
     engines: {node: ^12 || ^14 || >= 16}
     peerDependencies:
-      postcss: '>=8.5.12'
+      postcss: '>=8.5.18'
 
   postcss-load-config@6.0.1:
     resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
     engines: {node: '>= 18'}
     peerDependencies:
       jiti: '>=1.21.0'
-      postcss: '>=8.5.12'
+      postcss: '>=8.5.18'
       tsx: ^4.8.1
       yaml: ^2.4.2
     peerDependenciesMeta:
@@ -6832,7 +6832,7 @@ packages:
     resolution: {integrity: sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==}
     engines: {node: '>=12.0'}
     peerDependencies:
-      postcss: '>=8.5.12'
+      postcss: '>=8.5.18'
 
   postcss-selector-parser@6.1.2:
     resolution: {integrity: sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==}
@@ -6841,12 +6841,8 @@ packages:
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
-  postcss@8.5.15:
-    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
-    engines: {node: ^10 || ^12 || >=14}
-
-  postcss@8.5.16:
-    resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
+  postcss@8.5.20:
+    resolution: {integrity: sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -11891,13 +11887,13 @@ snapshots:
 
   at-least-node@1.0.0: {}
 
-  autoprefixer@10.5.0(postcss@8.5.16):
+  autoprefixer@10.5.0(postcss@8.5.20):
     dependencies:
       browserslist: 4.28.2
       caniuse-lite: 1.0.30001792
       fraction.js: 5.3.4
       picocolors: 1.1.1
-      postcss: 8.5.16
+      postcss: 8.5.20
       postcss-value-parser: 4.2.0
 
   available-typed-arrays@1.0.7:
@@ -14832,7 +14828,7 @@ snapshots:
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.29
       caniuse-lite: 1.0.30001792
-      postcss: 8.5.16
+      postcss: 8.5.20
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
       styled-jsx: 5.1.6(@babel/core@7.29.7)(babel-plugin-macros@3.1.0)(react@19.2.6)
@@ -15315,30 +15311,30 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss-import@15.1.0(postcss@8.5.16):
+  postcss-import@15.1.0(postcss@8.5.20):
     dependencies:
-      postcss: 8.5.16
+      postcss: 8.5.20
       postcss-value-parser: 4.2.0
       read-cache: 1.0.0
       resolve: 1.22.12
 
-  postcss-js@4.1.0(postcss@8.5.16):
+  postcss-js@4.1.0(postcss@8.5.20):
     dependencies:
       camelcase-css: 2.0.1
-      postcss: 8.5.16
+      postcss: 8.5.20
 
-  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.16)(tsx@4.21.0)(yaml@2.9.0):
+  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.20)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 1.21.7
-      postcss: 8.5.16
+      postcss: 8.5.20
       tsx: 4.21.0
       yaml: 2.9.0
 
-  postcss-nested@6.2.0(postcss@8.5.16):
+  postcss-nested@6.2.0(postcss@8.5.20):
     dependencies:
-      postcss: 8.5.16
+      postcss: 8.5.20
       postcss-selector-parser: 6.1.2
 
   postcss-selector-parser@6.1.2:
@@ -15348,13 +15344,7 @@ snapshots:
 
   postcss-value-parser@4.2.0: {}
 
-  postcss@8.5.15:
-    dependencies:
-      nanoid: 3.3.12
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
-  postcss@8.5.16:
+  postcss@8.5.20:
     dependencies:
       nanoid: 3.3.16
       picocolors: 1.1.1
@@ -16183,11 +16173,11 @@ snapshots:
       normalize-path: 3.0.0
       object-hash: 3.0.0
       picocolors: 1.1.1
-      postcss: 8.5.16
-      postcss-import: 15.1.0(postcss@8.5.16)
-      postcss-js: 4.1.0(postcss@8.5.16)
-      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.16)(tsx@4.21.0)(yaml@2.9.0)
-      postcss-nested: 6.2.0(postcss@8.5.16)
+      postcss: 8.5.20
+      postcss-import: 15.1.0(postcss@8.5.20)
+      postcss-js: 4.1.0(postcss@8.5.20)
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.20)(tsx@4.21.0)(yaml@2.9.0)
+      postcss-nested: 6.2.0(postcss@8.5.20)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.12
       sucrase: 3.35.1
@@ -16682,7 +16672,7 @@ snapshots:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.15
+      postcss: 8.5.20
       rollup: 4.62.0
       tinyglobby: 0.2.17
     optionalDependencies:
@@ -16698,7 +16688,7 @@ snapshots:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.15
+      postcss: 8.5.20
       rollup: 4.62.0
       tinyglobby: 0.2.17
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -28,9 +28,11 @@ overrides:
   unrun: '>=0.2.39 <0.3.0'
   # Avoid the libvips advisory (GHSA-f88m-g3jw-g9cj) in sharp <0.35.0
   sharp: '>=0.35.0'
-  # Avoid the sourceMappingURL file-read advisory (GHSA-6g55-p6wh-862q) in
-  # postcss <8.5.12; next pins the old 8.4.31 transitively in the realtime example.
-  postcss: '>=8.5.12'
+  # Avoid the sourceMappingURL advisories in postcss: file-read
+  # (GHSA-6g55-p6wh-862q, fixed in 8.5.12) and the follow-up path traversal
+  # (GHSA-r28c-9q8g-f849, fixed in 8.5.18); next pins the old 8.4.31
+  # transitively in the realtime example.
+  postcss: '>=8.5.18'
   # Avoid the sourceMappingURL file-read advisory (GHSA-4x5r-pxfx-6jf8) in
   # @babel/core <=7.29.0; reached via next>styled-jsx in the realtime example.
   # (No 7.29.1 was ever published; 7.29.7 is the first fixed 7.x release.)


### PR DESCRIPTION
Bump the `postcss` override from `>=8.5.12` to `>=8.5.18` (lockfile resolves to 8.5.20) to clear the new path traversal advisory https://github.com/advisories/GHSA-r28c-9q8g-f849, a follow-up to the sourceMappingURL advisory addressed in #2561. As before, postcss is only reached through the dev-only realtime-js example (via `next`, which pins an old version transitively), so no published package is affected.

Also fixes the `test:node:playwright` failure introduced by Playwright 1.62.0, whose tsconfig loader now throws on the directory-form project references in the supabase-js package tsconfig (microsoft/playwright#41571). Adds a boundary `tsconfig.json` in the node-browser test dir so Playwright stops walking up to the package one, and aligns `@playwright/test` to `^1.53.0` with the other playwright test apps.

(reported to playwright here: https://github.com/microsoft/playwright/issues/41998)