### PR TITLE
fix(auth): fail token refresh fast when offline and resume on reconnect

### DIFF
--- a/packages/core/auth-js/src/GoTrueClient.ts
+++ b/packages/core/auth-js/src/GoTrueClient.ts
@@ -300,6 +300,14 @@ export default class GoTrueClient {
    * restart background work on a client that was already torn down.
    */
   protected _disposed = false
+  /**
+   * True when no custom `fetch` was supplied and requests go through the
+   * environment's own transport. Offline retry suppression in
+   * `_refreshAccessToken` applies only in that case: `navigator.onLine`
+   * describes the user agent's network stack, not custom transports, which
+   * may fail transiently and succeed on a later attempt regardless of it.
+   */
+  protected readonly usesDefaultFetch: boolean
   protected refreshingDeferred: Deferred<CallRefreshTokenResult> | null = null
   /**
    * Cache of the most recent refresh failure, keyed by the refresh token
@@ -445,6 +453,7 @@ export default class GoTrueClient {
     this.url = settings.url
     this.headers = settings.headers
     this.fetch = resolveFetch(settings.fetch)
+    this.usesDefaultFetch = settings.fetch == null
     this.detectSessionInUrl = settings.detectSessionInUrl
     this.flowType = settings.flowType
     this.hasCustomAuthorizationHeader = settings.hasCustomAuthorizationHeader
@@ -4729,15 +4738,17 @@ export default class GoTrueClient {
             error &&
             isAuthRetryableFetchError(error) &&
             // Stop after an actual failure while the environment
-            // affirmatively reports being offline: retries through the user
-            // agent's own transport cannot succeed until connectivity
-            // returns, and the `online` listener resumes refreshing then.
-            // Only the retries are gated, never the first attempt, so
-            // custom `fetch` transports and loopback endpoints that work
-            // while `navigator.onLine` is false are still honored, while
-            // the backoff loop that blocked `getSession()` callers for up
-            // to the full tick duration no longer runs offline.
-            !isProvablyOffline() &&
+            // affirmatively reports being offline, but only on the default
+            // transport: retries through the user agent's own network stack
+            // cannot succeed until connectivity returns, and the `online`
+            // listener resumes refreshing then. A custom `fetch` is not
+            // bound by `navigator.onLine` (it may fail transiently and
+            // succeed on the next attempt even while offline), so it keeps
+            // the full retry loop. First attempts are never gated either
+            // way, which also keeps loopback endpoints working; what no
+            // longer runs offline is the backoff loop that blocked
+            // `getSession()` callers for up to the full tick duration.
+            !(this.usesDefaultFetch && isProvablyOffline()) &&
             // retryable only if the request can be sent before the backoff overflows the tick duration
             Date.now() + nextBackOffInterval - startedAt < AUTO_REFRESH_TICK_DURATION_MS
           )
@@ -5634,8 +5645,8 @@ export default class GoTrueClient {
    * the next auto-refresh tick. The event target comes from
    * `getOnlineEventTarget`: `window` in documents, the worker global scope
    * in Web Workers, which are exactly the environments whose
-   * `navigator.onLine` makes `_refreshAccessToken` stop retrying. No-op
-   * elsewhere. No `offline` listener is needed: while the environment
+   * `navigator.onLine` makes `_refreshAccessToken` stop retrying the
+   * default transport. No-op elsewhere. No `offline` listener is needed: while the environment
    * reports being offline, a failed refresh is not retried, so there is no
    * loop to cancel.
    */

--- a/packages/core/auth-js/src/GoTrueClient.ts
+++ b/packages/core/auth-js/src/GoTrueClient.ts
@@ -18,6 +18,7 @@ import {
   AuthPKCECodeVerifierMissingError,
   AuthPKCEGrantCodeExchangeError,
   AuthRefreshDiscardedError,
+  AuthRetryableFetchError,
   AuthSessionMissingError,
   AuthUnknownError,
   isAuthApiError,
@@ -46,6 +47,7 @@ import {
   getItemAsync,
   insecureUserWarningProxy,
   isBrowser,
+  isProvablyOffline,
   parseParametersFromURL,
   removeItemAsync,
   resolveFetch,
@@ -288,6 +290,7 @@ export default class GoTrueClient {
   protected autoRefreshTicker: ReturnType<typeof setInterval> | null = null
   protected autoRefreshTickTimeout: ReturnType<typeof setTimeout> | null = null
   protected visibilityChangedCallback: (() => Promise<any>) | null = null
+  protected onlineChangedCallback: (() => Promise<any>) | null = null
   protected refreshingDeferred: Deferred<CallRefreshTokenResult> | null = null
   /**
    * Cache of the most recent refresh failure, keyed by the refresh token
@@ -717,6 +720,7 @@ export default class GoTrueClient {
       })
     } finally {
       await this._handleVisibilityChange()
+      this._handleOnlineStatusChange()
       this._debug('#_initialize()', 'end')
     }
   }
@@ -4692,6 +4696,22 @@ export default class GoTrueClient {
             await sleep(200 * Math.pow(2, attempt - 1)) // 200, 400, 800, ...
           }
 
+          // The environment affirmatively reports having no network
+          // connectivity, so the request is guaranteed to fail. Fail fast
+          // with the same retryable error an actual network failure would
+          // produce, instead of running fetches and backoff sleeps that
+          // block `getSession()` callers for up to the full tick duration.
+          // Session preservation, the failure cooldown and callers' error
+          // handling behave exactly as if the request had been sent and
+          // failed; the `online` listener resumes refreshing when
+          // connectivity returns.
+          if (isProvablyOffline()) {
+            throw new AuthRetryableFetchError(
+              'Token refresh skipped because the environment reports being offline',
+              0
+            )
+          }
+
           this._debug(debugName, 'refreshing attempt', attempt)
 
           return await _request(this.fetch, 'POST', `${this.url}/token?grant_type=refresh_token`, {
@@ -4705,6 +4725,10 @@ export default class GoTrueClient {
           return (
             error &&
             isAuthRetryableFetchError(error) &&
+            // no point retrying while provably offline: attempts can't
+            // succeed until connectivity returns, and the `online` listener
+            // picks up from there
+            !isProvablyOffline() &&
             // retryable only if the request can be sent before the backoff overflows the tick duration
             Date.now() + nextBackOffInterval - startedAt < AUTO_REFRESH_TICK_DURATION_MS
           )
@@ -5391,6 +5415,7 @@ export default class GoTrueClient {
    */
   async dispose(): Promise<void> {
     this._removeVisibilityChangedCallback()
+    this._removeOnlineStatusChangeCallback()
     await this._stopAutoRefresh()
     this.broadcastChannel?.close()
     this.broadcastChannel = null
@@ -5581,6 +5606,74 @@ export default class GoTrueClient {
       if (this.autoRefreshToken) {
         this._stopAutoRefresh()
       }
+    }
+  }
+
+  /**
+   * Registers the browser `online` event so refreshing resumes the moment
+   * connectivity returns, instead of waiting out the failure cooldown plus
+   * the next auto-refresh tick. No-op outside browsers. No `offline`
+   * listener is needed: while the environment reports being offline,
+   * refresh attempts fail fast (see `_refreshAccessToken`).
+   */
+  private _handleOnlineStatusChange() {
+    if (!isBrowser() || !window?.addEventListener) {
+      return
+    }
+
+    try {
+      this.onlineChangedCallback = async () => {
+        try {
+          await this._onOnline()
+        } catch (error) {
+          this._debug('#onlineChangedCallback', 'error', error)
+        }
+      }
+
+      window?.addEventListener('online', this.onlineChangedCallback)
+    } catch (error) {
+      console.error('_handleOnlineStatusChange', error)
+    }
+  }
+
+  /**
+   * Callback registered with `window.addEventListener('online')`.
+   */
+  private async _onOnline() {
+    this._debug('#_onOnline()', 'network connectivity restored')
+
+    // The failure cooldown exists to stop refresh storms against the same
+    // broken refresh token; a connectivity transition invalidates that
+    // cached outcome, so the next caller attempts a real refresh
+    // immediately instead of receiving a stale offline failure.
+    this.lastRefreshFailure = null
+
+    await this.initializePromise
+
+    if (this.autoRefreshTicker) {
+      // Refresh proactively only where the ticker is already running (in
+      // browsers: the foreground tab), matching the single-tab discipline
+      // of the visibilitychange handler. Background tabs still benefit from
+      // the cooldown reset above and refresh on their next getSession().
+      await this._autoRefreshTokenTick()
+    }
+  }
+
+  /**
+   * Removes any registered `online` event callback.
+   */
+  private _removeOnlineStatusChangeCallback() {
+    this._debug('#_removeOnlineStatusChangeCallback()')
+
+    const callback = this.onlineChangedCallback
+    this.onlineChangedCallback = null
+
+    try {
+      if (callback && isBrowser() && window?.removeEventListener) {
+        window.removeEventListener('online', callback)
+      }
+    } catch (e) {
+      console.error('removing online callback failed', e)
     }
   }
 

--- a/packages/core/auth-js/src/GoTrueClient.ts
+++ b/packages/core/auth-js/src/GoTrueClient.ts
@@ -18,7 +18,6 @@ import {
   AuthPKCECodeVerifierMissingError,
   AuthPKCEGrantCodeExchangeError,
   AuthRefreshDiscardedError,
-  AuthRetryableFetchError,
   AuthSessionMissingError,
   AuthUnknownError,
   isAuthApiError,
@@ -4716,22 +4715,6 @@ export default class GoTrueClient {
             await sleep(200 * Math.pow(2, attempt - 1)) // 200, 400, 800, ...
           }
 
-          // The environment affirmatively reports having no network
-          // connectivity, so the request is guaranteed to fail. Fail fast
-          // with the same retryable error an actual network failure would
-          // produce, instead of running fetches and backoff sleeps that
-          // block `getSession()` callers for up to the full tick duration.
-          // Session preservation, the failure cooldown and callers' error
-          // handling behave exactly as if the request had been sent and
-          // failed; the `online` listener resumes refreshing when
-          // connectivity returns.
-          if (isProvablyOffline()) {
-            throw new AuthRetryableFetchError(
-              'Token refresh skipped because the environment reports being offline',
-              0
-            )
-          }
-
           this._debug(debugName, 'refreshing attempt', attempt)
 
           return await _request(this.fetch, 'POST', `${this.url}/token?grant_type=refresh_token`, {
@@ -4745,9 +4728,15 @@ export default class GoTrueClient {
           return (
             error &&
             isAuthRetryableFetchError(error) &&
-            // no point retrying while provably offline: attempts can't
-            // succeed until connectivity returns, and the `online` listener
-            // picks up from there
+            // Stop after an actual failure while the environment
+            // affirmatively reports being offline: retries through the user
+            // agent's own transport cannot succeed until connectivity
+            // returns, and the `online` listener resumes refreshing then.
+            // Only the retries are gated, never the first attempt, so
+            // custom `fetch` transports and loopback endpoints that work
+            // while `navigator.onLine` is false are still honored, while
+            // the backoff loop that blocked `getSession()` callers for up
+            // to the full tick duration no longer runs offline.
             !isProvablyOffline() &&
             // retryable only if the request can be sent before the backoff overflows the tick duration
             Date.now() + nextBackOffInterval - startedAt < AUTO_REFRESH_TICK_DURATION_MS
@@ -5645,9 +5634,10 @@ export default class GoTrueClient {
    * the next auto-refresh tick. The event target comes from
    * `getOnlineEventTarget`: `window` in documents, the worker global scope
    * in Web Workers, which are exactly the environments whose
-   * `navigator.onLine` makes `_refreshAccessToken` fail fast. No-op
+   * `navigator.onLine` makes `_refreshAccessToken` stop retrying. No-op
    * elsewhere. No `offline` listener is needed: while the environment
-   * reports being offline, refresh attempts fail fast.
+   * reports being offline, a failed refresh is not retried, so there is no
+   * loop to cancel.
    */
   private _handleOnlineStatusChange() {
     const target = getOnlineEventTarget()

--- a/packages/core/auth-js/src/GoTrueClient.ts
+++ b/packages/core/auth-js/src/GoTrueClient.ts
@@ -47,6 +47,7 @@ import {
   getOnlineEventTarget,
   insecureUserWarningProxy,
   isBrowser,
+  isLoopbackHost,
   isProvablyOffline,
   parseParametersFromURL,
   removeItemAsync,
@@ -301,13 +302,15 @@ export default class GoTrueClient {
    */
   protected _disposed = false
   /**
-   * True when no custom `fetch` was supplied and requests go through the
-   * environment's own transport. Offline retry suppression in
-   * `_refreshAccessToken` applies only in that case: `navigator.onLine`
-   * describes the user agent's network stack, not custom transports, which
-   * may fail transiently and succeed on a later attempt regardless of it.
+   * True when offline retry suppression in `_refreshAccessToken` can apply:
+   * requests go through the environment's own transport (no custom `fetch`
+   * was supplied) toward a non-loopback host. `navigator.onLine` describes
+   * the user agent's connectivity to the network, so neither bound applies
+   * elsewhere: custom transports may fail transiently and succeed on a later
+   * attempt regardless of it, and loopback endpoints stay reachable without
+   * it. Both keep the full retry loop.
    */
-  protected readonly usesDefaultFetch: boolean
+  protected readonly offlineRetrySuppressionApplies: boolean
   protected refreshingDeferred: Deferred<CallRefreshTokenResult> | null = null
   /**
    * Cache of the most recent refresh failure, keyed by the refresh token
@@ -453,7 +456,7 @@ export default class GoTrueClient {
     this.url = settings.url
     this.headers = settings.headers
     this.fetch = resolveFetch(settings.fetch)
-    this.usesDefaultFetch = settings.fetch == null
+    this.offlineRetrySuppressionApplies = settings.fetch == null && !isLoopbackHost(settings.url)
     this.detectSessionInUrl = settings.detectSessionInUrl
     this.flowType = settings.flowType
     this.hasCustomAuthorizationHeader = settings.hasCustomAuthorizationHeader
@@ -4738,17 +4741,17 @@ export default class GoTrueClient {
             error &&
             isAuthRetryableFetchError(error) &&
             // Stop after an actual failure while the environment
-            // affirmatively reports being offline, but only on the default
-            // transport: retries through the user agent's own network stack
-            // cannot succeed until connectivity returns, and the `online`
-            // listener resumes refreshing then. A custom `fetch` is not
-            // bound by `navigator.onLine` (it may fail transiently and
-            // succeed on the next attempt even while offline), so it keeps
-            // the full retry loop. First attempts are never gated either
-            // way, which also keeps loopback endpoints working; what no
-            // longer runs offline is the backoff loop that blocked
-            // `getSession()` callers for up to the full tick duration.
-            !(this.usesDefaultFetch && isProvablyOffline()) &&
+            // affirmatively reports being offline, but only where the
+            // signal is binding: the default transport toward a
+            // non-loopback host, whose retries cannot succeed until
+            // connectivity returns (the `online` listener resumes
+            // refreshing then). Custom `fetch` transports are not bound by
+            // `navigator.onLine` and loopback endpoints stay reachable
+            // without it, so both keep the full retry loop; first attempts
+            // are never gated anywhere. What no longer runs offline is the
+            // backoff loop that blocked `getSession()` callers for up to
+            // the full tick duration.
+            !(this.offlineRetrySuppressionApplies && isProvablyOffline()) &&
             // retryable only if the request can be sent before the backoff overflows the tick duration
             Date.now() + nextBackOffInterval - startedAt < AUTO_REFRESH_TICK_DURATION_MS
           )

--- a/packages/core/auth-js/src/GoTrueClient.ts
+++ b/packages/core/auth-js/src/GoTrueClient.ts
@@ -294,10 +294,11 @@ export default class GoTrueClient {
   protected onlineChangedCallback: (() => Promise<any>) | null = null
   /**
    * Set by `dispose()`. `_initialize()` checks it before registering the
-   * visibilitychange / online listeners so a dispose that runs while
-   * initialization is still pending (React Strict Mode, HMR) does not leak
-   * listeners or start background work on a client that was already torn
-   * down.
+   * visibilitychange / online listeners (re-checking after each await, since
+   * dispose can interleave with them), and `_startAutoRefresh()` checks it
+   * before creating timers, so a dispose that runs while initialization is
+   * still pending (React Strict Mode, HMR) does not leak listeners or
+   * restart background work on a client that was already torn down.
    */
   protected _disposed = false
   protected refreshingDeferred: Deferred<CallRefreshTokenResult> | null = null
@@ -730,8 +731,16 @@ export default class GoTrueClient {
     } finally {
       if (!this._disposed) {
         await this._handleVisibilityChange()
+      }
+
+      // Re-checked rather than hoisted: dispose() may have run while
+      // _handleVisibilityChange was awaited, and its cleanup has already
+      // completed by then, so registering the online listener now would
+      // leak it on a torn-down client.
+      if (!this._disposed) {
         this._handleOnlineStatusChange()
       }
+
       this._debug('#_initialize()', 'end')
     }
   }
@@ -5248,6 +5257,13 @@ export default class GoTrueClient {
    */
   private async _startAutoRefresh() {
     await this._stopAutoRefresh()
+
+    if (this._disposed) {
+      // dispose() interleaved with the await above; its own _stopAutoRefresh
+      // has already run, so timers created now would leak on a torn-down
+      // client with nothing left to clear them.
+      return
+    }
 
     this._debug('#_startAutoRefresh()')
 

--- a/packages/core/auth-js/src/GoTrueClient.ts
+++ b/packages/core/auth-js/src/GoTrueClient.ts
@@ -45,6 +45,7 @@ import {
   getAlgorithm,
   getCodeChallengeAndMethod,
   getItemAsync,
+  getOnlineEventTarget,
   insecureUserWarningProxy,
   isBrowser,
   isProvablyOffline,
@@ -291,6 +292,14 @@ export default class GoTrueClient {
   protected autoRefreshTickTimeout: ReturnType<typeof setTimeout> | null = null
   protected visibilityChangedCallback: (() => Promise<any>) | null = null
   protected onlineChangedCallback: (() => Promise<any>) | null = null
+  /**
+   * Set by `dispose()`. `_initialize()` checks it before registering the
+   * visibilitychange / online listeners so a dispose that runs while
+   * initialization is still pending (React Strict Mode, HMR) does not leak
+   * listeners or start background work on a client that was already torn
+   * down.
+   */
+  protected _disposed = false
   protected refreshingDeferred: Deferred<CallRefreshTokenResult> | null = null
   /**
    * Cache of the most recent refresh failure, keyed by the refresh token
@@ -719,8 +728,10 @@ export default class GoTrueClient {
         error: new AuthUnknownError('Unexpected error during initialization', error),
       })
     } finally {
-      await this._handleVisibilityChange()
-      this._handleOnlineStatusChange()
+      if (!this._disposed) {
+        await this._handleVisibilityChange()
+        this._handleOnlineStatusChange()
+      }
       this._debug('#_initialize()', 'end')
     }
   }
@@ -5414,6 +5425,9 @@ export default class GoTrueClient {
    * ```
    */
   async dispose(): Promise<void> {
+    // Set before any await so an initialization that is still pending sees
+    // it and skips its late listener registration (see _initialize).
+    this._disposed = true
     this._removeVisibilityChangedCallback()
     this._removeOnlineStatusChangeCallback()
     await this._stopAutoRefresh()
@@ -5610,14 +5624,18 @@ export default class GoTrueClient {
   }
 
   /**
-   * Registers the browser `online` event so refreshing resumes the moment
+   * Registers the `online` event so refreshing resumes the moment
    * connectivity returns, instead of waiting out the failure cooldown plus
-   * the next auto-refresh tick. No-op outside browsers. No `offline`
-   * listener is needed: while the environment reports being offline,
-   * refresh attempts fail fast (see `_refreshAccessToken`).
+   * the next auto-refresh tick. The event target comes from
+   * `getOnlineEventTarget`: `window` in documents, the worker global scope
+   * in Web Workers, which are exactly the environments whose
+   * `navigator.onLine` makes `_refreshAccessToken` fail fast. No-op
+   * elsewhere. No `offline` listener is needed: while the environment
+   * reports being offline, refresh attempts fail fast.
    */
   private _handleOnlineStatusChange() {
-    if (!isBrowser() || !window?.addEventListener) {
+    const target = getOnlineEventTarget()
+    if (!target) {
       return
     }
 
@@ -5630,7 +5648,7 @@ export default class GoTrueClient {
         }
       }
 
-      window?.addEventListener('online', this.onlineChangedCallback)
+      target.addEventListener('online', this.onlineChangedCallback)
     } catch (error) {
       console.error('_handleOnlineStatusChange', error)
     }
@@ -5669,8 +5687,9 @@ export default class GoTrueClient {
     this.onlineChangedCallback = null
 
     try {
-      if (callback && isBrowser() && window?.removeEventListener) {
-        window.removeEventListener('online', callback)
+      const target = getOnlineEventTarget()
+      if (callback && target) {
+        target.removeEventListener('online', callback)
       }
     } catch (e) {
       console.error('removing online callback failed', e)

--- a/packages/core/auth-js/src/lib/helpers.ts
+++ b/packages/core/auth-js/src/lib/helpers.ts
@@ -42,6 +42,36 @@ export const isBrowser = () => typeof window !== 'undefined' && typeof document 
 export const isProvablyOffline = () =>
   typeof navigator !== 'undefined' && typeof navigator.onLine === 'boolean' && !navigator.onLine
 
+export interface OnlineEventTarget {
+  addEventListener(type: 'online', listener: () => unknown): void
+  removeEventListener(type: 'online', listener: () => unknown): void
+}
+
+/**
+ * Returns the global object to observe reconnection on, or null when the
+ * environment cannot observe it. Documents receive the `online` event on
+ * `window`, Web Workers on the worker global scope; `globalThis` is both, and
+ * the same environments expose the boolean `navigator.onLine` that
+ * `isProvablyOffline` reads, so fail-fast and reconnection handling stay
+ * active in the same set of environments. Environments without a boolean
+ * `navigator.onLine` or without global listener support (React Native,
+ * Node.js, Deno) return null.
+ */
+export function getOnlineEventTarget(): OnlineEventTarget | null {
+  if (typeof navigator === 'undefined' || typeof navigator.onLine !== 'boolean') {
+    return null
+  }
+
+  if (
+    typeof globalThis.addEventListener !== 'function' ||
+    typeof globalThis.removeEventListener !== 'function'
+  ) {
+    return null
+  }
+
+  return globalThis
+}
+
 const localStorageWriteTests = {
   tested: false,
   writable: false,

--- a/packages/core/auth-js/src/lib/helpers.ts
+++ b/packages/core/auth-js/src/lib/helpers.ts
@@ -28,6 +28,20 @@ export function generateCallbackId(): symbol {
 
 export const isBrowser = () => typeof window !== 'undefined' && typeof document !== 'undefined'
 
+/**
+ * Returns true only when the environment affirmatively reports having no
+ * network connectivity (`navigator.onLine === false`).
+ *
+ * Per the HTML spec, `onLine === false` means the user agent will not contact
+ * the network, so a request is guaranteed to fail. The opposite is not true:
+ * `onLine === true` may be reported while the network is unreachable, so a
+ * `true` value is never used to make decisions. Environments without a boolean
+ * `navigator.onLine` (React Native, Node.js, Deno) always return false and are
+ * unaffected by callers that branch on this.
+ */
+export const isProvablyOffline = () =>
+  typeof navigator !== 'undefined' && typeof navigator.onLine === 'boolean' && !navigator.onLine
+
 const localStorageWriteTests = {
   tested: false,
   writable: false,

--- a/packages/core/auth-js/src/lib/helpers.ts
+++ b/packages/core/auth-js/src/lib/helpers.ts
@@ -47,16 +47,27 @@ export const isProvablyOffline = () =>
   typeof navigator !== 'undefined' && typeof navigator.onLine === 'boolean' && !navigator.onLine
 
 /**
- * Whether a URL targets a loopback host: `localhost`, `*.localhost`,
- * `127.0.0.0/8` or `[::1]`, mirroring the loopback rules of the W3C
- * "potentially trustworthy origin" definition. Loopback stays reachable
- * while `navigator.onLine === false` (the signal describes connectivity to
- * the network, not to the local machine), so offline retry suppression must
- * not apply to it. Unparseable URLs return false.
+ * Whether a URL targets a loopback host: `localhost`, `*.localhost` (also
+ * their fully qualified trailing-dot forms), `127.0.0.0/8` or `[::1]`,
+ * mirroring the loopback rules of the W3C "potentially trustworthy origin"
+ * definition. Loopback stays reachable while `navigator.onLine === false`
+ * (the signal describes connectivity to the network, not to the local
+ * machine), so offline retry suppression must not apply to it. Unparseable
+ * URLs return false.
  */
 export function isLoopbackHost(url: string): boolean {
   try {
-    const { hostname } = new URL(url)
+    let { hostname } = new URL(url)
+
+    // The URL parser keeps the trailing dot of fully qualified name forms
+    // ("localhost.", "project.localhost."); Secure Contexts includes them in
+    // its loopback matching, so strip exactly one before comparing. IPv4
+    // hosts are already normalized by the parser ("127.0.0.1." parses to
+    // "127.0.0.1").
+    if (hostname.endsWith('.')) {
+      hostname = hostname.slice(0, -1)
+    }
+
     return (
       hostname === 'localhost' ||
       hostname.endsWith('.localhost') ||

--- a/packages/core/auth-js/src/lib/helpers.ts
+++ b/packages/core/auth-js/src/lib/helpers.ts
@@ -37,8 +37,9 @@ export const isBrowser = () => typeof window !== 'undefined' && typeof document 
  * user agent's own transport cannot succeed until connectivity returns. The
  * guarantee does not extend to custom `fetch` transports or loopback
  * endpoints, and `onLine === true` may be reported while the network is
- * unreachable, so callers only use this to stop retrying after an actual
- * failure, never to skip a request. Environments without a boolean
+ * unreachable, so callers only use this to stop retrying default-transport
+ * requests after an actual failure, never to skip a request and never for
+ * custom transports. Environments without a boolean
  * `navigator.onLine` (React Native, Node.js, Deno) always return false and
  * are unaffected by callers that branch on this.
  */

--- a/packages/core/auth-js/src/lib/helpers.ts
+++ b/packages/core/auth-js/src/lib/helpers.ts
@@ -46,6 +46,28 @@ export const isBrowser = () => typeof window !== 'undefined' && typeof document 
 export const isProvablyOffline = () =>
   typeof navigator !== 'undefined' && typeof navigator.onLine === 'boolean' && !navigator.onLine
 
+/**
+ * Whether a URL targets a loopback host: `localhost`, `*.localhost`,
+ * `127.0.0.0/8` or `[::1]`, mirroring the loopback rules of the W3C
+ * "potentially trustworthy origin" definition. Loopback stays reachable
+ * while `navigator.onLine === false` (the signal describes connectivity to
+ * the network, not to the local machine), so offline retry suppression must
+ * not apply to it. Unparseable URLs return false.
+ */
+export function isLoopbackHost(url: string): boolean {
+  try {
+    const { hostname } = new URL(url)
+    return (
+      hostname === 'localhost' ||
+      hostname.endsWith('.localhost') ||
+      hostname === '[::1]' ||
+      /^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(hostname)
+    )
+  } catch {
+    return false
+  }
+}
+
 export interface OnlineEventTarget {
   addEventListener(type: 'online', listener: () => unknown): void
   removeEventListener(type: 'online', listener: () => unknown): void

--- a/packages/core/auth-js/src/lib/helpers.ts
+++ b/packages/core/auth-js/src/lib/helpers.ts
@@ -33,11 +33,14 @@ export const isBrowser = () => typeof window !== 'undefined' && typeof document 
  * network connectivity (`navigator.onLine === false`).
  *
  * Per the HTML spec, `onLine === false` means the user agent will not contact
- * the network, so a request is guaranteed to fail. The opposite is not true:
- * `onLine === true` may be reported while the network is unreachable, so a
- * `true` value is never used to make decisions. Environments without a boolean
- * `navigator.onLine` (React Native, Node.js, Deno) always return false and are
- * unaffected by callers that branch on this.
+ * the network for remote requests, so retrying such a request through the
+ * user agent's own transport cannot succeed until connectivity returns. The
+ * guarantee does not extend to custom `fetch` transports or loopback
+ * endpoints, and `onLine === true` may be reported while the network is
+ * unreachable, so callers only use this to stop retrying after an actual
+ * failure, never to skip a request. Environments without a boolean
+ * `navigator.onLine` (React Native, Node.js, Deno) always return false and
+ * are unaffected by callers that branch on this.
  */
 export const isProvablyOffline = () =>
   typeof navigator !== 'undefined' && typeof navigator.onLine === 'boolean' && !navigator.onLine

--- a/packages/core/auth-js/test/GoTrueClient.browser.test.ts
+++ b/packages/core/auth-js/test/GoTrueClient.browser.test.ts
@@ -1335,4 +1335,42 @@ describe('online event handling', () => {
     // listener removed, so the seeded cooldown is untouched
     expect(client.lastRefreshFailure).not.toBeNull()
   })
+
+  test('dispose during pending initialization registers no lifecycle listeners', async () => {
+    const addSpy = jest.spyOn(window, 'addEventListener')
+
+    // Storage whose first read blocks until released, keeping _initialize
+    // pending across the dispose() call (React Strict Mode / HMR shape).
+    let releaseStorage: () => void = () => {}
+    const gate = new Promise<void>((resolve) => {
+      releaseStorage = resolve
+    })
+    const backing = memoryLocalStorageAdapter()
+    const delayedStorage = {
+      getItem: async (key: string) => {
+        await gate
+        return backing.getItem(key)
+      },
+      setItem: (key: string, value: string) => backing.setItem(key, value),
+      removeItem: (key: string) => backing.removeItem(key),
+    }
+
+    const client = new GoTrueClient({
+      url: 'http://localhost:9999',
+      storage: delayedStorage,
+      autoRefreshToken: false,
+      persistSession: true,
+    })
+    const initPromise = client.initialize()
+    await client.dispose()
+    releaseStorage()
+    await initPromise
+
+    const lifecycleListeners = addSpy.mock.calls.filter(
+      ([type]) => type === 'online' || type === 'visibilitychange',
+    )
+    expect(lifecycleListeners).toHaveLength(0)
+
+    addSpy.mockRestore()
+  })
 })

--- a/packages/core/auth-js/test/GoTrueClient.browser.test.ts
+++ b/packages/core/auth-js/test/GoTrueClient.browser.test.ts
@@ -1373,4 +1373,58 @@ describe('online event handling', () => {
 
     addSpy.mockRestore()
   })
+
+  test('dispose during visibility setup: no online listener, no restarted ticker', async () => {
+    const addSpy = jest.spyOn(window, 'addEventListener')
+
+    const client = new GoTrueClient({
+      url: 'http://localhost:9999',
+      storage: memoryLocalStorageAdapter(),
+      autoRefreshToken: true,
+      persistSession: true,
+      skipAutoInitialize: true,
+    })
+
+    // Gate _onVisibilityChanged so dispose() interleaves inside
+    // _handleVisibilityChange's await, after initialization already passed
+    // its first _disposed check. The original then resumes on the disposed
+    // client and reaches _startAutoRefresh.
+    let release: () => void = () => {}
+    const gate = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    const original = (client as any)._onVisibilityChanged.bind(client)
+    jest
+      .spyOn(client as any, '_onVisibilityChanged')
+      .mockImplementation(async (...args: unknown[]) => {
+        await gate
+        return original(...args)
+      })
+
+    const initPromise = client.initialize()
+    await flush() // let initialize reach the gated await
+    await client.dispose()
+    release()
+    await initPromise
+    await flush() // let the fire-and-forget _startAutoRefresh settle
+
+    expect(addSpy.mock.calls.filter(([type]) => type === 'online')).toHaveLength(0)
+    expect((client as any).autoRefreshTicker).toBeNull()
+    expect((client as any).autoRefreshTickTimeout).toBeNull()
+
+    addSpy.mockRestore()
+  })
+
+  test('_startAutoRefresh resumed after dispose creates no timers', async () => {
+    const client = buildClient()
+    await client.initialize()
+
+    // Suspended at its internal await when dispose() runs.
+    const startPromise = (client as any)._startAutoRefresh()
+    await client.dispose()
+    await startPromise
+
+    expect((client as any).autoRefreshTicker).toBeNull()
+    expect((client as any).autoRefreshTickTimeout).toBeNull()
+  })
 })

--- a/packages/core/auth-js/test/GoTrueClient.browser.test.ts
+++ b/packages/core/auth-js/test/GoTrueClient.browser.test.ts
@@ -1264,3 +1264,75 @@ describe('MFA Complex Branches', () => {
     expect(mockFetch).toHaveBeenCalled()
   })
 })
+
+describe('online event handling', () => {
+  const GoTrueClient = require('../src/GoTrueClient').default
+  const { memoryLocalStorageAdapter } = require('../src/lib/local-storage')
+
+  const buildClient = () =>
+    new GoTrueClient({
+      url: 'http://localhost:9999',
+      storage: memoryLocalStorageAdapter(),
+      autoRefreshToken: false,
+      persistSession: true,
+    })
+
+  const seedCooldown = (client: any) => {
+    client.lastRefreshFailure = {
+      refreshToken: 'refresh-token-r1',
+      result: { data: null, error: { name: 'AuthRetryableFetchError' } },
+      expiresAt: Date.now() + 60_000,
+    }
+  }
+
+  const flush = () => new Promise((resolve) => setTimeout(resolve, 0))
+
+  test('online event clears the refresh-failure cooldown', async () => {
+    const client = buildClient()
+    await client.initialize()
+    seedCooldown(client)
+
+    window.dispatchEvent(new Event('online'))
+    await flush()
+
+    expect(client.lastRefreshFailure).toBeNull()
+
+    await client.dispose()
+  })
+
+  test('online event ticks only while the auto-refresh ticker is active', async () => {
+    const client = buildClient()
+    await client.initialize()
+
+    const tickSpy = jest.spyOn(client, '_autoRefreshTokenTick').mockResolvedValue(undefined)
+
+    // Ticker not running (e.g. background tab): no proactive refresh.
+    window.dispatchEvent(new Event('online'))
+    await flush()
+    expect(tickSpy).not.toHaveBeenCalled()
+
+    await client.startAutoRefresh()
+    await flush() // let startAutoRefresh's own initial tick fire
+    tickSpy.mockClear()
+
+    window.dispatchEvent(new Event('online'))
+    await flush()
+    expect(tickSpy).toHaveBeenCalled()
+
+    await client.stopAutoRefresh()
+    await client.dispose()
+  })
+
+  test('dispose removes the online listener', async () => {
+    const client = buildClient()
+    await client.initialize()
+    await client.dispose()
+
+    seedCooldown(client)
+    window.dispatchEvent(new Event('online'))
+    await flush()
+
+    // listener removed, so the seeded cooldown is untouched
+    expect(client.lastRefreshFailure).not.toBeNull()
+  })
+})

--- a/packages/core/auth-js/test/GoTrueClient.browser.test.ts
+++ b/packages/core/auth-js/test/GoTrueClient.browser.test.ts
@@ -1367,7 +1367,7 @@ describe('online event handling', () => {
     await initPromise
 
     const lifecycleListeners = addSpy.mock.calls.filter(
-      ([type]) => type === 'online' || type === 'visibilitychange',
+      ([type]) => type === 'online' || type === 'visibilitychange'
     )
     expect(lifecycleListeners).toHaveLength(0)
 

--- a/packages/core/auth-js/test/GoTrueClient.test.ts
+++ b/packages/core/auth-js/test/GoTrueClient.test.ts
@@ -5072,5 +5072,64 @@ describe('Refresh-token lifecycle (proactive/reactive, cooldown)', () => {
         jest.useRealTimers()
       }
     })
+
+    test('worker-style global (no window): online listener registers, clears cooldown, removed on dispose', async () => {
+      // Simulates a Web Worker: window/document are undefined, but the
+      // environment exposes a boolean navigator.onLine (WorkerNavigator)
+      // and global online events (WorkerGlobalScope). Fail-fast activates
+      // there, so reconnection handling must too.
+      setNavigator({ onLine: true })
+
+      const added: Array<[string, () => unknown]> = []
+      const removed: Array<[string, () => unknown]> = []
+      const originalAdd = Object.getOwnPropertyDescriptor(globalThis, 'addEventListener')
+      const originalRemove = Object.getOwnPropertyDescriptor(globalThis, 'removeEventListener')
+      Object.defineProperty(globalThis, 'addEventListener', {
+        value: (type: string, listener: () => unknown) => added.push([type, listener]),
+        configurable: true,
+        writable: true,
+      })
+      Object.defineProperty(globalThis, 'removeEventListener', {
+        value: (type: string, listener: () => unknown) => removed.push([type, listener]),
+        configurable: true,
+        writable: true,
+      })
+
+      try {
+        const storage = memoryLocalStorageAdapter()
+        const client = buildClientWithFetch(storage, jest.fn())
+        await client.initialize()
+
+        const onlineListeners = added.filter(([type]) => type === 'online')
+        expect(onlineListeners).toHaveLength(1)
+
+        // An offline refresh failure caches a cooldown entry...
+        // @ts-expect-error access protected for test
+        client.lastRefreshFailure = {
+          refreshToken: 'refresh-token-r1',
+          result: { data: null, error: { name: 'AuthRetryableFetchError' } } as any,
+          expiresAt: Date.now() + 60_000,
+        }
+
+        // ...and the worker-global online event clears it on reconnection.
+        await onlineListeners[0][1]()
+        // @ts-expect-error access protected for test
+        expect(client.lastRefreshFailure).toBeNull()
+
+        await client.dispose()
+        expect(removed.filter(([type]) => type === 'online')).toHaveLength(1)
+      } finally {
+        if (originalAdd) {
+          Object.defineProperty(globalThis, 'addEventListener', originalAdd)
+        } else {
+          delete (globalThis as any).addEventListener
+        }
+        if (originalRemove) {
+          Object.defineProperty(globalThis, 'removeEventListener', originalRemove)
+        } else {
+          delete (globalThis as any).removeEventListener
+        }
+      }
+    })
   })
 })

--- a/packages/core/auth-js/test/GoTrueClient.test.ts
+++ b/packages/core/auth-js/test/GoTrueClient.test.ts
@@ -4952,4 +4952,125 @@ describe('Refresh-token lifecycle (proactive/reactive, cooldown)', () => {
       errorSpy.mockRestore()
     })
   })
+
+  describe('offline fail-fast (provably offline)', () => {
+    const originalNavigator = Object.getOwnPropertyDescriptor(globalThis, 'navigator')
+
+    const setNavigator = (value: unknown) => {
+      Object.defineProperty(globalThis, 'navigator', {
+        value,
+        configurable: true,
+        writable: true,
+      })
+    }
+
+    afterEach(() => {
+      if (originalNavigator) {
+        Object.defineProperty(globalThis, 'navigator', originalNavigator)
+      } else {
+        delete (globalThis as any).navigator
+      }
+    })
+
+    const buildClientWithFetch = (
+      storage: ReturnType<typeof memoryLocalStorageAdapter>,
+      fetchSpy: jest.Mock
+    ) =>
+      new GoTrueClient({
+        url: GOTRUE_URL_SIGNUP_ENABLED_AUTO_CONFIRM_ON,
+        storage,
+        autoRefreshToken: false,
+        persistSession: true,
+        fetch: fetchSpy as any,
+      })
+
+    test('refresh fails fast without network attempts or backoff sleeps', async () => {
+      setNavigator({ onLine: false })
+      const storage = memoryLocalStorageAdapter()
+      const fetchSpy = jest.fn()
+      const client = buildClientWithFetch(storage, fetchSpy)
+      await client.initialize()
+      await plantSession(storage, { secondsUntilExpiry: -60 })
+
+      const startedAt = Date.now()
+      // @ts-expect-error access protected for test
+      const result = await client._callRefreshToken('refresh-token-r1')
+      const elapsed = Date.now() - startedAt
+
+      expect(result.data).toBeNull()
+      expect((result.error as AuthError)?.name).toBe('AuthRetryableFetchError')
+      // no request went out and the ~25s retry/backoff loop did not run
+      expect(fetchSpy).not.toHaveBeenCalled()
+      expect(elapsed).toBeLessThan(1000)
+
+      // the failure enters the regular cooldown so subsequent ticks stay quiet
+      // @ts-expect-error access protected for test
+      expect(client.lastRefreshFailure).not.toBeNull()
+
+      // retryable failure: session must survive in storage
+      const stored = (await getItemAsync(storage, STORAGE_KEY)) as Session | null
+      expect(stored?.refresh_token).toBe('refresh-token-r1')
+    })
+
+    test('getSession() offline with access token still valid → preserved session, no error', async () => {
+      setNavigator({ onLine: false })
+      const storage = memoryLocalStorageAdapter()
+      const fetchSpy = jest.fn()
+      const client = buildClientWithFetch(storage, fetchSpy)
+      await client.initialize()
+      // inside EXPIRY_MARGIN_MS (triggers proactive refresh) but not expired
+      await plantSession(storage, { secondsUntilExpiry: 30 })
+
+      const { data, error } = await client.getSession()
+
+      expect(error).toBeNull()
+      expect(data.session?.access_token).toBe('jwt.accesstoken.signature')
+      expect(fetchSpy).not.toHaveBeenCalled()
+    })
+
+    test('getSession() offline with access token fully expired → null + retryable error, storage kept', async () => {
+      setNavigator({ onLine: false })
+      const storage = memoryLocalStorageAdapter()
+      const fetchSpy = jest.fn()
+      const client = buildClientWithFetch(storage, fetchSpy)
+      await client.initialize()
+      await plantSession(storage, { secondsUntilExpiry: -60 })
+
+      const { data, error } = await client.getSession()
+
+      // Callers can distinguish "can't verify right now" (retryable error)
+      // from "signed out" (null session, null error).
+      expect(data.session).toBeNull()
+      expect((error as AuthError)?.name).toBe('AuthRetryableFetchError')
+      expect(fetchSpy).not.toHaveBeenCalled()
+
+      const stored = (await getItemAsync(storage, STORAGE_KEY)) as Session | null
+      expect(stored?.refresh_token).toBe('refresh-token-r1')
+    })
+
+    test('navigator without boolean onLine → requests still attempted (React Native / Node)', async () => {
+      setNavigator({ product: 'ReactNative' })
+      jest.useFakeTimers({ doNotFake: ['setImmediate'] })
+      try {
+        const storage = memoryLocalStorageAdapter()
+        const fetchSpy = jest.fn(async () => {
+          throw new TypeError('fetch failed')
+        })
+        const client = buildClientWithFetch(storage, fetchSpy)
+        await client.initialize()
+        await plantSession(storage, { secondsUntilExpiry: -60 })
+
+        // @ts-expect-error access protected for test
+        const resultPromise = client._callRefreshToken('refresh-token-r1')
+        await jest.runAllTimersAsync()
+        const result = await resultPromise
+
+        expect((result.error as AuthError)?.name).toBe('AuthRetryableFetchError')
+        // the point: absence of onLine must not short-circuit the request
+        expect(fetchSpy).toHaveBeenCalled()
+      } finally {
+        jest.useRealTimers()
+      }
+    })
+  })
 })

--- a/packages/core/auth-js/test/GoTrueClient.test.ts
+++ b/packages/core/auth-js/test/GoTrueClient.test.ts
@@ -4984,10 +4984,16 @@ describe('Refresh-token lifecycle (proactive/reactive, cooldown)', () => {
         fetch: fetchSpy as any,
       })
 
-    test('refresh fails fast without network attempts or backoff sleeps', async () => {
+    // Simulates the user agent's own transport failing while offline.
+    const buildRejectingFetchSpy = () =>
+      jest.fn(async () => {
+        throw new TypeError('Failed to fetch')
+      })
+
+    test('offline refresh probes the transport once and skips the backoff loop', async () => {
       setNavigator({ onLine: false })
       const storage = memoryLocalStorageAdapter()
-      const fetchSpy = jest.fn()
+      const fetchSpy = buildRejectingFetchSpy()
       const client = buildClientWithFetch(storage, fetchSpy)
       await client.initialize()
       await plantSession(storage, { secondsUntilExpiry: -60 })
@@ -4999,8 +5005,9 @@ describe('Refresh-token lifecycle (proactive/reactive, cooldown)', () => {
 
       expect(result.data).toBeNull()
       expect((result.error as AuthError)?.name).toBe('AuthRetryableFetchError')
-      // no request went out and the ~25s retry/backoff loop did not run
-      expect(fetchSpy).not.toHaveBeenCalled()
+      // exactly one probe went through the configured transport; the ~25s
+      // retry/backoff loop did not run
+      expect(fetchSpy).toHaveBeenCalledTimes(1)
       expect(elapsed).toBeLessThan(1000)
 
       // the failure enters the regular cooldown so subsequent ticks stay quiet
@@ -5015,7 +5022,7 @@ describe('Refresh-token lifecycle (proactive/reactive, cooldown)', () => {
     test('getSession() offline with access token still valid → preserved session, no error', async () => {
       setNavigator({ onLine: false })
       const storage = memoryLocalStorageAdapter()
-      const fetchSpy = jest.fn()
+      const fetchSpy = buildRejectingFetchSpy()
       const client = buildClientWithFetch(storage, fetchSpy)
       await client.initialize()
       // inside EXPIRY_MARGIN_MS (triggers proactive refresh) but not expired
@@ -5025,13 +5032,13 @@ describe('Refresh-token lifecycle (proactive/reactive, cooldown)', () => {
 
       expect(error).toBeNull()
       expect(data.session?.access_token).toBe('jwt.accesstoken.signature')
-      expect(fetchSpy).not.toHaveBeenCalled()
+      expect(fetchSpy).toHaveBeenCalledTimes(1)
     })
 
     test('getSession() offline with access token fully expired → null + retryable error, storage kept', async () => {
       setNavigator({ onLine: false })
       const storage = memoryLocalStorageAdapter()
-      const fetchSpy = jest.fn()
+      const fetchSpy = buildRejectingFetchSpy()
       const client = buildClientWithFetch(storage, fetchSpy)
       await client.initialize()
       await plantSession(storage, { secondsUntilExpiry: -60 })
@@ -5042,10 +5049,42 @@ describe('Refresh-token lifecycle (proactive/reactive, cooldown)', () => {
       // from "signed out" (null session, null error).
       expect(data.session).toBeNull()
       expect((error as AuthError)?.name).toBe('AuthRetryableFetchError')
-      expect(fetchSpy).not.toHaveBeenCalled()
+      expect(fetchSpy).toHaveBeenCalledTimes(1)
 
       const stored = (await getItemAsync(storage, STORAGE_KEY)) as Session | null
       expect(stored?.refresh_token).toBe('refresh-token-r1')
+    })
+
+    test('custom transport that succeeds while navigator reports offline is honored', async () => {
+      setNavigator({ onLine: false })
+      const storage = memoryLocalStorageAdapter()
+      // e.g. request interception, a service-worker-backed transport, or a
+      // loopback endpoint: reachable even though navigator.onLine is false
+      const fetchSpy = jest.fn(async () => ({
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        json: async () => ({
+          access_token: 'jwt.rotated.signature',
+          refresh_token: 'refresh-token-r2',
+          token_type: 'bearer',
+          expires_in: 3600,
+          user: { id: 'user-1', aud: 'authenticated', email: 'u@example.com' },
+        }),
+      }))
+      const client = buildClientWithFetch(storage, fetchSpy)
+      await client.initialize()
+      await plantSession(storage, { secondsUntilExpiry: -60 })
+
+      // @ts-expect-error access protected for test
+      const result = await client._callRefreshToken('refresh-token-r1')
+
+      expect(result.error).toBeNull()
+      expect(result.data?.refresh_token).toBe('refresh-token-r2')
+      expect(fetchSpy).toHaveBeenCalledTimes(1)
+
+      const stored = (await getItemAsync(storage, STORAGE_KEY)) as Session | null
+      expect(stored?.refresh_token).toBe('refresh-token-r2')
     })
 
     test('navigator without boolean onLine → requests still attempted (React Native / Node)', async () => {

--- a/packages/core/auth-js/test/GoTrueClient.test.ts
+++ b/packages/core/auth-js/test/GoTrueClient.test.ts
@@ -5006,9 +5006,18 @@ describe('Refresh-token lifecycle (proactive/reactive, cooldown)', () => {
       }
     })
 
-    const buildDefaultTransportClient = (storage: ReturnType<typeof memoryLocalStorageAdapter>) =>
+    // A remote-looking auth URL: offline retry suppression never applies to
+    // loopback hosts (they stay reachable while navigator.onLine is false),
+    // and the docker GoTrue test URL is loopback. The rejecting global-fetch
+    // spy intercepts every request, so nothing is actually contacted.
+    const REMOTE_AUTH_URL = 'https://project.example.com/auth/v1'
+
+    const buildDefaultTransportClient = (
+      storage: ReturnType<typeof memoryLocalStorageAdapter>,
+      url: string = REMOTE_AUTH_URL
+    ) =>
       new GoTrueClient({
-        url: GOTRUE_URL_SIGNUP_ENABLED_AUTO_CONFIRM_ON,
+        url,
         storage,
         autoRefreshToken: false,
         persistSession: true,
@@ -5152,6 +5161,44 @@ describe('Refresh-token lifecycle (proactive/reactive, cooldown)', () => {
       expect(result.error).toBeNull()
       expect(result.data?.refresh_token).toBe('refresh-token-r2')
       // one transient failure, one successful retry: not suppressed by onLine
+      expect(fetchSpy).toHaveBeenCalledTimes(2)
+    })
+
+    test('loopback auth URL keeps the retry loop on the default transport while offline', async () => {
+      setNavigator({ onLine: false })
+      // Loopback stays reachable while navigator.onLine is false, so a
+      // transient first failure against a local Supabase instance must keep
+      // the regular retry loop instead of caching a failure for the
+      // cooldown window with no online event in sight.
+      const fetchSpy = jest
+        .fn(async () => ({
+          ok: true,
+          status: 200,
+          headers: new Headers(),
+          json: async () => ({
+            access_token: 'jwt.rotated.signature',
+            refresh_token: 'refresh-token-r2',
+            token_type: 'bearer',
+            expires_in: 3600,
+            user: { id: 'user-1', aud: 'authenticated', email: 'u@example.com' },
+          }),
+        }))
+        .mockImplementationOnce(async () => {
+          throw new TypeError('transient failure')
+        })
+      setGlobalFetch(fetchSpy)
+      const storage = memoryLocalStorageAdapter()
+      // the docker GoTrue test URL is loopback (127.0.0.1)
+      const client = buildDefaultTransportClient(storage, GOTRUE_URL_SIGNUP_ENABLED_AUTO_CONFIRM_ON)
+      await client.initialize()
+      await plantSession(storage, { secondsUntilExpiry: -60 })
+
+      // @ts-expect-error access protected for test
+      const result = await client._callRefreshToken('refresh-token-r1')
+
+      expect(result.error).toBeNull()
+      expect(result.data?.refresh_token).toBe('refresh-token-r2')
+      // one transient failure, one successful retry: not suppressed for loopback
       expect(fetchSpy).toHaveBeenCalledTimes(2)
     })
 

--- a/packages/core/auth-js/test/GoTrueClient.test.ts
+++ b/packages/core/auth-js/test/GoTrueClient.test.ts
@@ -4984,17 +4984,48 @@ describe('Refresh-token lifecycle (proactive/reactive, cooldown)', () => {
         fetch: fetchSpy as any,
       })
 
+    // Offline retry suppression applies only to the environment's own
+    // transport, so those tests observe it by overriding the global fetch
+    // (bound by resolveFetch at construction) instead of passing a custom
+    // `fetch` option, which keeps the full retry loop.
+    const originalFetchDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'fetch')
+
+    const setGlobalFetch = (impl: unknown) => {
+      Object.defineProperty(globalThis, 'fetch', {
+        value: impl,
+        configurable: true,
+        writable: true,
+      })
+    }
+
+    afterEach(() => {
+      if (originalFetchDescriptor) {
+        Object.defineProperty(globalThis, 'fetch', originalFetchDescriptor)
+      } else {
+        delete (globalThis as any).fetch
+      }
+    })
+
+    const buildDefaultTransportClient = (storage: ReturnType<typeof memoryLocalStorageAdapter>) =>
+      new GoTrueClient({
+        url: GOTRUE_URL_SIGNUP_ENABLED_AUTO_CONFIRM_ON,
+        storage,
+        autoRefreshToken: false,
+        persistSession: true,
+      })
+
     // Simulates the user agent's own transport failing while offline.
     const buildRejectingFetchSpy = () =>
       jest.fn(async () => {
         throw new TypeError('Failed to fetch')
       })
 
-    test('offline refresh probes the transport once and skips the backoff loop', async () => {
+    test('offline refresh probes the default transport once and skips the backoff loop', async () => {
       setNavigator({ onLine: false })
-      const storage = memoryLocalStorageAdapter()
       const fetchSpy = buildRejectingFetchSpy()
-      const client = buildClientWithFetch(storage, fetchSpy)
+      setGlobalFetch(fetchSpy)
+      const storage = memoryLocalStorageAdapter()
+      const client = buildDefaultTransportClient(storage)
       await client.initialize()
       await plantSession(storage, { secondsUntilExpiry: -60 })
 
@@ -5005,7 +5036,7 @@ describe('Refresh-token lifecycle (proactive/reactive, cooldown)', () => {
 
       expect(result.data).toBeNull()
       expect((result.error as AuthError)?.name).toBe('AuthRetryableFetchError')
-      // exactly one probe went through the configured transport; the ~25s
+      // exactly one probe went through the default transport; the ~25s
       // retry/backoff loop did not run
       expect(fetchSpy).toHaveBeenCalledTimes(1)
       expect(elapsed).toBeLessThan(1000)
@@ -5021,9 +5052,10 @@ describe('Refresh-token lifecycle (proactive/reactive, cooldown)', () => {
 
     test('getSession() offline with access token still valid → preserved session, no error', async () => {
       setNavigator({ onLine: false })
-      const storage = memoryLocalStorageAdapter()
       const fetchSpy = buildRejectingFetchSpy()
-      const client = buildClientWithFetch(storage, fetchSpy)
+      setGlobalFetch(fetchSpy)
+      const storage = memoryLocalStorageAdapter()
+      const client = buildDefaultTransportClient(storage)
       await client.initialize()
       // inside EXPIRY_MARGIN_MS (triggers proactive refresh) but not expired
       await plantSession(storage, { secondsUntilExpiry: 30 })
@@ -5037,9 +5069,10 @@ describe('Refresh-token lifecycle (proactive/reactive, cooldown)', () => {
 
     test('getSession() offline with access token fully expired → null + retryable error, storage kept', async () => {
       setNavigator({ onLine: false })
-      const storage = memoryLocalStorageAdapter()
       const fetchSpy = buildRejectingFetchSpy()
-      const client = buildClientWithFetch(storage, fetchSpy)
+      setGlobalFetch(fetchSpy)
+      const storage = memoryLocalStorageAdapter()
+      const client = buildDefaultTransportClient(storage)
       await client.initialize()
       await plantSession(storage, { secondsUntilExpiry: -60 })
 
@@ -5087,15 +5120,51 @@ describe('Refresh-token lifecycle (proactive/reactive, cooldown)', () => {
       expect(stored?.refresh_token).toBe('refresh-token-r2')
     })
 
-    test('navigator without boolean onLine → requests still attempted (React Native / Node)', async () => {
+    test('custom transport retries while offline: fails once, succeeds on the second attempt', async () => {
+      setNavigator({ onLine: false })
+      const storage = memoryLocalStorageAdapter()
+      // A custom transport is not bound by navigator.onLine, so a transient
+      // first failure must keep the regular retry loop instead of caching a
+      // failure that a second attempt would have avoided.
+      const fetchSpy = jest
+        .fn(async () => ({
+          ok: true,
+          status: 200,
+          headers: new Headers(),
+          json: async () => ({
+            access_token: 'jwt.rotated.signature',
+            refresh_token: 'refresh-token-r2',
+            token_type: 'bearer',
+            expires_in: 3600,
+            user: { id: 'user-1', aud: 'authenticated', email: 'u@example.com' },
+          }),
+        }))
+        .mockImplementationOnce(async () => {
+          throw new TypeError('transient failure')
+        })
+      const client = buildClientWithFetch(storage, fetchSpy)
+      await client.initialize()
+      await plantSession(storage, { secondsUntilExpiry: -60 })
+
+      // @ts-expect-error access protected for test
+      const result = await client._callRefreshToken('refresh-token-r1')
+
+      expect(result.error).toBeNull()
+      expect(result.data?.refresh_token).toBe('refresh-token-r2')
+      // one transient failure, one successful retry: not suppressed by onLine
+      expect(fetchSpy).toHaveBeenCalledTimes(2)
+    })
+
+    test('navigator without boolean onLine → default transport keeps the retry loop (React Native / Node)', async () => {
       setNavigator({ product: 'ReactNative' })
       jest.useFakeTimers({ doNotFake: ['setImmediate'] })
       try {
-        const storage = memoryLocalStorageAdapter()
         const fetchSpy = jest.fn(async () => {
           throw new TypeError('fetch failed')
         })
-        const client = buildClientWithFetch(storage, fetchSpy)
+        setGlobalFetch(fetchSpy)
+        const storage = memoryLocalStorageAdapter()
+        const client = buildDefaultTransportClient(storage)
         await client.initialize()
         await plantSession(storage, { secondsUntilExpiry: -60 })
 
@@ -5105,8 +5174,9 @@ describe('Refresh-token lifecycle (proactive/reactive, cooldown)', () => {
         const result = await resultPromise
 
         expect((result.error as AuthError)?.name).toBe('AuthRetryableFetchError')
-        // the point: absence of onLine must not short-circuit the request
-        expect(fetchSpy).toHaveBeenCalled()
+        // the point: absence of onLine must not suppress requests or
+        // retries, even on the default transport
+        expect(fetchSpy.mock.calls.length).toBeGreaterThan(1)
       } finally {
         jest.useRealTimers()
       }

--- a/packages/core/auth-js/test/helpers.test.ts
+++ b/packages/core/auth-js/test/helpers.test.ts
@@ -5,6 +5,7 @@ import {
   getAlgorithm,
   getItemAsync,
   getOnlineEventTarget,
+  isLoopbackHost,
   isProvablyOffline,
   parseParametersFromURL,
   parseResponseAPIVersion,
@@ -475,5 +476,28 @@ describe('getOnlineEventTarget', () => {
     if (originalAdd) delete (globalThis as any).addEventListener
     if (originalRemove) delete (globalThis as any).removeEventListener
     expect(getOnlineEventTarget()).toBeNull()
+  })
+})
+
+describe('isLoopbackHost', () => {
+  it('recognizes loopback hosts', () => {
+    expect(isLoopbackHost('http://localhost:54321/auth/v1')).toBe(true)
+    expect(isLoopbackHost('http://project.localhost/auth/v1')).toBe(true)
+    expect(isLoopbackHost('http://127.0.0.1:54321/auth/v1')).toBe(true)
+    expect(isLoopbackHost('http://127.255.0.42/auth/v1')).toBe(true)
+    expect(isLoopbackHost('http://[::1]:54321/auth/v1')).toBe(true)
+  })
+
+  it('rejects remote hosts', () => {
+    expect(isLoopbackHost('https://project.supabase.co/auth/v1')).toBe(false)
+    expect(isLoopbackHost('https://example.com/auth/v1')).toBe(false)
+    // resembles but is not loopback
+    expect(isLoopbackHost('https://localhost.example.com/auth/v1')).toBe(false)
+    expect(isLoopbackHost('http://128.0.0.1/auth/v1')).toBe(false)
+  })
+
+  it('returns false for unparseable URLs', () => {
+    expect(isLoopbackHost('not a url')).toBe(false)
+    expect(isLoopbackHost('')).toBe(false)
   })
 })

--- a/packages/core/auth-js/test/helpers.test.ts
+++ b/packages/core/auth-js/test/helpers.test.ts
@@ -4,6 +4,7 @@ import {
   generateCallbackId,
   getAlgorithm,
   getItemAsync,
+  isProvablyOffline,
   parseParametersFromURL,
   parseResponseAPIVersion,
   getCodeChallengeAndMethod,
@@ -383,5 +384,50 @@ describe('getItemAsync', () => {
     // valid behavior. We are only guarding against parse failures here.
     const storage = makeStorage({ session: '"hello"' })
     expect(await getItemAsync(storage, 'session')).toEqual('hello')
+  })
+})
+
+describe('isProvablyOffline', () => {
+  const originalNavigator = Object.getOwnPropertyDescriptor(globalThis, 'navigator')
+
+  const setNavigator = (value: unknown) => {
+    Object.defineProperty(globalThis, 'navigator', {
+      value,
+      configurable: true,
+      writable: true,
+    })
+  }
+
+  afterEach(() => {
+    if (originalNavigator) {
+      Object.defineProperty(globalThis, 'navigator', originalNavigator)
+    } else {
+      delete (globalThis as any).navigator
+    }
+  })
+
+  it('returns true only when navigator.onLine is exactly false', () => {
+    setNavigator({ onLine: false })
+    expect(isProvablyOffline()).toBe(true)
+  })
+
+  it('returns false when navigator.onLine is true', () => {
+    setNavigator({ onLine: true })
+    expect(isProvablyOffline()).toBe(false)
+  })
+
+  it('returns false when navigator has no boolean onLine (React Native, Node.js)', () => {
+    setNavigator({ product: 'ReactNative' })
+    expect(isProvablyOffline()).toBe(false)
+
+    setNavigator({ onLine: undefined })
+    expect(isProvablyOffline()).toBe(false)
+  })
+
+  it('returns false when navigator is not defined', () => {
+    if (originalNavigator) {
+      delete (globalThis as any).navigator
+    }
+    expect(isProvablyOffline()).toBe(false)
   })
 })

--- a/packages/core/auth-js/test/helpers.test.ts
+++ b/packages/core/auth-js/test/helpers.test.ts
@@ -4,6 +4,7 @@ import {
   generateCallbackId,
   getAlgorithm,
   getItemAsync,
+  getOnlineEventTarget,
   isProvablyOffline,
   parseParametersFromURL,
   parseResponseAPIVersion,
@@ -429,5 +430,50 @@ describe('isProvablyOffline', () => {
       delete (globalThis as any).navigator
     }
     expect(isProvablyOffline()).toBe(false)
+  })
+})
+
+describe('getOnlineEventTarget', () => {
+  const originalNavigator = Object.getOwnPropertyDescriptor(globalThis, 'navigator')
+  const originalAdd = Object.getOwnPropertyDescriptor(globalThis, 'addEventListener')
+  const originalRemove = Object.getOwnPropertyDescriptor(globalThis, 'removeEventListener')
+
+  const defineGlobal = (name: string, value: unknown) => {
+    Object.defineProperty(globalThis, name, { value, configurable: true, writable: true })
+  }
+
+  const restore = (name: string, descriptor: PropertyDescriptor | undefined) => {
+    if (descriptor) {
+      Object.defineProperty(globalThis, name, descriptor)
+    } else {
+      delete (globalThis as any)[name]
+    }
+  }
+
+  afterEach(() => {
+    restore('navigator', originalNavigator)
+    restore('addEventListener', originalAdd)
+    restore('removeEventListener', originalRemove)
+  })
+
+  it('returns the global scope when navigator.onLine and global listeners exist (window, workers)', () => {
+    defineGlobal('navigator', { onLine: true })
+    defineGlobal('addEventListener', () => {})
+    defineGlobal('removeEventListener', () => {})
+    expect(getOnlineEventTarget()).toBe(globalThis)
+  })
+
+  it('returns null without a boolean navigator.onLine (React Native, Node.js, Deno)', () => {
+    defineGlobal('navigator', { product: 'ReactNative' })
+    defineGlobal('addEventListener', () => {})
+    defineGlobal('removeEventListener', () => {})
+    expect(getOnlineEventTarget()).toBeNull()
+  })
+
+  it('returns null without global listener support', () => {
+    defineGlobal('navigator', { onLine: true })
+    if (originalAdd) delete (globalThis as any).addEventListener
+    if (originalRemove) delete (globalThis as any).removeEventListener
+    expect(getOnlineEventTarget()).toBeNull()
   })
 })

--- a/packages/core/auth-js/test/helpers.test.ts
+++ b/packages/core/auth-js/test/helpers.test.ts
@@ -488,9 +488,18 @@ describe('isLoopbackHost', () => {
     expect(isLoopbackHost('http://[::1]:54321/auth/v1')).toBe(true)
   })
 
+  it('recognizes fully qualified (trailing-dot) loopback names', () => {
+    expect(isLoopbackHost('http://localhost.:54321/auth/v1')).toBe(true)
+    expect(isLoopbackHost('http://project.localhost./auth/v1')).toBe(true)
+    // the URL parser normalizes trailing-dot IPv4 itself
+    expect(isLoopbackHost('http://127.0.0.1./auth/v1')).toBe(true)
+  })
+
   it('rejects remote hosts', () => {
     expect(isLoopbackHost('https://project.supabase.co/auth/v1')).toBe(false)
     expect(isLoopbackHost('https://example.com/auth/v1')).toBe(false)
+    // fully qualified remote names stay remote after normalization
+    expect(isLoopbackHost('https://example.com./auth/v1')).toBe(false)
     // resembles but is not loopback
     expect(isLoopbackHost('https://localhost.example.com/auth/v1')).toBe(false)
     expect(isLoopbackHost('http://128.0.0.1/auth/v1')).toBe(false)


### PR DESCRIPTION
## 🔍 Description

### What changed?

Token refreshing is now aware of the browser's affirmative offline signal:

1. `_refreshAccessToken` always sends the first attempt through the configured `fetch`, but stops the retry/backoff loop after an actual failure while `navigator.onLine === false`, and only where the signal is binding: the default transport (no custom `fetch` was supplied; supabase-js forwards `global.fetch` verbatim, undefined when not configured) toward a non-loopback auth URL (`localhost`, `*.localhost`, their fully qualified trailing-dot forms, `127.0.0.0/8` and `[::1]` are exempt, mirroring the loopback rules of the potentially trustworthy origin definition; the check parses the configured auth endpoint, not the page origin, so WebView apps served from a synthetic localhost origin keep suppression for remote Supabase URLs). Custom transports (request interception, service-worker-backed or native-bridged fetch) are not bound by `onLine`, and loopback endpoints stay reachable without it, so both keep the full retry loop in every case; what no longer happens on the default transport toward remote hosts is the exponential backoff loop of doomed retries (about 25 seconds of fetches and sleeps per refresh in browsers, longer on flaky mobile networks where each fetch can hang).
2. A new helper `isProvablyOffline()` encapsulates the check. Per the HTML spec, `onLine === false` means the user agent will not contact the network for remote requests, so retrying through the user agent's own transport cannot succeed until connectivity returns. The `true` value can be wrong in both directions and is never trusted or used for decisions, and the signal is only used to stop retrying default-transport requests after a real failure, never to skip a request and never for custom transports.
3. The client registers an `online` event listener on the global returned by `getOnlineEventTarget()`: `window` in documents, the worker global scope in Web Workers (both fire `online` and expose the boolean `navigator.onLine` the retry gate reads), nothing in environments without that signal. On reconnect it clears the refresh-failure cooldown and runs an auto-refresh tick, but only while the ticker is active, keeping the foreground-tab-only refresh discipline. The listener is removed in `dispose()`.
4. Disposal races are handled: `_initialize` re-checks a `_disposed` flag around its lifecycle setup (dispose can interleave with the awaited visibility handler), and `_startAutoRefresh` creates no timers when dispose ran during its internal await, so React Strict Mode / HMR teardown cannot leak listeners or restart the ticker.

Everything else engages unchanged: proactive-preserve keeps the session in storage and in `getSession()` results, the failure cooldown caches the failed outcome, and callers see the transport's real error.

### Why was this change needed?

Apps used on devices that go offline (mobile web and hybrid apps in areas with poor coverage) currently hit two problems:

- With the stored access token inside the expiry margin, every `getSession()` call triggers a real refresh attempt. While offline this blocks callers for up to the full tick duration in browsers and effectively unbounded time on flaky networks, so auth-dependent UI stalls or appears logged out at startup.
- After connectivity returns, nothing refreshes until the failure cooldown expires and the next auto-refresh tick fires, which can add up to another 90 seconds.

With this change, offline behavior becomes deterministic and immediate:

- `getSession()` resolves quickly offline: a single transport probe with no backoff sleeps, returning the preserved session while the access token is inside its real expiry, or `{ session: null, error: AuthRetryableFetchError }` once it has truly expired, letting apps distinguish "cannot verify right now" from "signed out" (the session stays in storage).
- Refreshing resumes the moment connectivity returns, in documents and in Web Workers.

## 📸 Screenshots/Examples

N/A

## 🔄 Breaking changes

- [x] This PR contains no breaking changes

React Native, Node.js and Deno have no boolean `navigator.onLine`, so `isProvablyOffline()` returns false there and no listener is registered; behavior in those environments is identical. Transports that succeed while `onLine === false` keep working because the first attempt is always sent. In browsers and workers the only observable differences are a faster failure while provably offline (single probe, same error surface) and an immediate refresh on reconnect.

## 📋 Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/supabase/supabase-js/blob/master/CONTRIBUTING.md)
- [x] My PR title follows the [conventional commit format](https://www.conventionalcommits.org/): `<type>(<scope>): <description>`
- [x] I have run `pnpm nx format` to ensure consistent code formatting
- [x] I have added tests for new functionality (if applicable)
- [x] I have updated documentation (if applicable)

## 📝 Additional notes

Test coverage added:

- `GoTrueClient.test.ts`, "offline fail-fast (provably offline)" suite: single default-transport probe with no backoff while offline against a remote auth URL (observed via a global-fetch override so no custom `fetch` is configured; cooldown entered, storage preserved), preserved session via `getSession()` inside the margin, null plus retryable error once fully expired, a regression test proving a navigator without a boolean `onLine` (React Native) keeps the full retry loop, regression tests proving a custom transport is never suppressed (succeeds on the first attempt, and fails once then succeeds on the retried second attempt, both while `onLine === false`), a regression test proving a loopback auth URL keeps the retry loop on the default transport (fails once, succeeds on the second attempt), and worker-style global registration with cooldown clearing and removal on dispose.
- `GoTrueClient.browser.test.ts` (jsdom): `online` clears the cooldown, the tick is gated on an active ticker, `dispose()` removes the listener, dispose during pending initialization registers no lifecycle listeners, dispose interleaving with visibility setup registers no online listener and restarts no ticker, and `_startAutoRefresh` resumed across dispose creates no timers (the interleaving tests fail without the fixes).
- `helpers.test.ts`: `isProvablyOffline`, `getOnlineEventTarget` and `isLoopbackHost` truth tables.

All existing refresh lifecycle tests pass unchanged. Documentation is TSDoc on the new helpers and methods; no separate docs apply.
