### PR TITLE
fix(realtime): preserve presence refs

### DIFF
--- a/packages/core/realtime-js/src/phoenix/presenceAdapter.ts
+++ b/packages/core/realtime-js/src/phoenix/presenceAdapter.ts
@@ -94,12 +94,13 @@ export default class PresenceAdapter {
 
 function transformState(presences: PresenceState) {
   return presences.metas.map((presence) => {
-    presence['presence_ref'] = presence['phx_ref']
+    const transformedPresence = { ...presence }
+    transformedPresence['presence_ref'] = transformedPresence['phx_ref']
 
-    delete presence['phx_ref']
-    delete presence['phx_ref_prev']
+    delete transformedPresence['phx_ref']
+    delete transformedPresence['phx_ref_prev']
 
-    return presence
+    return transformedPresence
   }) as RealtimePresenceType[]
 }
 

--- a/packages/core/realtime-js/src/phoenix/presenceAdapter.ts
+++ b/packages/core/realtime-js/src/phoenix/presenceAdapter.ts
@@ -94,7 +94,9 @@ export default class PresenceAdapter {
 
 function transformState(presences: PresenceState) {
   return presences.metas.map((presence) => {
-    const transformedPresence = { ...presence }
+    // Object spread compiles to Object.assign for ES2017, which treats __proto__ as a setter.
+    const descriptors = Object.getOwnPropertyDescriptors(presence)
+    const transformedPresence = Object.defineProperties({}, descriptors) as typeof presence
     transformedPresence['presence_ref'] = transformedPresence['phx_ref']
 
     delete transformedPresence['phx_ref']

--- a/packages/core/realtime-js/test/phoenix/presenceAdapter.test.ts
+++ b/packages/core/realtime-js/test/phoenix/presenceAdapter.test.ts
@@ -111,6 +111,47 @@ describe('transformState', () => {
   })
 })
 
+describe('presence diff payloads', () => {
+  test('removes a presence key after all of its metas leave', () => {
+    const key = 'user-123'
+    // Each server message is decoded into fresh meta objects.
+    const meta = (phx_ref: string) => ({ phx_ref, user_id: key })
+    let state: PresenceStates = {
+      [key]: { metas: [meta('device-1')] },
+    }
+
+    state = Presence.syncDiff(
+      state,
+      {
+        joins: { [key]: { metas: [meta('device-2')] } },
+        leaves: {},
+      },
+      PresenceAdapter.onJoinPayload,
+      PresenceAdapter.onLeavePayload
+    )
+    state = Presence.syncDiff(
+      state,
+      {
+        joins: {},
+        leaves: { [key]: { metas: [meta('device-2')] } },
+      },
+      PresenceAdapter.onJoinPayload,
+      PresenceAdapter.onLeavePayload
+    )
+    state = Presence.syncDiff(
+      state,
+      {
+        joins: {},
+        leaves: { [key]: { metas: [meta('device-1')] } },
+      },
+      PresenceAdapter.onJoinPayload,
+      PresenceAdapter.onLeavePayload
+    )
+
+    expect(state).not.toHaveProperty(key)
+  })
+})
+
 // Reproduces GHSA-63mc-hw7g-86rr: @supabase/phoenix's Presence.syncState/syncDiff look up
 // presence keys with a bare `state[key]` check, so a key matching an Object.prototype
 // member (e.g. "constructor") resolves to the inherited prototype value instead of

--- a/packages/core/realtime-js/test/phoenix/presenceAdapter.test.ts
+++ b/packages/core/realtime-js/test/phoenix/presenceAdapter.test.ts
@@ -123,6 +123,32 @@ describe('presence diff payloads', () => {
     expect('is_admin' in transformedPresence).toBe(false)
   })
 
+  test('collapses a presence update instead of duplicating the member', () => {
+    const key = 'user-123'
+    let state: PresenceStates = {
+      [key]: { metas: [{ phx_ref: 'r1', status: 'online' }] },
+    }
+    const onJoin = PresenceAdapter.onJoinPayload
+    const onLeave = PresenceAdapter.onLeavePayload
+    const syncDiff = (joins: PresenceStates, leaves: PresenceStates) => {
+      state = Presence.syncDiff(state, { joins, leaves }, onJoin, onLeave)
+    }
+    const updateJoins = {
+      [key]: { metas: [{ phx_ref: 'r2', phx_ref_prev: 'r1', status: 'away' }] },
+    }
+    const updateLeaves = {
+      [key]: { metas: [{ phx_ref: 'r1', status: 'online' }] },
+    }
+
+    // track() with a changed payload: the server sends Presence.update as join + leave.
+    syncDiff(updateJoins, updateLeaves)
+
+    expect(state[key].metas).toHaveLength(1)
+
+    syncDiff({}, { [key]: { metas: [{ phx_ref: 'r2', status: 'away' }] } })
+    expect(state).not.toHaveProperty(key)
+  })
+
   test('removes a presence key after all of its metas leave', () => {
     const key = 'user-123'
     // Each server message is decoded into fresh meta objects.

--- a/packages/core/realtime-js/test/phoenix/presenceAdapter.test.ts
+++ b/packages/core/realtime-js/test/phoenix/presenceAdapter.test.ts
@@ -112,6 +112,17 @@ describe('transformState', () => {
 })
 
 describe('presence diff payloads', () => {
+  test('preserves __proto__ metadata as an own property', () => {
+    const meta = JSON.parse('{"phx_ref":"device-1","__proto__":{"is_admin":true}}')
+    const payload = PresenceAdapter.onJoinPayload('user-123', { metas: [] }, { metas: [meta] })
+    const transformedPresence = payload.newPresences[0]
+
+    expect(Object.getPrototypeOf(transformedPresence)).toBe(Object.prototype)
+    expect(Object.hasOwn(transformedPresence, '__proto__')).toBe(true)
+    expect(Reflect.get(transformedPresence, '__proto__')).toEqual({ is_admin: true })
+    expect('is_admin' in transformedPresence).toBe(false)
+  })
+
   test('removes a presence key after all of its metas leave', () => {
     const key = 'user-123'
     // Each server message is decoded into fresh meta objects.
@@ -119,34 +130,15 @@ describe('presence diff payloads', () => {
     let state: PresenceStates = {
       [key]: { metas: [meta('device-1')] },
     }
+    const onJoin = PresenceAdapter.onJoinPayload
+    const onLeave = PresenceAdapter.onLeavePayload
+    const syncDiff = (joins: PresenceStates, leaves: PresenceStates) => {
+      state = Presence.syncDiff(state, { joins, leaves }, onJoin, onLeave)
+    }
 
-    state = Presence.syncDiff(
-      state,
-      {
-        joins: { [key]: { metas: [meta('device-2')] } },
-        leaves: {},
-      },
-      PresenceAdapter.onJoinPayload,
-      PresenceAdapter.onLeavePayload
-    )
-    state = Presence.syncDiff(
-      state,
-      {
-        joins: {},
-        leaves: { [key]: { metas: [meta('device-2')] } },
-      },
-      PresenceAdapter.onJoinPayload,
-      PresenceAdapter.onLeavePayload
-    )
-    state = Presence.syncDiff(
-      state,
-      {
-        joins: {},
-        leaves: { [key]: { metas: [meta('device-1')] } },
-      },
-      PresenceAdapter.onJoinPayload,
-      PresenceAdapter.onLeavePayload
-    )
+    syncDiff({ [key]: { metas: [meta('device-2')] } }, {})
+    syncDiff({}, { [key]: { metas: [meta('device-2')] } })
+    syncDiff({}, { [key]: { metas: [meta('device-1')] } })
 
     expect(state).not.toHaveProperty(key)
   })


### PR DESCRIPTION
## TL;DR

Build presence event payloads from copies so live presence refs remain intact and
 departed members are removed correctly.

## ref:

- closes #2565