### PR TITLE
feat(auth): store PKCE verifiers in per-flow slots to survive overlapping flows

### DIFF
--- a/packages/core/auth-js/src/GoTrueClient.ts
+++ b/packages/core/auth-js/src/GoTrueClient.ts
@@ -1294,7 +1294,8 @@ export default class GoTrueClient {
    * {
    *   data: {
    *     provider: 'github',
-   *     url: <PROVIDER_URL_TO_REDIRECT_TO>
+   *     url: <PROVIDER_URL_TO_REDIRECT_TO>,
+   *     flowId: <PKCE_FLOW_ID_OR_NULL>
    *   },
    *   error: null
    * }
@@ -4568,7 +4569,8 @@ export default class GoTrueClient {
    * {
    *   data: {
    *     provider: 'github',
-   *     url: <PROVIDER_URL_TO_REDIRECT_TO>
+   *     url: <PROVIDER_URL_TO_REDIRECT_TO>,
+   *     flowId: <PKCE_FLOW_ID_OR_NULL>
    *   },
    *   error: null
    * }

--- a/packages/core/auth-js/src/GoTrueClient.ts
+++ b/packages/core/auth-js/src/GoTrueClient.ts
@@ -4583,8 +4583,8 @@ export default class GoTrueClient {
   }
 
   private async linkIdentityOAuth(credentials: SignInWithOAuthCredentials): Promise<OAuthResponse> {
+    let flowId: string | null = null
     try {
-      let flowId: string | null = null
       const { data, error } = await this._useSession(async (result) => {
         const { data, error } = result
         if (error) throw error
@@ -4614,7 +4614,10 @@ export default class GoTrueClient {
       })
     } catch (error) {
       if (isAuthError(error)) {
-        return this._returnResult({ data: { provider: credentials.provider, url: null }, error })
+        return this._returnResult({
+          data: { provider: credentials.provider, url: null, flowId },
+          error,
+        })
       }
       throw error
     }

--- a/packages/core/auth-js/src/GoTrueClient.ts
+++ b/packages/core/auth-js/src/GoTrueClient.ts
@@ -6,6 +6,7 @@ import {
   EXPIRY_MARGIN_MS,
   GOTRUE_URL,
   JWKS_TTL,
+  PKCE_FLOW_ID_PARAM,
   REFRESH_FAILURE_COOLDOWN_MS,
   STORAGE_KEY,
 } from './lib/constants'
@@ -36,6 +37,7 @@ import {
   _userResponse,
 } from './lib/fetch'
 import {
+  appendFlowIdToRedirectTo,
   assertPasskeyExperimentalEnabled,
   decodeJWT,
   deepClone,
@@ -47,14 +49,18 @@ import {
   insecureUserWarningProxy,
   isBrowser,
   parseParametersFromURL,
+  pkceVerifierSlotKey,
   removeItemAsync,
+  removePKCEVerifier,
   resolveFetch,
+  retrievePKCEVerifier,
   retryable,
   setItemAsync,
   sleep,
   supportsLocalStorage,
   userNotAvailableProxy,
   validateExp,
+  validatePKCEFlowId,
 } from './lib/helpers'
 import { memoryLocalStorageAdapter } from './lib/local-storage'
 import { LockAcquireTimeoutError, navigatorLock } from './lib/locks'
@@ -1005,6 +1011,7 @@ export default class GoTrueClient {
    * ```
    */
   async signUp(credentials: SignUpWithPasswordCredentials): Promise<AuthResponse> {
+    let flowId: string | null = null
     try {
       let res: AuthResponse
       if ('email' in credentials) {
@@ -1012,14 +1019,14 @@ export default class GoTrueClient {
         let codeChallenge: string | null = null
         let codeChallengeMethod: string | null = null
         if (this.flowType === 'pkce') {
-          ;[codeChallenge, codeChallengeMethod] = await getCodeChallengeAndMethod(
+          ;[codeChallenge, codeChallengeMethod, flowId] = await getCodeChallengeAndMethod(
             this.storage,
             this.storageKey
           )
         }
         res = await _request(this.fetch, 'POST', `${this.url}/signup`, {
           headers: this.headers,
-          redirectTo: options?.emailRedirectTo,
+          redirectTo: this._maybeAppendFlowIdToRedirect(options?.emailRedirectTo, flowId),
           body: {
             email,
             password,
@@ -1052,7 +1059,7 @@ export default class GoTrueClient {
       const { data, error } = res
 
       if (error || !data) {
-        await removeItemAsync(this.storage, `${this.storageKey}-code-verifier`)
+        await removePKCEVerifier(this.storage, this.storageKey, flowId)
         return this._returnResult({ data: { user: null, session: null }, error: error })
       }
 
@@ -1066,7 +1073,7 @@ export default class GoTrueClient {
 
       return this._returnResult({ data: { user, session }, error: null })
     } catch (error) {
-      await removeItemAsync(this.storage, `${this.storageKey}-code-verifier`)
+      await removePKCEVerifier(this.storage, this.storageKey, flowId)
       if (isAuthError(error)) {
         return this._returnResult({ data: { user: null, session: null }, error })
       }
@@ -1362,10 +1369,23 @@ export default class GoTrueClient {
    *
    * @remarks
    * - Used when `flowType` is set to `pkce` in client options.
+   * - When several PKCE flows are in flight at once, pass `options.flowId`
+   *   (the value of the reserved `sb_flow_id` query parameter on your
+   *   callback URL, present when `experimental.appendPkceFlowIdToRedirects`
+   *   is enabled) so the code is exchanged with the verifier created by that
+   *   specific flow. In a browser the parameter is read from the current URL
+   *   automatically; without a flow id the most recently stored verifier is
+   *   used.
    *
    * @example Exchange Auth Code
    * ```js
    * supabase.auth.exchangeCodeForSession('34e770dd-9ff9-416c-87fa-43b31d7ef225')
+   * ```
+   *
+   * @example Exchange Auth Code for a specific flow (e.g. in a server-side callback handler)
+   * ```js
+   * const flowId = requestUrl.searchParams.get('sb_flow_id')
+   * supabase.auth.exchangeCodeForSession(code, flowId ? { flowId } : undefined)
    * ```
    *
    * @exampleResponse Exchange Auth Code
@@ -1525,17 +1545,20 @@ export default class GoTrueClient {
    * }
    * ```
    */
-  async exchangeCodeForSession(authCode: string): Promise<AuthTokenResponse> {
+  async exchangeCodeForSession(
+    authCode: string,
+    options?: { flowId?: string }
+  ): Promise<AuthTokenResponse> {
     await this.initializePromise
 
     if (this.lock != null) {
       // TODO(v3): remove legacy lock path
       return this._acquireLock(this.lockAcquireTimeout, async () => {
-        return this._exchangeCodeForSession(authCode)
+        return this._exchangeCodeForSession(authCode, options)
       })
     }
 
-    return this._exchangeCodeForSession(authCode)
+    return this._exchangeCodeForSession(authCode, options)
   }
 
   /**
@@ -1968,15 +1991,27 @@ export default class GoTrueClient {
     }
   }
 
-  private async _exchangeCodeForSession(authCode: string): Promise<
+  private async _exchangeCodeForSession(
+    authCode: string,
+    options?: { flowId?: string }
+  ): Promise<
     | {
         data: { session: Session; user: User; redirectType: string | null }
         error: null
       }
     | { data: { session: null; user: null; redirectType: null }; error: AuthError }
   > {
-    const storageItem = await getItemAsync(this.storage, `${this.storageKey}-code-verifier`)
-    const [codeVerifier, redirectType] = ((storageItem ?? '') as string).split('/')
+    const requestedFlowId =
+      validatePKCEFlowId(options?.flowId) ??
+      (isBrowser()
+        ? validatePKCEFlowId(parseParametersFromURL(window.location.href)[PKCE_FLOW_ID_PARAM])
+        : null)
+    const { verifier: storageItem, flowId } = await retrievePKCEVerifier(
+      this.storage,
+      this.storageKey,
+      requestedFlowId
+    )
+    const [codeVerifier, redirectType] = (storageItem ?? '').split('/')
 
     try {
       if (!codeVerifier && this.flowType === 'pkce') {
@@ -1996,7 +2031,7 @@ export default class GoTrueClient {
           xform: _sessionResponse,
         }
       )
-      await removeItemAsync(this.storage, `${this.storageKey}-code-verifier`)
+      await removePKCEVerifier(this.storage, this.storageKey, flowId)
       if (error) {
         throw error
       }
@@ -2016,7 +2051,7 @@ export default class GoTrueClient {
       }
       return this._returnResult({ data: { ...data, redirectType: redirectType ?? null }, error })
     } catch (error) {
-      await removeItemAsync(this.storage, `${this.storageKey}-code-verifier`)
+      await removePKCEVerifier(this.storage, this.storageKey, flowId)
       if (isAuthError(error)) {
         return this._returnResult({
           data: { user: null, session: null, redirectType: null },
@@ -2216,13 +2251,14 @@ export default class GoTrueClient {
    * ```
    */
   async signInWithOtp(credentials: SignInWithPasswordlessCredentials): Promise<AuthOtpResponse> {
+    let flowId: string | null = null
     try {
       if ('email' in credentials) {
         const { email, options } = credentials
         let codeChallenge: string | null = null
         let codeChallengeMethod: string | null = null
         if (this.flowType === 'pkce') {
-          ;[codeChallenge, codeChallengeMethod] = await getCodeChallengeAndMethod(
+          ;[codeChallenge, codeChallengeMethod, flowId] = await getCodeChallengeAndMethod(
             this.storage,
             this.storageKey
           )
@@ -2237,7 +2273,7 @@ export default class GoTrueClient {
             code_challenge: codeChallenge,
             code_challenge_method: codeChallengeMethod,
           },
-          redirectTo: options?.emailRedirectTo,
+          redirectTo: this._maybeAppendFlowIdToRedirect(options?.emailRedirectTo, flowId),
         })
         return this._returnResult({ data: { user: null, session: null }, error })
       }
@@ -2260,7 +2296,7 @@ export default class GoTrueClient {
       }
       throw new AuthInvalidCredentialsError('You must provide either an email or phone number.')
     } catch (error) {
-      await removeItemAsync(this.storage, `${this.storageKey}-code-verifier`)
+      await removePKCEVerifier(this.storage, this.storageKey, flowId)
       if (isAuthError(error)) {
         return this._returnResult({ data: { user: null, session: null }, error })
       }
@@ -2507,11 +2543,12 @@ export default class GoTrueClient {
    * ```
    */
   async signInWithSSO(params: SignInWithSSO): Promise<SSOResponse> {
+    let flowId: string | null = null
     try {
       let codeChallenge: string | null = null
       let codeChallengeMethod: string | null = null
       if (this.flowType === 'pkce') {
-        ;[codeChallenge, codeChallengeMethod] = await getCodeChallengeAndMethod(
+        ;[codeChallenge, codeChallengeMethod, flowId] = await getCodeChallengeAndMethod(
           this.storage,
           this.storageKey
         )
@@ -2521,7 +2558,7 @@ export default class GoTrueClient {
         body: {
           ...('providerId' in params ? { provider_id: params.providerId } : null),
           ...('domain' in params ? { domain: params.domain } : null),
-          redirect_to: params.options?.redirectTo ?? undefined,
+          redirect_to: this._maybeAppendFlowIdToRedirect(params.options?.redirectTo, flowId),
           ...(params?.options?.captchaToken
             ? { gotrue_meta_security: { captcha_token: params.options.captchaToken } }
             : null),
@@ -2540,7 +2577,7 @@ export default class GoTrueClient {
 
       return this._returnResult(result)
     } catch (error) {
-      await removeItemAsync(this.storage, `${this.storageKey}-code-verifier`)
+      await removePKCEVerifier(this.storage, this.storageKey, flowId)
       if (isAuthError(error)) {
         return this._returnResult({ data: null, error })
       }
@@ -2666,6 +2703,7 @@ export default class GoTrueClient {
    * ```
    */
   async resend(credentials: ResendParams): Promise<AuthOtpResponse> {
+    let flowId: string | null = null
     try {
       const endpoint = `${this.url}/resend`
       if ('email' in credentials) {
@@ -2673,7 +2711,7 @@ export default class GoTrueClient {
         let codeChallenge: string | null = null
         let codeChallengeMethod: string | null = null
         if (this.flowType === 'pkce') {
-          ;[codeChallenge, codeChallengeMethod] = await getCodeChallengeAndMethod(
+          ;[codeChallenge, codeChallengeMethod, flowId] = await getCodeChallengeAndMethod(
             this.storage,
             this.storageKey
           )
@@ -2687,10 +2725,10 @@ export default class GoTrueClient {
             code_challenge: codeChallenge,
             code_challenge_method: codeChallengeMethod,
           },
-          redirectTo: options?.emailRedirectTo,
+          redirectTo: this._maybeAppendFlowIdToRedirect(options?.emailRedirectTo, flowId),
         })
         if (error) {
-          await removeItemAsync(this.storage, `${this.storageKey}-code-verifier`)
+          await removePKCEVerifier(this.storage, this.storageKey, flowId)
         }
         return this._returnResult({ data: { user: null, session: null }, error })
       } else if ('phone' in credentials) {
@@ -2712,7 +2750,7 @@ export default class GoTrueClient {
         'You must provide either an email or phone number and a type'
       )
     } catch (error) {
-      await removeItemAsync(this.storage, `${this.storageKey}-code-verifier`)
+      await removePKCEVerifier(this.storage, this.storageKey, flowId)
       if (isAuthError(error)) {
         return this._returnResult({ data: { user: null, session: null }, error })
       }
@@ -3355,6 +3393,7 @@ export default class GoTrueClient {
       emailRedirectTo?: string | undefined
     } = {}
   ): Promise<UserResponse> {
+    let flowId: string | null = null
     try {
       return await this._useSession(async (result) => {
         const { data: sessionData, error: sessionError } = result
@@ -3368,7 +3407,7 @@ export default class GoTrueClient {
         let codeChallenge: string | null = null
         let codeChallengeMethod: string | null = null
         if (this.flowType === 'pkce' && attributes.email != null) {
-          ;[codeChallenge, codeChallengeMethod] = await getCodeChallengeAndMethod(
+          ;[codeChallenge, codeChallengeMethod, flowId] = await getCodeChallengeAndMethod(
             this.storage,
             this.storageKey
           )
@@ -3376,7 +3415,7 @@ export default class GoTrueClient {
 
         const { data, error: userError } = await _request(this.fetch, 'PUT', `${this.url}/user`, {
           headers: this.headers,
-          redirectTo: options?.emailRedirectTo,
+          redirectTo: this._maybeAppendFlowIdToRedirect(options?.emailRedirectTo, flowId),
           body: {
             ...attributes,
             code_challenge: codeChallenge,
@@ -3394,7 +3433,7 @@ export default class GoTrueClient {
         return this._returnResult({ data: { user: session.user }, error: null })
       })
     } catch (error) {
-      await removeItemAsync(this.storage, `${this.storageKey}-code-verifier`)
+      await removePKCEVerifier(this.storage, this.storageKey, flowId)
       if (isAuthError(error)) {
         return this._returnResult({ data: { user: null }, error })
       }
@@ -3826,11 +3865,14 @@ export default class GoTrueClient {
       if (callbackUrlType === 'pkce') {
         this._debug('#_initialize()', 'begin', 'is PKCE flow', true)
         if (!params.code) throw new AuthPKCEGrantCodeExchangeError('No code detected.')
-        const { data, error } = await this._exchangeCodeForSession(params.code)
+        const { data, error } = await this._exchangeCodeForSession(params.code, {
+          flowId: params[PKCE_FLOW_ID_PARAM],
+        })
         if (error) throw error
 
         const url = new URL(window.location.href)
         url.searchParams.delete('code')
+        url.searchParams.delete(PKCE_FLOW_ID_PARAM)
 
         window.history.replaceState(window.history.state, '', url.toString())
 
@@ -3934,12 +3976,24 @@ export default class GoTrueClient {
    * Checks if the current URL and backing storage contain parameters given by a PKCE flow
    */
   private async _isPKCECallback(params: { [parameter: string]: string }): Promise<boolean> {
+    if (!params.code) {
+      return false
+    }
+
+    const flowId = validatePKCEFlowId(params[PKCE_FLOW_ID_PARAM])
+    if (
+      flowId &&
+      (await getItemAsync(this.storage, pkceVerifierSlotKey(this.storageKey, flowId)))
+    ) {
+      return true
+    }
+
     const currentStorageContent = await getItemAsync(
       this.storage,
       `${this.storageKey}-code-verifier`
     )
 
-    return !!(params.code && currentStorageContent)
+    return !!currentStorageContent
   }
 
   /**
@@ -4392,9 +4446,10 @@ export default class GoTrueClient {
   > {
     let codeChallenge: string | null = null
     let codeChallengeMethod: string | null = null
+    let flowId: string | null = null
 
     if (this.flowType === 'pkce') {
-      ;[codeChallenge, codeChallengeMethod] = await getCodeChallengeAndMethod(
+      ;[codeChallenge, codeChallengeMethod, flowId] = await getCodeChallengeAndMethod(
         this.storage,
         this.storageKey,
         true // isPasswordRecovery
@@ -4409,10 +4464,10 @@ export default class GoTrueClient {
           gotrue_meta_security: { captcha_token: options.captchaToken },
         },
         headers: this.headers,
-        redirectTo: options.redirectTo,
+        redirectTo: this._maybeAppendFlowIdToRedirect(options.redirectTo, flowId),
       })
     } catch (error) {
-      await removeItemAsync(this.storage, `${this.storageKey}-code-verifier`)
+      await removePKCEVerifier(this.storage, this.storageKey, flowId)
       if (isAuthError(error)) {
         return this._returnResult({ data: null, error })
       }
@@ -5600,19 +5655,26 @@ export default class GoTrueClient {
       skipBrowserRedirect?: boolean
     }
   ) {
+    let redirectTo = options?.redirectTo
+    let codeChallenge: string | null = null
+    let codeChallengeMethod: string | null = null
+    if (this.flowType === 'pkce') {
+      let flowId: string
+      ;[codeChallenge, codeChallengeMethod, flowId] = await getCodeChallengeAndMethod(
+        this.storage,
+        this.storageKey
+      )
+      redirectTo = this._maybeAppendFlowIdToRedirect(redirectTo, flowId)
+    }
+
     const urlParams: string[] = [`provider=${encodeURIComponent(provider)}`]
-    if (options?.redirectTo) {
-      urlParams.push(`redirect_to=${encodeURIComponent(options.redirectTo)}`)
+    if (redirectTo) {
+      urlParams.push(`redirect_to=${encodeURIComponent(redirectTo)}`)
     }
     if (options?.scopes) {
       urlParams.push(`scopes=${encodeURIComponent(options.scopes)}`)
     }
-    if (this.flowType === 'pkce') {
-      const [codeChallenge, codeChallengeMethod] = await getCodeChallengeAndMethod(
-        this.storage,
-        this.storageKey
-      )
-
+    if (codeChallenge != null && codeChallengeMethod != null) {
       const flowParams = new URLSearchParams({
         code_challenge: `${encodeURIComponent(codeChallenge)}`,
         code_challenge_method: `${encodeURIComponent(codeChallengeMethod)}`,
@@ -5628,6 +5690,23 @@ export default class GoTrueClient {
     }
 
     return `${url}?${urlParams.join('&')}`
+  }
+
+  /**
+   * Appends the reserved flow id parameter to a redirect URL so the callback
+   * can be matched to the verifier stored for its flow. Opt-in via
+   * `experimental.appendPkceFlowIdToRedirects`: redirect URLs are validated
+   * against the project's allow list including the query string, so an extra
+   * parameter can stop exact (non-wildcard) entries from matching.
+   */
+  private _maybeAppendFlowIdToRedirect(
+    redirectTo: string | undefined,
+    flowId: string | null
+  ): string | undefined {
+    if (!redirectTo || !flowId || !this.experimental.appendPkceFlowIdToRedirects) {
+      return redirectTo
+    }
+    return appendFlowIdToRedirectTo(redirectTo, flowId)
   }
 
   private async _unenroll(params: MFAUnenrollParams): Promise<AuthMFAUnenrollResponse> {

--- a/packages/core/auth-js/src/GoTrueClient.ts
+++ b/packages/core/auth-js/src/GoTrueClient.ts
@@ -50,6 +50,7 @@ import {
   isBrowser,
   parseParametersFromURL,
   pkceVerifierSlotKey,
+  removeAllPKCEVerifiers,
   removeItemAsync,
   removePKCEVerifier,
   resolveFetch,
@@ -1019,10 +1020,7 @@ export default class GoTrueClient {
         let codeChallenge: string | null = null
         let codeChallengeMethod: string | null = null
         if (this.flowType === 'pkce') {
-          ;[codeChallenge, codeChallengeMethod, flowId] = await getCodeChallengeAndMethod(
-            this.storage,
-            this.storageKey
-          )
+          ;[codeChallenge, codeChallengeMethod, flowId] = await this._getCodeChallengeAndMethod()
         }
         res = await _request(this.fetch, 'POST', `${this.url}/signup`, {
           headers: this.headers,
@@ -1369,13 +1367,17 @@ export default class GoTrueClient {
    *
    * @remarks
    * - Used when `flowType` is set to `pkce` in client options.
-   * - When several PKCE flows are in flight at once, pass `options.flowId`
-   *   (the value of the reserved `sb_flow_id` query parameter on your
-   *   callback URL, present when `experimental.appendPkceFlowIdToRedirects`
-   *   is enabled) so the code is exchanged with the verifier created by that
-   *   specific flow. In a browser the parameter is read from the current URL
-   *   automatically; without a flow id the most recently stored verifier is
-   *   used.
+   * - When several PKCE flows are in flight at once, pass `options.flowId` so
+   *   the code is exchanged with the verifier created by that specific flow.
+   *   The flow id is returned by `signInWithOAuth`, and with
+   *   `experimental.appendPkceFlowIdToRedirects` enabled it also arrives on
+   *   your callback URL as the reserved `sb_flow_id` query parameter (read
+   *   automatically in a browser).
+   * - When a flow id is present but its stored verifier is gone (evicted,
+   *   already used, or from another device), the call fails with a verifier
+   *   missing error instead of trying another flow's verifier — a mismatched
+   *   verifier would consume the single-use code. Without any flow id the
+   *   most recently stored verifier is used, as before.
    *
    * @example Exchange Auth Code
    * ```js
@@ -2001,16 +2003,29 @@ export default class GoTrueClient {
       }
     | { data: { session: null; user: null; redirectType: null }; error: AuthError }
   > {
-    const requestedFlowId =
-      validatePKCEFlowId(options?.flowId) ??
-      (isBrowser()
+    const hasExplicitFlowId = options?.flowId != null
+    const requestedFlowId = hasExplicitFlowId
+      ? validatePKCEFlowId(options?.flowId)
+      : isBrowser()
         ? validatePKCEFlowId(parseParametersFromURL(window.location.href)[PKCE_FLOW_ID_PARAM])
-        : null)
-    const { verifier: storageItem, flowId } = await retrievePKCEVerifier(
-      this.storage,
-      this.storageKey,
-      requestedFlowId
-    )
+        : null
+
+    if (hasExplicitFlowId && !requestedFlowId) {
+      this._debug(
+        '#_exchangeCodeForSession()',
+        'provided flowId is not a valid flow id',
+        options?.flowId
+      )
+    }
+
+    // With a flow id (explicit or from the callback URL) the lookup is
+    // slot-only and a miss fails fast — see retrievePKCEVerifier. An invalid
+    // explicit flow id also fails fast rather than borrowing another flow's
+    // verifier.
+    const { verifier: storageItem, flowId } =
+      hasExplicitFlowId && !requestedFlowId
+        ? { verifier: null, flowId: null }
+        : await retrievePKCEVerifier(this.storage, this.storageKey, requestedFlowId)
     const [codeVerifier, redirectType] = (storageItem ?? '').split('/')
 
     try {
@@ -2258,10 +2273,7 @@ export default class GoTrueClient {
         let codeChallenge: string | null = null
         let codeChallengeMethod: string | null = null
         if (this.flowType === 'pkce') {
-          ;[codeChallenge, codeChallengeMethod, flowId] = await getCodeChallengeAndMethod(
-            this.storage,
-            this.storageKey
-          )
+          ;[codeChallenge, codeChallengeMethod, flowId] = await this._getCodeChallengeAndMethod()
         }
         const { error } = await _request(this.fetch, 'POST', `${this.url}/otp`, {
           headers: this.headers,
@@ -2548,10 +2560,7 @@ export default class GoTrueClient {
       let codeChallenge: string | null = null
       let codeChallengeMethod: string | null = null
       if (this.flowType === 'pkce') {
-        ;[codeChallenge, codeChallengeMethod, flowId] = await getCodeChallengeAndMethod(
-          this.storage,
-          this.storageKey
-        )
+        ;[codeChallenge, codeChallengeMethod, flowId] = await this._getCodeChallengeAndMethod()
       }
 
       const result = await _request(this.fetch, 'POST', `${this.url}/sso`, {
@@ -2711,10 +2720,7 @@ export default class GoTrueClient {
         let codeChallenge: string | null = null
         let codeChallengeMethod: string | null = null
         if (this.flowType === 'pkce') {
-          ;[codeChallenge, codeChallengeMethod, flowId] = await getCodeChallengeAndMethod(
-            this.storage,
-            this.storageKey
-          )
+          ;[codeChallenge, codeChallengeMethod, flowId] = await this._getCodeChallengeAndMethod()
         }
         const { error } = await _request(this.fetch, 'POST', endpoint, {
           headers: this.headers,
@@ -3245,7 +3251,6 @@ export default class GoTrueClient {
           // session in the database, indicating the user is signed out.
 
           await this._removeSession()
-          await removeItemAsync(this.storage, `${this.storageKey}-code-verifier`)
         }
 
         return this._returnResult({ data: { user: null }, error })
@@ -3407,10 +3412,7 @@ export default class GoTrueClient {
         let codeChallenge: string | null = null
         let codeChallengeMethod: string | null = null
         if (this.flowType === 'pkce' && attributes.email != null) {
-          ;[codeChallenge, codeChallengeMethod, flowId] = await getCodeChallengeAndMethod(
-            this.storage,
-            this.storageKey
-          )
+          ;[codeChallenge, codeChallengeMethod, flowId] = await this._getCodeChallengeAndMethod()
         }
 
         const { data, error: userError } = await _request(this.fetch, 'PUT', `${this.url}/user`, {
@@ -4056,7 +4058,6 @@ export default class GoTrueClient {
     return await this._useSession(async (result) => {
       const removeCurrentSession = async () => {
         await this._removeSession()
-        await removeItemAsync(this.storage, `${this.storageKey}-code-verifier`)
       }
       const { data, error: sessionError } = result
       if (sessionError && !isAuthSessionMissingError(sessionError)) {
@@ -4449,9 +4450,7 @@ export default class GoTrueClient {
     let flowId: string | null = null
 
     if (this.flowType === 'pkce') {
-      ;[codeChallenge, codeChallengeMethod, flowId] = await getCodeChallengeAndMethod(
-        this.storage,
-        this.storageKey,
+      ;[codeChallenge, codeChallengeMethod, flowId] = await this._getCodeChallengeAndMethod(
         true // isPasswordRecovery
       )
     }
@@ -4585,10 +4584,11 @@ export default class GoTrueClient {
 
   private async linkIdentityOAuth(credentials: SignInWithOAuthCredentials): Promise<OAuthResponse> {
     try {
+      let flowId: string | null = null
       const { data, error } = await this._useSession(async (result) => {
         const { data, error } = result
         if (error) throw error
-        const url: string = await this._getUrlForProvider(
+        const { url, flowId: urlFlowId } = await this._getUrlForProvider(
           `${this.url}/user/identities/authorize`,
           credentials.provider,
           {
@@ -4598,6 +4598,7 @@ export default class GoTrueClient {
             skipBrowserRedirect: true,
           }
         )
+        flowId = urlFlowId
         return await _request(this.fetch, 'GET', url, {
           headers: this.headers,
           jwt: data.session?.access_token ?? undefined,
@@ -4608,7 +4609,7 @@ export default class GoTrueClient {
         window.location.assign(data?.url)
       }
       return this._returnResult({
-        data: { provider: credentials.provider, url: data?.url },
+        data: { provider: credentials.provider, url: data?.url, flowId },
         error: null,
       })
     } catch (error) {
@@ -4661,7 +4662,7 @@ export default class GoTrueClient {
         }
         return this._returnResult({ data, error })
       } catch (error) {
-        await removeItemAsync(this.storage, `${this.storageKey}-code-verifier`)
+        await removePKCEVerifier(this.storage, this.storageKey, null)
         if (isAuthError(error)) {
           return this._returnResult({ data: { user: null, session: null }, error })
         }
@@ -4797,7 +4798,7 @@ export default class GoTrueClient {
       skipBrowserRedirect?: boolean
     }
   ) {
-    const url: string = await this._getUrlForProvider(`${this.url}/authorize`, provider, {
+    const { url, flowId } = await this._getUrlForProvider(`${this.url}/authorize`, provider, {
       redirectTo: options.redirectTo,
       scopes: options.scopes,
       queryParams: options.queryParams,
@@ -4810,7 +4811,7 @@ export default class GoTrueClient {
       window.location.assign(url)
     }
 
-    return { data: { provider, url }, error: null }
+    return { data: { provider, url, flowId }, error: null }
   }
 
   /**
@@ -5231,7 +5232,7 @@ export default class GoTrueClient {
     this.suppressGetSessionWarning = false
 
     await removeItemAsync(this.storage, this.storageKey)
-    await removeItemAsync(this.storage, this.storageKey + '-code-verifier')
+    await removeAllPKCEVerifiers(this.storage, this.storageKey)
     await removeItemAsync(this.storage, this.storageKey + '-user')
 
     if (this.userStorage) {
@@ -5658,12 +5659,9 @@ export default class GoTrueClient {
     let redirectTo = options?.redirectTo
     let codeChallenge: string | null = null
     let codeChallengeMethod: string | null = null
+    let flowId: string | null = null
     if (this.flowType === 'pkce') {
-      let flowId: string
-      ;[codeChallenge, codeChallengeMethod, flowId] = await getCodeChallengeAndMethod(
-        this.storage,
-        this.storageKey
-      )
+      ;[codeChallenge, codeChallengeMethod, flowId] = await this._getCodeChallengeAndMethod()
       redirectTo = this._maybeAppendFlowIdToRedirect(redirectTo, flowId)
     }
 
@@ -5689,7 +5687,7 @@ export default class GoTrueClient {
       urlParams.push(`skip_http_redirect=${options.skipBrowserRedirect}`)
     }
 
-    return `${url}?${urlParams.join('&')}`
+    return { url: `${url}?${urlParams.join('&')}`, flowId }
   }
 
   /**
@@ -5704,9 +5702,29 @@ export default class GoTrueClient {
     flowId: string | null
   ): string | undefined {
     if (!redirectTo || !flowId || !this.experimental.appendPkceFlowIdToRedirects) {
-      return redirectTo
+      return redirectTo ?? undefined
     }
     return appendFlowIdToRedirectTo(redirectTo, flowId)
+  }
+
+  /**
+   * Generates and stores a PKCE challenge/verifier pair for a new flow,
+   * logging any pending verifier the bounded slot ring evicts.
+   */
+  private async _getCodeChallengeAndMethod(
+    isPasswordRecovery = false
+  ): Promise<[string, string, string]> {
+    return getCodeChallengeAndMethod(
+      this.storage,
+      this.storageKey,
+      isPasswordRecovery,
+      (evictedFlowId) =>
+        this._debug(
+          '#_getCodeChallengeAndMethod()',
+          'evicted oldest pending PKCE verifier slot',
+          evictedFlowId
+        )
+    )
   }
 
   private async _unenroll(params: MFAUnenrollParams): Promise<AuthMFAUnenrollResponse> {

--- a/packages/core/auth-js/src/lib/constants.ts
+++ b/packages/core/auth-js/src/lib/constants.ts
@@ -40,4 +40,19 @@ export const API_VERSIONS = {
 
 export const BASE64URL_REGEX = /^([a-z0-9_-]{4})*($|[a-z0-9_-]{3}$|[a-z0-9_-]{2}$)$/i
 
+/**
+ * Reserved query parameter appended to `redirectTo` URLs (behind
+ * `experimental.appendPkceFlowIdToRedirects`) that correlates a PKCE callback
+ * with the code verifier stored when its flow started. It round-trips through
+ * the auth server untouched and identifies a verifier slot in storage — the
+ * verifier itself never appears in a URL.
+ */
+export const PKCE_FLOW_ID_PARAM = 'sb_flow_id'
+
+/**
+ * Maximum number of PKCE code verifiers kept in storage at once. Starting a
+ * new flow beyond this evicts the oldest pending verifier.
+ */
+export const PKCE_MAX_CONCURRENT_FLOWS = 5
+
 export const JWKS_TTL = 10 * 60 * 1000 // 10 minutes

--- a/packages/core/auth-js/src/lib/helpers.ts
+++ b/packages/core/auth-js/src/lib/helpers.ts
@@ -357,9 +357,11 @@ async function getPKCEFlowIndex(storage: SupportedStorage, storageKey: string): 
 /**
  * The index is read-modify-write without a lock: two concurrent starts (e.g.
  * two tabs) can lose one index update. The losing flow still works — its slot
- * is addressed directly by key — but is never ring-evicted, leaving a
- * bounded orphan entry. Accepted trade-off: locking every flow start is far
- * more intrusive than the leak.
+ * is addressed directly by key — but its entry is missing from the index, so
+ * it escapes both ring eviction and removeAllPKCEVerifiers: the orphaned slot
+ * persists for the storage medium's lifetime (up to the cookie max age in
+ * cookie storage) and repeated races accumulate one orphan each. Accepted
+ * trade-off: locking every flow start is far more intrusive than the leak.
  */
 export async function storePKCEVerifier(
   storage: SupportedStorage,
@@ -425,11 +427,17 @@ export async function removePKCEVerifier(
   const slotValue = await getItemAsync(storage, slotKey)
   await removeItemAsync(storage, slotKey)
 
-  const index = (await getPKCEFlowIndex(storage, storageKey)).filter((id) => id !== flowId)
-  if (index.length > 0) {
-    await setItemAsync(storage, pkceFlowIndexKey(storageKey), index)
-  } else {
-    await removeItemAsync(storage, pkceFlowIndexKey(storageKey))
+  // Skip the index rewrite when the flow was never indexed (e.g. a failed
+  // exchange for an absent slot): on cookie storage every write is a full
+  // Set-Cookie cycle.
+  const index = await getPKCEFlowIndex(storage, storageKey)
+  const remaining = index.filter((id) => id !== flowId)
+  if (remaining.length !== index.length) {
+    if (remaining.length > 0) {
+      await setItemAsync(storage, pkceFlowIndexKey(storageKey), remaining)
+    } else {
+      await removeItemAsync(storage, pkceFlowIndexKey(storageKey))
+    }
   }
 
   if (slotValue != null && slotValue === (await getItemAsync(storage, legacyKey))) {

--- a/packages/core/auth-js/src/lib/helpers.ts
+++ b/packages/core/auth-js/src/lib/helpers.ts
@@ -330,29 +330,43 @@ export function generatePKCEFlowId(): string {
   return flowId
 }
 
-// Hyphen-delimited on purpose: @supabase/ssr splits oversized cookies into
-// chunks named `<key>.<number>`, so a dot-delimited slot key could be
-// mistaken for a chunk of the fixed `-code-verifier` cookie and get clobbered
-// by its chunk management.
+// Slot keys deliberately end in `-code-verifier`: @supabase/ssr's server
+// cookie adapter only persists writes immediately for keys with that suffix
+// (no auth event fires when a verifier is stored). They also contain no dot,
+// because @supabase/ssr chunks oversized cookies as `<key>.<number>` and a
+// dot-delimited key could be mistaken for a chunk of the fixed
+// `-code-verifier` cookie and clobbered by its chunk management.
 export const pkceVerifierSlotKey = (storageKey: string, flowId: string) =>
-  `${storageKey}-code-verifier-${flowId}`
+  `${storageKey}-flow-${flowId}-code-verifier`
 
-const pkceFlowIndexKey = (storageKey: string) => `${storageKey}-code-verifier-flows`
+const pkceFlowIndexKey = (storageKey: string) => `${storageKey}-flows-code-verifier`
 
 /**
  * Storage adapters cannot enumerate keys, so the ids of pending verifier
- * slots are tracked in an index entry, oldest first.
+ * slots are tracked in an index entry, oldest first. Index entries pass
+ * through the same validation as URL-provided flow ids: with cookie-based
+ * storage the index contents are no more trustworthy than a URL parameter.
  */
 async function getPKCEFlowIndex(storage: SupportedStorage, storageKey: string): Promise<string[]> {
   const index = await getItemAsync(storage, pkceFlowIndexKey(storageKey))
-  return Array.isArray(index) ? index.filter((id): id is string => typeof id === 'string') : []
+  return Array.isArray(index)
+    ? index.filter((id): id is string => validatePKCEFlowId(id) !== null)
+    : []
 }
 
+/**
+ * The index is read-modify-write without a lock: two concurrent starts (e.g.
+ * two tabs) can lose one index update. The losing flow still works — its slot
+ * is addressed directly by key — but is never ring-evicted, leaving a
+ * bounded orphan entry. Accepted trade-off: locking every flow start is far
+ * more intrusive than the leak.
+ */
 export async function storePKCEVerifier(
   storage: SupportedStorage,
   storageKey: string,
   flowId: string,
-  verifier: string
+  verifier: string,
+  onEvictFlow?: (evictedFlowId: string) => void
 ): Promise<void> {
   await setItemAsync(storage, pkceVerifierSlotKey(storageKey, flowId), verifier)
 
@@ -361,6 +375,7 @@ export async function storePKCEVerifier(
   while (index.length > PKCE_MAX_CONCURRENT_FLOWS) {
     const evicted = index.shift()!
     await removeItemAsync(storage, pkceVerifierSlotKey(storageKey, evicted))
+    onEvictFlow?.(evicted)
   }
   await setItemAsync(storage, pkceFlowIndexKey(storageKey), index)
 
@@ -371,9 +386,11 @@ export async function storePKCEVerifier(
 }
 
 /**
- * Looks up the verifier for `flowId`, falling back to the fixed legacy key
- * when no slot matches. The returned `flowId` is `null` when the legacy key
- * was used, so cleanup can be scoped accordingly.
+ * Looks up the verifier for `flowId`. When a flow id is given, only that slot
+ * is consulted — deliberately no fallback to the fixed legacy key: submitting
+ * another flow's verifier would burn the single-use auth code, and the
+ * subsequent cleanup would delete a pending flow's only fallback. The legacy
+ * key is read only when no flow id is available at all.
  */
 export async function retrievePKCEVerifier(
   storage: SupportedStorage,
@@ -382,9 +399,7 @@ export async function retrievePKCEVerifier(
 ): Promise<{ verifier: string | null; flowId: string | null }> {
   if (flowId) {
     const verifier = await getItemAsync(storage, pkceVerifierSlotKey(storageKey, flowId))
-    if (typeof verifier === 'string') {
-      return { verifier, flowId }
-    }
+    return { verifier: typeof verifier === 'string' ? verifier : null, flowId }
   }
   const verifier = await getItemAsync(storage, `${storageKey}-code-verifier`)
   return { verifier: typeof verifier === 'string' ? verifier : null, flowId: null }
@@ -423,14 +438,47 @@ export async function removePKCEVerifier(
 }
 
 /**
- * Appends the reserved flow id parameter to a `redirectTo` URL. String-based
- * so custom schemes (native deep links) survive untouched; an existing
- * fragment stays at the end of the URL.
+ * Removes every pending verifier: all slots in the index, the index itself
+ * and the fixed legacy key. Used on session teardown (sign-out, invalid
+ * session) — matches the pre-slot behavior where tearing down the session
+ * deleted the only verifier, and prevents long-lived stale verifier cookies.
+ */
+export async function removeAllPKCEVerifiers(
+  storage: SupportedStorage,
+  storageKey: string
+): Promise<void> {
+  const index = await getPKCEFlowIndex(storage, storageKey)
+  for (const flowId of index) {
+    await removeItemAsync(storage, pkceVerifierSlotKey(storageKey, flowId))
+  }
+  await removeItemAsync(storage, pkceFlowIndexKey(storageKey))
+  await removeItemAsync(storage, `${storageKey}-code-verifier`)
+}
+
+/**
+ * Appends the reserved flow id parameter to a `redirectTo` URL, replacing any
+ * existing occurrence. String-based (no URL round-trip) so custom schemes
+ * (native deep links) and the exact encoding of the app's own parameters
+ * survive untouched; an existing fragment stays at the end of the URL.
  */
 export function appendFlowIdToRedirectTo(redirectTo: string, flowId: string): string {
   const hashIndex = redirectTo.indexOf('#')
-  const base = hashIndex === -1 ? redirectTo : redirectTo.slice(0, hashIndex)
+  let base = hashIndex === -1 ? redirectTo : redirectTo.slice(0, hashIndex)
   const fragment = hashIndex === -1 ? '' : redirectTo.slice(hashIndex)
+
+  const queryIndex = base.indexOf('?')
+  if (queryIndex !== -1) {
+    const path = base.slice(0, queryIndex)
+    const remaining = base
+      .slice(queryIndex + 1)
+      .split('&')
+      .filter(
+        (pair) =>
+          pair !== '' && pair !== PKCE_FLOW_ID_PARAM && !pair.startsWith(`${PKCE_FLOW_ID_PARAM}=`)
+      )
+    base = remaining.length > 0 ? `${path}?${remaining.join('&')}` : path
+  }
+
   const separator = base.includes('?') ? '&' : '?'
   return `${base}${separator}${PKCE_FLOW_ID_PARAM}=${encodeURIComponent(flowId)}${fragment}`
 }
@@ -438,7 +486,8 @@ export function appendFlowIdToRedirectTo(redirectTo: string, flowId: string): st
 export async function getCodeChallengeAndMethod(
   storage: SupportedStorage,
   storageKey: string,
-  isPasswordRecovery = false
+  isPasswordRecovery = false,
+  onEvictFlow?: (evictedFlowId: string) => void
 ): Promise<[string, string, string]> {
   const codeVerifier = generatePKCEVerifier()
   let storedCodeVerifier = codeVerifier
@@ -446,7 +495,7 @@ export async function getCodeChallengeAndMethod(
     storedCodeVerifier += '/recovery'
   }
   const flowId = generatePKCEFlowId()
-  await storePKCEVerifier(storage, storageKey, flowId, storedCodeVerifier)
+  await storePKCEVerifier(storage, storageKey, flowId, storedCodeVerifier, onEvictFlow)
   const codeChallenge = await generatePKCEChallenge(codeVerifier)
   const codeChallengeMethod = codeVerifier === codeChallenge ? 'plain' : 's256'
   return [codeChallenge, codeChallengeMethod, flowId]

--- a/packages/core/auth-js/src/lib/helpers.ts
+++ b/packages/core/auth-js/src/lib/helpers.ts
@@ -1,4 +1,9 @@
-import { API_VERSION_HEADER_NAME, BASE64URL_REGEX } from './constants'
+import {
+  API_VERSION_HEADER_NAME,
+  BASE64URL_REGEX,
+  PKCE_FLOW_ID_PARAM,
+  PKCE_MAX_CONCURRENT_FLOWS,
+} from './constants'
 import { AuthInvalidJwtError } from './errors'
 import { base64UrlToUint8Array, stringFromBase64URL } from './base64url'
 import { JwtHeader, JwtPayload, SupportedStorage, User } from './types'
@@ -301,20 +306,150 @@ export async function generatePKCEChallenge(verifier: string) {
   return btoa(hashed).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
 }
 
+const PKCE_FLOW_ID_PATTERN = /^[a-zA-Z0-9_-]{8,64}$/
+
+/**
+ * Returns the flow id if it is a plausible flow id, `null` otherwise. Flow
+ * ids can arrive via URL parameters, so anything outside the expected shape
+ * is discarded before it is used to build a storage key.
+ */
+export function validatePKCEFlowId(flowId: unknown): string | null {
+  return typeof flowId === 'string' && PKCE_FLOW_ID_PATTERN.test(flowId) ? flowId : null
+}
+
+export function generatePKCEFlowId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.getRandomValues === 'function') {
+    const bytes = new Uint8Array(16)
+    crypto.getRandomValues(bytes)
+    return Array.from(bytes, dec2hex).join('')
+  }
+  let flowId = ''
+  for (let i = 0; i < 32; i++) {
+    flowId += Math.floor(Math.random() * 16).toString(16)
+  }
+  return flowId
+}
+
+// Hyphen-delimited on purpose: @supabase/ssr splits oversized cookies into
+// chunks named `<key>.<number>`, so a dot-delimited slot key could be
+// mistaken for a chunk of the fixed `-code-verifier` cookie and get clobbered
+// by its chunk management.
+export const pkceVerifierSlotKey = (storageKey: string, flowId: string) =>
+  `${storageKey}-code-verifier-${flowId}`
+
+const pkceFlowIndexKey = (storageKey: string) => `${storageKey}-code-verifier-flows`
+
+/**
+ * Storage adapters cannot enumerate keys, so the ids of pending verifier
+ * slots are tracked in an index entry, oldest first.
+ */
+async function getPKCEFlowIndex(storage: SupportedStorage, storageKey: string): Promise<string[]> {
+  const index = await getItemAsync(storage, pkceFlowIndexKey(storageKey))
+  return Array.isArray(index) ? index.filter((id): id is string => typeof id === 'string') : []
+}
+
+export async function storePKCEVerifier(
+  storage: SupportedStorage,
+  storageKey: string,
+  flowId: string,
+  verifier: string
+): Promise<void> {
+  await setItemAsync(storage, pkceVerifierSlotKey(storageKey, flowId), verifier)
+
+  const index = (await getPKCEFlowIndex(storage, storageKey)).filter((id) => id !== flowId)
+  index.push(flowId)
+  while (index.length > PKCE_MAX_CONCURRENT_FLOWS) {
+    const evicted = index.shift()!
+    await removeItemAsync(storage, pkceVerifierSlotKey(storageKey, evicted))
+  }
+  await setItemAsync(storage, pkceFlowIndexKey(storageKey), index)
+
+  // Deprecation-window dual write: exchanges that cannot identify their flow
+  // (older SDK versions, redirects without the flow id parameter) read the
+  // fixed key, which mirrors the most recently started flow.
+  await setItemAsync(storage, `${storageKey}-code-verifier`, verifier)
+}
+
+/**
+ * Looks up the verifier for `flowId`, falling back to the fixed legacy key
+ * when no slot matches. The returned `flowId` is `null` when the legacy key
+ * was used, so cleanup can be scoped accordingly.
+ */
+export async function retrievePKCEVerifier(
+  storage: SupportedStorage,
+  storageKey: string,
+  flowId: string | null
+): Promise<{ verifier: string | null; flowId: string | null }> {
+  if (flowId) {
+    const verifier = await getItemAsync(storage, pkceVerifierSlotKey(storageKey, flowId))
+    if (typeof verifier === 'string') {
+      return { verifier, flowId }
+    }
+  }
+  const verifier = await getItemAsync(storage, `${storageKey}-code-verifier`)
+  return { verifier: typeof verifier === 'string' ? verifier : null, flowId: null }
+}
+
+/**
+ * Removes a single flow's verifier. Never clears other flows' slots: with a
+ * `flowId` only that slot is deleted (plus the legacy fixed key when it holds
+ * the same verifier); without one, only the legacy fixed key is deleted.
+ */
+export async function removePKCEVerifier(
+  storage: SupportedStorage,
+  storageKey: string,
+  flowId: string | null
+): Promise<void> {
+  const legacyKey = `${storageKey}-code-verifier`
+  if (!flowId) {
+    await removeItemAsync(storage, legacyKey)
+    return
+  }
+
+  const slotKey = pkceVerifierSlotKey(storageKey, flowId)
+  const slotValue = await getItemAsync(storage, slotKey)
+  await removeItemAsync(storage, slotKey)
+
+  const index = (await getPKCEFlowIndex(storage, storageKey)).filter((id) => id !== flowId)
+  if (index.length > 0) {
+    await setItemAsync(storage, pkceFlowIndexKey(storageKey), index)
+  } else {
+    await removeItemAsync(storage, pkceFlowIndexKey(storageKey))
+  }
+
+  if (slotValue != null && slotValue === (await getItemAsync(storage, legacyKey))) {
+    await removeItemAsync(storage, legacyKey)
+  }
+}
+
+/**
+ * Appends the reserved flow id parameter to a `redirectTo` URL. String-based
+ * so custom schemes (native deep links) survive untouched; an existing
+ * fragment stays at the end of the URL.
+ */
+export function appendFlowIdToRedirectTo(redirectTo: string, flowId: string): string {
+  const hashIndex = redirectTo.indexOf('#')
+  const base = hashIndex === -1 ? redirectTo : redirectTo.slice(0, hashIndex)
+  const fragment = hashIndex === -1 ? '' : redirectTo.slice(hashIndex)
+  const separator = base.includes('?') ? '&' : '?'
+  return `${base}${separator}${PKCE_FLOW_ID_PARAM}=${encodeURIComponent(flowId)}${fragment}`
+}
+
 export async function getCodeChallengeAndMethod(
   storage: SupportedStorage,
   storageKey: string,
   isPasswordRecovery = false
-) {
+): Promise<[string, string, string]> {
   const codeVerifier = generatePKCEVerifier()
   let storedCodeVerifier = codeVerifier
   if (isPasswordRecovery) {
     storedCodeVerifier += '/recovery'
   }
-  await setItemAsync(storage, `${storageKey}-code-verifier`, storedCodeVerifier)
+  const flowId = generatePKCEFlowId()
+  await storePKCEVerifier(storage, storageKey, flowId, storedCodeVerifier)
   const codeChallenge = await generatePKCEChallenge(codeVerifier)
   const codeChallengeMethod = codeVerifier === codeChallenge ? 'plain' : 's256'
-  return [codeChallenge, codeChallengeMethod]
+  return [codeChallenge, codeChallengeMethod, flowId]
 }
 
 /** Parses the API version which is 2YYY-MM-DD. */

--- a/packages/core/auth-js/src/lib/types.ts
+++ b/packages/core/auth-js/src/lib/types.ts
@@ -306,8 +306,12 @@ export type OAuthResponse =
          * `null` on the implicit flow. The id is a selector for a verifier
          * kept in storage — it is not a secret and never contains the
          * verifier itself.
+         *
+         * Always set at runtime; optional in the type so existing code that
+         * constructs `OAuthResponse` values (e.g. test mocks) keeps
+         * compiling.
          */
-        flowId: string | null
+        flowId?: string | null
       }
       error: null
     }
@@ -315,7 +319,7 @@ export type OAuthResponse =
       data: {
         provider: Provider
         url: null
-        flowId: string | null
+        flowId?: string | null
       }
       error: AuthError
     }

--- a/packages/core/auth-js/src/lib/types.ts
+++ b/packages/core/auth-js/src/lib/types.ts
@@ -307,7 +307,7 @@ export type OAuthResponse =
          * kept in storage — it is not a secret and never contains the
          * verifier itself.
          */
-        flowId?: string | null
+        flowId: string | null
       }
       error: null
     }
@@ -315,7 +315,7 @@ export type OAuthResponse =
       data: {
         provider: Provider
         url: null
-        flowId?: string | null
+        flowId: string | null
       }
       error: AuthError
     }

--- a/packages/core/auth-js/src/lib/types.ts
+++ b/packages/core/auth-js/src/lib/types.ts
@@ -206,8 +206,12 @@ export type ExperimentalFeatureFlags = {
    * your Site URL. Redirects to the Site URL's own origin always pass.
    *
    * Defaults to `false`. Without it, concurrent flows still keep separate
-   * verifiers in storage, but a callback can only be matched to its verifier
-   * when you pass `flowId` to `exchangeCodeForSession` yourself.
+   * verifiers in storage, but no flow id travels through the redirect: to
+   * match a callback to its verifier you must carry the `flowId` returned by
+   * `signInWithOAuth` (or `linkIdentity`) through your own channel and pass
+   * it to `exchangeCodeForSession`. Flows that offer no way to obtain the
+   * flow id (email OTP, password recovery, sign-up confirmation) can only be
+   * correlated via this flag.
    */
   appendPkceFlowIdToRedirects?: boolean
 }
@@ -295,6 +299,15 @@ export type OAuthResponse =
       data: {
         provider: Provider
         url: string
+        /**
+         * Identifier of the PKCE flow started by this call, usable as the
+         * `flowId` option of {@link GoTrueClient#exchangeCodeForSession} to
+         * select this flow's code verifier when several flows are in flight.
+         * `null` on the implicit flow. The id is a selector for a verifier
+         * kept in storage — it is not a secret and never contains the
+         * verifier itself.
+         */
+        flowId?: string | null
       }
       error: null
     }
@@ -302,6 +315,7 @@ export type OAuthResponse =
       data: {
         provider: Provider
         url: null
+        flowId?: string | null
       }
       error: AuthError
     }

--- a/packages/core/auth-js/src/lib/types.ts
+++ b/packages/core/auth-js/src/lib/types.ts
@@ -190,6 +190,26 @@ export type ExperimentalFeatureFlags = {
    * disabled throws a descriptive error at call time.
    */
   passkey?: boolean
+  /**
+   * Appends a reserved `sb_flow_id` query parameter to `redirectTo` URLs on
+   * PKCE flows. The parameter round-trips through the auth server back to
+   * your callback URL, where the client uses it to select the code verifier
+   * created by that specific flow — so multiple sign-in flows (e.g. two OAuth
+   * providers started in different tabs) can be in flight at the same time
+   * without overwriting each other.
+   *
+   * Before enabling, make sure your [redirect URL allow
+   * list](https://supabase.com/docs/guides/auth/redirect-urls) tolerates the
+   * extra query parameter: allow-list entries are matched against the full
+   * URL including the query string, so an exact entry (no wildcard) stops
+   * matching once the parameter is appended and the redirect falls back to
+   * your Site URL. Redirects to the Site URL's own origin always pass.
+   *
+   * Defaults to `false`. Without it, concurrent flows still keep separate
+   * verifiers in storage, but a callback can only be matched to its verifier
+   * when you pass `flowId` to `exchangeCodeForSession` yourself.
+   */
+  appendPkceFlowIdToRedirects?: boolean
 }
 
 const WeakPasswordReasons = ['length', 'characters', 'pwned'] as const

--- a/packages/core/auth-js/test/GoTrueClient.pkce.browser.test.ts
+++ b/packages/core/auth-js/test/GoTrueClient.pkce.browser.test.ts
@@ -1,0 +1,125 @@
+/**
+ * @jest-environment jsdom
+ * @jest-environment-options {"url": "http://localhost:9999/auth/callback"}
+ */
+
+import GoTrueClient from '../src/GoTrueClient'
+import { memoryLocalStorageAdapter } from '../src/lib/local-storage'
+
+const AUTH_URL = 'https://project-ref.supabase.example/auth/v1'
+const FLOW_ID = 'abcdef1234567890abcdef1234567890'
+
+const SYNTHETIC_SESSION = {
+  access_token: 'synthetic-access-token',
+  token_type: 'bearer',
+  expires_in: 3600,
+  refresh_token: 'synthetic-refresh-token',
+  user: {
+    id: '11111111-1111-1111-1111-111111111111',
+    aud: 'authenticated',
+    role: 'authenticated',
+    email: 'user@example.test',
+    app_metadata: {},
+    user_metadata: {},
+    created_at: '2024-01-01T00:00:00Z',
+    updated_at: '2024-01-01T00:00:00Z',
+  },
+}
+
+function syntheticFetch(tokenBodies: Array<{ [key: string]: string }>, succeed: boolean) {
+  return (async (input: RequestInfo | URL, init?: RequestInit) => {
+    if (String(input).includes('/token?grant_type=pkce')) {
+      tokenBodies.push(JSON.parse(String(init?.body)))
+      if (succeed) {
+        return {
+          ok: true,
+          status: 200,
+          headers: new Headers(),
+          json: () => Promise.resolve({ ...SYNTHETIC_SESSION }),
+        } as unknown as Response
+      }
+    }
+    return {
+      ok: false,
+      status: 400,
+      headers: new Headers(),
+      json: () =>
+        Promise.resolve({ error: 'invalid_grant', error_description: 'Synthetic response' }),
+    } as unknown as Response
+  }) as typeof fetch
+}
+
+function seedFlow(store: { [key: string]: string }, storageKey: string) {
+  // a pending flow's slot, plus a legacy key overwritten by a later start
+  store[`${storageKey}-flow-${FLOW_ID}-code-verifier`] = JSON.stringify('verifier-own-flow')
+  store[`${storageKey}-flows-code-verifier`] = JSON.stringify([FLOW_ID])
+  store[`${storageKey}-code-verifier`] = JSON.stringify('verifier-other-flow')
+}
+
+describe('PKCE flow id auto-detection in the browser', () => {
+  it('exchangeCodeForSession reads sb_flow_id from the current URL', async () => {
+    window.history.replaceState(null, '', `/auth/callback?code=some-code&sb_flow_id=${FLOW_ID}`)
+
+    const store: { [key: string]: string } = {}
+    const tokenBodies: Array<{ [key: string]: string }> = []
+    const client = new GoTrueClient({
+      url: AUTH_URL,
+      autoRefreshToken: false,
+      persistSession: true,
+      detectSessionInUrl: false,
+      storage: memoryLocalStorageAdapter(store),
+      flowType: 'pkce',
+      fetch: syntheticFetch(tokenBodies, false),
+    })
+    // @ts-expect-error 'Allow access to protected storageKey'
+    seedFlow(store, client.storageKey)
+
+    await client.exchangeCodeForSession('some-code')
+
+    expect(tokenBodies).toHaveLength(1)
+    expect(tokenBodies[0].code_verifier).toEqual('verifier-own-flow')
+  })
+
+  it('detectSessionInUrl consumes the flow slot and scrubs sb_flow_id from the URL', async () => {
+    window.history.replaceState(null, '', `/auth/callback?code=some-code&sb_flow_id=${FLOW_ID}`)
+
+    const store: { [key: string]: string } = {}
+    const tokenBodies: Array<{ [key: string]: string }> = []
+    const preClient = new GoTrueClient({
+      url: AUTH_URL,
+      autoRefreshToken: false,
+      persistSession: true,
+      detectSessionInUrl: false,
+      storage: memoryLocalStorageAdapter(store),
+      flowType: 'pkce',
+      fetch: syntheticFetch(tokenBodies, true),
+    })
+    // @ts-expect-error 'Allow access to protected storageKey'
+    const storageKey: string = preClient.storageKey
+    seedFlow(store, storageKey)
+
+    const client = new GoTrueClient({
+      url: AUTH_URL,
+      autoRefreshToken: false,
+      persistSession: true,
+      detectSessionInUrl: true,
+      storage: memoryLocalStorageAdapter(store),
+      flowType: 'pkce',
+      fetch: syntheticFetch(tokenBodies, true),
+    })
+    await client.initialize()
+
+    expect(tokenBodies).toHaveLength(1)
+    expect(tokenBodies[0].code_verifier).toEqual('verifier-own-flow')
+
+    const { data } = await client.getSession()
+    expect(data.session?.access_token).toEqual('synthetic-access-token')
+
+    // the reserved parameter is scrubbed alongside the code
+    expect(window.location.search).not.toContain('code=')
+    expect(window.location.search).not.toContain('sb_flow_id=')
+
+    // only this flow's slot was consumed
+    expect(store[`${storageKey}-flow-${FLOW_ID}-code-verifier`]).toBeUndefined()
+  })
+})

--- a/packages/core/auth-js/test/GoTrueClient.pkce.test.ts
+++ b/packages/core/auth-js/test/GoTrueClient.pkce.test.ts
@@ -1,35 +1,71 @@
 import GoTrueClient from '../src/GoTrueClient'
 import { PKCE_FLOW_ID_PARAM } from '../src/lib/constants'
+import { AuthPKCECodeVerifierMissingError } from '../src/lib/errors'
 import { getItemAsync } from '../src/lib/helpers'
 import { memoryLocalStorageAdapter } from '../src/lib/local-storage'
+import type { SupportedStorage } from '../src/lib/types'
 
 const AUTH_URL = 'https://project-ref.supabase.example/auth/v1'
+
+const SYNTHETIC_SESSION = {
+  access_token: 'synthetic-access-token',
+  token_type: 'bearer',
+  expires_in: 3600,
+  refresh_token: 'synthetic-refresh-token',
+  user: {
+    id: '11111111-1111-1111-1111-111111111111',
+    aud: 'authenticated',
+    role: 'authenticated',
+    email: 'user@example.test',
+    app_metadata: {},
+    user_metadata: {},
+    created_at: '2024-01-01T00:00:00Z',
+    updated_at: '2024-01-01T00:00:00Z',
+  },
+}
 
 function makePkceClient(options?: {
   store?: { [key: string]: string }
   appendPkceFlowIdToRedirects?: boolean
+  storage?: SupportedStorage
+  exchangeSucceeds?: boolean
 }) {
   const store = options?.store ?? {}
-  const storage = memoryLocalStorageAdapter(store)
+  const storage = options?.storage ?? memoryLocalStorageAdapter(store)
   const requestUrls: string[] = []
   const tokenBodies: Array<{ [key: string]: string }> = []
 
-  // network-free synthetic fetch: records requests, answers every call with
-  // invalid_grant so no session construction is needed
+  // network-free synthetic fetch: records requests, succeeds on flow starts
+  // (so verifiers stay stored) and, unless exchangeSucceeds is set, fails
+  // token exchanges with invalid_grant so no session construction is needed
   const syntheticFetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
     requestUrls.push(String(input))
     if (String(input).includes('/token?grant_type=pkce')) {
       tokenBodies.push(JSON.parse(String(init?.body)))
+      if (!options?.exchangeSucceeds) {
+        return {
+          ok: false,
+          status: 400,
+          headers: new Headers(),
+          json: () =>
+            Promise.resolve({
+              error: 'invalid_grant',
+              error_description: 'Synthetic response',
+            }),
+        } as unknown as Response
+      }
+      return {
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        json: () => Promise.resolve({ ...SYNTHETIC_SESSION }),
+      } as unknown as Response
     }
     return {
-      ok: false,
-      status: 400,
+      ok: true,
+      status: 200,
       headers: new Headers(),
-      json: () =>
-        Promise.resolve({
-          error: 'invalid_grant',
-          error_description: 'Synthetic response',
-        }),
+      json: () => Promise.resolve({}),
     } as unknown as Response
   }) as typeof fetch
 
@@ -49,10 +85,13 @@ function makePkceClient(options?: {
   return { client, storage, store, storageKey, requestUrls, tokenBodies }
 }
 
+function slotKey(storageKey: string, flowId: string) {
+  return `${storageKey}-flow-${flowId}-code-verifier`
+}
+
 function slotKeys(store: { [key: string]: string }, storageKey: string) {
   return Object.keys(store).filter(
-    (key) =>
-      key.startsWith(`${storageKey}-code-verifier-`) && key !== `${storageKey}-code-verifier-flows`
+    (key) => key.startsWith(`${storageKey}-flow-`) && key !== `${storageKey}-flows-code-verifier`
   )
 }
 
@@ -62,6 +101,35 @@ function flowIdFromOAuthUrl(url: string): string {
   const flowId = new URL(redirectTo!).searchParams.get(PKCE_FLOW_ID_PARAM)
   expect(flowId).not.toBeNull()
   return flowId!
+}
+
+/**
+ * Mimics the buffering behavior of @supabase/ssr's server cookie adapter:
+ * writes are buffered in memory and only keys ending in `-code-verifier` are
+ * persisted (flushed to `jar`) immediately; everything else waits for an auth
+ * event, which never fires during a flow start.
+ */
+function ssrServerLikeStorage(jar: { [key: string]: string }): SupportedStorage {
+  const setItems: { [key: string]: string } = {}
+  const removedItems: { [key: string]: boolean } = {}
+  return {
+    getItem: async (key: string) => {
+      if (typeof setItems[key] === 'string') return setItems[key]
+      if (removedItems[key]) return null
+      return jar[key] ?? null
+    },
+    setItem: async (key: string, value: string) => {
+      if (key.endsWith('-code-verifier')) {
+        jar[key] = value
+      }
+      setItems[key] = value
+      delete removedItems[key]
+    },
+    removeItem: async (key: string) => {
+      delete setItems[key]
+      removedItems[key] = true
+    },
+  }
 }
 
 describe('overlapping PKCE flows', () => {
@@ -118,12 +186,12 @@ describe('overlapping PKCE flows', () => {
     const firstFlowId = flowIdFromOAuthUrl(first.url!)
     const secondFlowId = flowIdFromOAuthUrl(second.url!)
     expect(firstFlowId).not.toEqual(secondFlowId)
+    // the same flow id is returned directly on the response
+    expect(first.flowId).toEqual(firstFlowId)
+    expect(second.flowId).toEqual(secondFlowId)
 
-    const firstVerifier = await getItemAsync(storage, `${storageKey}-code-verifier-${firstFlowId}`)
-    const secondVerifier = await getItemAsync(
-      storage,
-      `${storageKey}-code-verifier-${secondFlowId}`
-    )
+    const firstVerifier = await getItemAsync(storage, slotKey(storageKey, firstFlowId))
+    const secondVerifier = await getItemAsync(storage, slotKey(storageKey, secondFlowId))
 
     // first flow's callback arrives after the second start overwrote the fixed key
     await client.exchangeCodeForSession('code-from-first-flow', { flowId: firstFlowId })
@@ -133,7 +201,7 @@ describe('overlapping PKCE flows', () => {
     expect(tokenBodies[0].code_verifier).not.toEqual(secondVerifier)
 
     // only the first flow's slot is cleaned up; the second flow stays pending
-    expect(slotKeys(store, storageKey)).toEqual([`${storageKey}-code-verifier-${secondFlowId}`])
+    expect(slotKeys(store, storageKey)).toEqual([slotKey(storageKey, secondFlowId)])
     expect(await getItemAsync(storage, `${storageKey}-code-verifier`)).toEqual(secondVerifier)
 
     await client.exchangeCodeForSession('code-from-second-flow', { flowId: secondFlowId })
@@ -144,8 +212,42 @@ describe('overlapping PKCE flows', () => {
     expect(await getItemAsync(storage, `${storageKey}-code-verifier`)).toBeNull()
   })
 
-  it('does not append the flow id parameter without the experimental flag', async () => {
-    const { client } = makePkceClient()
+  it('returns a usable flowId even without the experimental flag', async () => {
+    const { client, storage, storageKey, tokenBodies } = makePkceClient()
+
+    const { data: first } = await client.signInWithOAuth({
+      provider: 'github',
+      options: {
+        redirectTo: 'https://app.example.test/auth/callback',
+        skipBrowserRedirect: true,
+      },
+    })
+    // the redirect URL carries no flow id parameter without the flag
+    const redirectTo = new URL(first.url!).searchParams.get('redirect_to')
+    expect(redirectTo).toEqual('https://app.example.test/auth/callback')
+    expect(first.flowId).toBeTruthy()
+
+    // a second start overwrites the fixed key, but the app can still
+    // self-correlate by carrying flowId through its own channel
+    await client.signInWithOAuth({
+      provider: 'google',
+      options: {
+        redirectTo: 'https://app.example.test/auth/callback',
+        skipBrowserRedirect: true,
+      },
+    })
+
+    const firstVerifier = await getItemAsync(storage, slotKey(storageKey, first.flowId!))
+    await client.exchangeCodeForSession('code-from-first-flow', { flowId: first.flowId! })
+
+    expect(tokenBodies).toHaveLength(1)
+    expect(tokenBodies[0].code_verifier).toEqual(firstVerifier)
+  })
+
+  it('fails fast when a flow id has no stored verifier instead of borrowing one', async () => {
+    const { client, storage, store, storageKey, tokenBodies } = makePkceClient({
+      appendPkceFlowIdToRedirects: true,
+    })
 
     const { data } = await client.signInWithOAuth({
       provider: 'github',
@@ -155,8 +257,16 @@ describe('overlapping PKCE flows', () => {
       },
     })
 
-    const redirectTo = new URL(data.url!).searchParams.get('redirect_to')
-    expect(redirectTo).toEqual('https://app.example.test/auth/callback')
+    const { error } = await client.exchangeCodeForSession('stale-code', {
+      flowId: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    })
+
+    // no request was made with another flow's verifier, and the pending
+    // flow's slot and legacy fallback both survive
+    expect(error).toBeInstanceOf(AuthPKCECodeVerifierMissingError)
+    expect(tokenBodies).toHaveLength(0)
+    expect(slotKeys(store, storageKey)).toEqual([slotKey(storageKey, data.flowId!)])
+    expect(await getItemAsync(storage, `${storageKey}-code-verifier`)).not.toBeNull()
   })
 
   it('falls back to the fixed key when no flow id is available', async () => {
@@ -169,6 +279,32 @@ describe('overlapping PKCE flows', () => {
 
     expect(tokenBodies).toHaveLength(1)
     expect(tokenBodies[0].code_verifier).toEqual('legacy-verifier')
+    expect(await getItemAsync(storage, `${storageKey}-code-verifier`)).toBeNull()
+  })
+
+  it('a successful exchange saves the session and consumes the slot', async () => {
+    const { client, storage, store, storageKey } = makePkceClient({
+      appendPkceFlowIdToRedirects: true,
+      exchangeSucceeds: true,
+    })
+
+    const { data: start } = await client.signInWithOAuth({
+      provider: 'github',
+      options: {
+        redirectTo: 'https://app.example.test/auth/callback',
+        skipBrowserRedirect: true,
+      },
+    })
+
+    const { data, error } = await client.exchangeCodeForSession('good-code', {
+      flowId: start.flowId!,
+    })
+
+    expect(error).toBeNull()
+    expect(data.session?.access_token).toEqual('synthetic-access-token')
+    const persisted = (await getItemAsync(storage, storageKey)) as { access_token?: string }
+    expect(persisted?.access_token).toEqual('synthetic-access-token')
+    expect(slotKeys(store, storageKey)).toHaveLength(0)
     expect(await getItemAsync(storage, `${storageKey}-code-verifier`)).toBeNull()
   })
 
@@ -187,10 +323,7 @@ describe('overlapping PKCE flows', () => {
     const flowId = new URL(redirectTo!).searchParams.get(PKCE_FLOW_ID_PARAM)
     expect(flowId).not.toBeNull()
 
-    const storedVerifier = (await getItemAsync(
-      storage,
-      `${storageKey}-code-verifier-${flowId}`
-    )) as string
+    const storedVerifier = (await getItemAsync(storage, slotKey(storageKey, flowId!))) as string
     expect(storedVerifier).toMatch(/\/recovery$/)
 
     await client.exchangeCodeForSession('recovery-code', { flowId: flowId! })
@@ -236,5 +369,63 @@ describe('overlapping PKCE flows', () => {
     }
 
     expect(slotKeys(store, storageKey)).toHaveLength(5)
+  })
+
+  it('signOut clears every pending verifier slot and the index', async () => {
+    const { client, store, storageKey } = makePkceClient()
+
+    await client.signInWithOAuth({
+      provider: 'github',
+      options: {
+        redirectTo: 'https://app.example.test/auth/callback',
+        skipBrowserRedirect: true,
+      },
+    })
+    await client.signInWithOAuth({
+      provider: 'google',
+      options: {
+        redirectTo: 'https://app.example.test/auth/callback',
+        skipBrowserRedirect: true,
+      },
+    })
+    expect(slotKeys(store, storageKey)).toHaveLength(2)
+
+    await client.signOut()
+
+    expect(slotKeys(store, storageKey)).toHaveLength(0)
+    expect(store[`${storageKey}-flows-code-verifier`]).toBeUndefined()
+    expect(store[`${storageKey}-code-verifier`]).toBeUndefined()
+  })
+
+  it('persists slots through an ssr-server-like buffered storage adapter', async () => {
+    // server-initiated start: only immediately-flushed keys survive the
+    // request, which is why every verifier-family key ends in -code-verifier
+    const jar: { [key: string]: string } = {}
+    const { client: startClient, storageKey } = makePkceClient({
+      appendPkceFlowIdToRedirects: true,
+      storage: ssrServerLikeStorage(jar),
+    })
+
+    const { data } = await startClient.signInWithOAuth({
+      provider: 'github',
+      options: {
+        redirectTo: 'https://app.example.test/auth/callback',
+        skipBrowserRedirect: true,
+      },
+    })
+    const flowId = data.flowId!
+
+    expect(jar[slotKey(storageKey, flowId)]).toBeDefined()
+    expect(jar[`${storageKey}-flows-code-verifier`]).toBeDefined()
+    expect(jar[`${storageKey}-code-verifier`]).toBeDefined()
+
+    // the callback arrives on a fresh server client that only has the cookies
+    const { client: callbackClient, tokenBodies } = makePkceClient({
+      storage: ssrServerLikeStorage(jar),
+    })
+    await callbackClient.exchangeCodeForSession('some-code', { flowId })
+
+    expect(tokenBodies).toHaveLength(1)
+    expect(tokenBodies[0].code_verifier).toEqual(JSON.parse(jar[slotKey(storageKey, flowId)]))
   })
 })

--- a/packages/core/auth-js/test/GoTrueClient.pkce.test.ts
+++ b/packages/core/auth-js/test/GoTrueClient.pkce.test.ts
@@ -1,0 +1,240 @@
+import GoTrueClient from '../src/GoTrueClient'
+import { PKCE_FLOW_ID_PARAM } from '../src/lib/constants'
+import { getItemAsync } from '../src/lib/helpers'
+import { memoryLocalStorageAdapter } from '../src/lib/local-storage'
+
+const AUTH_URL = 'https://project-ref.supabase.example/auth/v1'
+
+function makePkceClient(options?: {
+  store?: { [key: string]: string }
+  appendPkceFlowIdToRedirects?: boolean
+}) {
+  const store = options?.store ?? {}
+  const storage = memoryLocalStorageAdapter(store)
+  const requestUrls: string[] = []
+  const tokenBodies: Array<{ [key: string]: string }> = []
+
+  // network-free synthetic fetch: records requests, answers every call with
+  // invalid_grant so no session construction is needed
+  const syntheticFetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    requestUrls.push(String(input))
+    if (String(input).includes('/token?grant_type=pkce')) {
+      tokenBodies.push(JSON.parse(String(init?.body)))
+    }
+    return {
+      ok: false,
+      status: 400,
+      headers: new Headers(),
+      json: () =>
+        Promise.resolve({
+          error: 'invalid_grant',
+          error_description: 'Synthetic response',
+        }),
+    } as unknown as Response
+  }) as typeof fetch
+
+  const client = new GoTrueClient({
+    url: AUTH_URL,
+    autoRefreshToken: false,
+    persistSession: true,
+    storage,
+    flowType: 'pkce',
+    fetch: syntheticFetch,
+    experimental: options?.appendPkceFlowIdToRedirects
+      ? { appendPkceFlowIdToRedirects: true }
+      : undefined,
+  })
+  // @ts-expect-error 'Allow access to protected storageKey'
+  const storageKey: string = client.storageKey
+  return { client, storage, store, storageKey, requestUrls, tokenBodies }
+}
+
+function slotKeys(store: { [key: string]: string }, storageKey: string) {
+  return Object.keys(store).filter(
+    (key) =>
+      key.startsWith(`${storageKey}-code-verifier-`) && key !== `${storageKey}-code-verifier-flows`
+  )
+}
+
+function flowIdFromOAuthUrl(url: string): string {
+  const redirectTo = new URL(url).searchParams.get('redirect_to')
+  expect(redirectTo).not.toBeNull()
+  const flowId = new URL(redirectTo!).searchParams.get(PKCE_FLOW_ID_PARAM)
+  expect(flowId).not.toBeNull()
+  return flowId!
+}
+
+describe('overlapping PKCE flows', () => {
+  it('two in-flight starts keep distinct verifiers in separate slots', async () => {
+    const { client, storage, store, storageKey } = makePkceClient()
+
+    await client.signInWithOAuth({
+      provider: 'github',
+      options: {
+        redirectTo: 'https://app.example.test/auth/callback?flow=first',
+        skipBrowserRedirect: true,
+      },
+    })
+    const firstLegacyValue = await getItemAsync(storage, `${storageKey}-code-verifier`)
+
+    await client.signInWithOAuth({
+      provider: 'google',
+      options: {
+        redirectTo: 'https://app.example.test/auth/callback?flow=second',
+        skipBrowserRedirect: true,
+      },
+    })
+    const secondLegacyValue = await getItemAsync(storage, `${storageKey}-code-verifier`)
+
+    const slots = slotKeys(store, storageKey)
+    expect(slots).toHaveLength(2)
+    expect(firstLegacyValue).not.toEqual(secondLegacyValue)
+
+    const slotValues = await Promise.all(slots.map((key) => getItemAsync(storage, key)))
+    expect(slotValues).toContain(firstLegacyValue)
+    expect(slotValues).toContain(secondLegacyValue)
+  })
+
+  it('each callback exchanges its own verifier and cleans up only its slot', async () => {
+    const { client, storage, store, storageKey, tokenBodies } = makePkceClient({
+      appendPkceFlowIdToRedirects: true,
+    })
+
+    const { data: first } = await client.signInWithOAuth({
+      provider: 'github',
+      options: {
+        redirectTo: 'https://app.example.test/auth/callback?flow=first',
+        skipBrowserRedirect: true,
+      },
+    })
+    const { data: second } = await client.signInWithOAuth({
+      provider: 'google',
+      options: {
+        redirectTo: 'https://app.example.test/auth/callback?flow=second',
+        skipBrowserRedirect: true,
+      },
+    })
+
+    const firstFlowId = flowIdFromOAuthUrl(first.url!)
+    const secondFlowId = flowIdFromOAuthUrl(second.url!)
+    expect(firstFlowId).not.toEqual(secondFlowId)
+
+    const firstVerifier = await getItemAsync(storage, `${storageKey}-code-verifier-${firstFlowId}`)
+    const secondVerifier = await getItemAsync(
+      storage,
+      `${storageKey}-code-verifier-${secondFlowId}`
+    )
+
+    // first flow's callback arrives after the second start overwrote the fixed key
+    await client.exchangeCodeForSession('code-from-first-flow', { flowId: firstFlowId })
+
+    expect(tokenBodies).toHaveLength(1)
+    expect(tokenBodies[0].code_verifier).toEqual(firstVerifier)
+    expect(tokenBodies[0].code_verifier).not.toEqual(secondVerifier)
+
+    // only the first flow's slot is cleaned up; the second flow stays pending
+    expect(slotKeys(store, storageKey)).toEqual([`${storageKey}-code-verifier-${secondFlowId}`])
+    expect(await getItemAsync(storage, `${storageKey}-code-verifier`)).toEqual(secondVerifier)
+
+    await client.exchangeCodeForSession('code-from-second-flow', { flowId: secondFlowId })
+
+    expect(tokenBodies).toHaveLength(2)
+    expect(tokenBodies[1].code_verifier).toEqual(secondVerifier)
+    expect(slotKeys(store, storageKey)).toHaveLength(0)
+    expect(await getItemAsync(storage, `${storageKey}-code-verifier`)).toBeNull()
+  })
+
+  it('does not append the flow id parameter without the experimental flag', async () => {
+    const { client } = makePkceClient()
+
+    const { data } = await client.signInWithOAuth({
+      provider: 'github',
+      options: {
+        redirectTo: 'https://app.example.test/auth/callback',
+        skipBrowserRedirect: true,
+      },
+    })
+
+    const redirectTo = new URL(data.url!).searchParams.get('redirect_to')
+    expect(redirectTo).toEqual('https://app.example.test/auth/callback')
+  })
+
+  it('falls back to the fixed key when no flow id is available', async () => {
+    const { client, storage, storageKey, tokenBodies } = makePkceClient()
+
+    // simulate a flow started by an older SDK version: fixed key only
+    await storage.setItem(`${storageKey}-code-verifier`, JSON.stringify('legacy-verifier'))
+
+    await client.exchangeCodeForSession('some-code')
+
+    expect(tokenBodies).toHaveLength(1)
+    expect(tokenBodies[0].code_verifier).toEqual('legacy-verifier')
+    expect(await getItemAsync(storage, `${storageKey}-code-verifier`)).toBeNull()
+  })
+
+  it('password recovery round-trips the flow id and keeps the /recovery marker', async () => {
+    const { client, storage, storageKey, requestUrls, tokenBodies } = makePkceClient({
+      appendPkceFlowIdToRedirects: true,
+    })
+
+    await client.resetPasswordForEmail('user@example.test', {
+      redirectTo: 'https://app.example.test/auth/reset',
+    })
+
+    // the flow id travels on the redirect_to of the /recover request
+    const recoverUrl = requestUrls.find((url) => url.includes('/recover'))!
+    const redirectTo = new URL(recoverUrl).searchParams.get('redirect_to')
+    const flowId = new URL(redirectTo!).searchParams.get(PKCE_FLOW_ID_PARAM)
+    expect(flowId).not.toBeNull()
+
+    const storedVerifier = (await getItemAsync(
+      storage,
+      `${storageKey}-code-verifier-${flowId}`
+    )) as string
+    expect(storedVerifier).toMatch(/\/recovery$/)
+
+    await client.exchangeCodeForSession('recovery-code', { flowId: flowId! })
+
+    expect(tokenBodies).toHaveLength(1)
+    expect(tokenBodies[0].code_verifier).toEqual(storedVerifier.replace(/\/recovery$/, ''))
+  })
+
+  it('detects a PKCE callback from the flow id slot even when the fixed key is gone', async () => {
+    const { client, storage, storageKey } = makePkceClient({
+      appendPkceFlowIdToRedirects: true,
+    })
+
+    const { data } = await client.signInWithOAuth({
+      provider: 'github',
+      options: {
+        redirectTo: 'https://app.example.test/auth/callback',
+        skipBrowserRedirect: true,
+      },
+    })
+    const flowId = flowIdFromOAuthUrl(data.url!)
+
+    // another flow's exchange (old SDK, or no flow id) consumed the fixed key
+    await storage.removeItem(`${storageKey}-code-verifier`)
+
+    // @ts-expect-error 'Allow access to private _isPKCECallback'
+    expect(await client._isPKCECallback({ code: 'abc', [PKCE_FLOW_ID_PARAM]: flowId })).toBe(true)
+    // @ts-expect-error 'Allow access to private _isPKCECallback'
+    expect(await client._isPKCECallback({ code: 'abc' })).toBe(false)
+  })
+
+  it('bounds the number of stored verifier slots', async () => {
+    const { client, store, storageKey } = makePkceClient()
+
+    for (let i = 0; i < 7; i++) {
+      await client.signInWithOAuth({
+        provider: 'github',
+        options: {
+          redirectTo: 'https://app.example.test/auth/callback',
+          skipBrowserRedirect: true,
+        },
+      })
+    }
+
+    expect(slotKeys(store, storageKey)).toHaveLength(5)
+  })
+})

--- a/packages/core/auth-js/test/GoTrueClient.test.ts
+++ b/packages/core/auth-js/test/GoTrueClient.test.ts
@@ -3596,13 +3596,15 @@ describe('Storage adapter edge cases', () => {
   test('should build provider URL with _getUrlForProvider', async () => {
     const client = getClientWithSpecificStorage(memoryLocalStorageAdapter())
     // @ts-expect-error private method
-    const url = await client._getUrlForProvider(
+    const { url, flowId } = await client._getUrlForProvider(
       GOTRUE_URL_SIGNUP_ENABLED_AUTO_CONFIRM_ON,
       'google',
       { redirectTo: 'http://localhost' }
     )
     expect(typeof url).toBe('string')
     expect(url).toContain('google')
+    // implicit flow: no PKCE flow is started
+    expect(flowId).toBeNull()
   })
 
   test('_getUrlForProvider builds correct URL with PKCE flow', async () => {
@@ -3613,13 +3615,18 @@ describe('Storage adapter edge cases', () => {
       flowType: 'pkce',
     })
 
-    const url = await client['_getUrlForProvider']('https://example.com/authorize', 'github', {
-      redirectTo: 'http://localhost:3000/callback',
-    })
+    const { url, flowId } = await client['_getUrlForProvider'](
+      'https://example.com/authorize',
+      'github',
+      {
+        redirectTo: 'http://localhost:3000/callback',
+      }
+    )
 
     expect(url).toContain('provider=github')
     expect(url).toContain('code_challenge=')
     expect(url).toContain('code_challenge_method=')
+    expect(flowId).toMatch(/^[a-f0-9]{32}$/)
   })
 
   test('should handle localStorage not supported', async () => {
@@ -3722,9 +3729,7 @@ describe('Lockless coordination (default) and legacy lock opt-in', () => {
   test('legacy path: custom `lock` is invoked when supplied', async () => {
     const mockLock = jest
       .fn()
-      .mockImplementation(async (name: string, timeout: number, fn: () => Promise<unknown>) =>
-        fn()
-      )
+      .mockImplementation(async (name: string, timeout: number, fn: () => Promise<unknown>) => fn())
 
     const client = new GoTrueClient({
       url: GOTRUE_URL_SIGNUP_ENABLED_AUTO_CONFIRM_ON,

--- a/packages/core/auth-js/test/helpers.test.ts
+++ b/packages/core/auth-js/test/helpers.test.ts
@@ -9,6 +9,7 @@ import {
   parseParametersFromURL,
   parseResponseAPIVersion,
   getCodeChallengeAndMethod,
+  removeAllPKCEVerifiers,
   removePKCEVerifier,
   retrievePKCEVerifier,
   storePKCEVerifier,
@@ -301,13 +302,13 @@ describe('getCodeChallengeAndMethod', () => {
 
     const setItemKeys = mockStorage.setItem.mock.calls.map((call) => call[0])
     expect(setItemKeys).toContain('test-storage-key-code-verifier')
-    expect(setItemKeys).toContain(`test-storage-key-code-verifier-${flowId}`)
+    expect(setItemKeys).toContain(`test-storage-key-flow-${flowId}-code-verifier`)
 
     const legacyCall = mockStorage.setItem.mock.calls.find(
       (call) => call[0] === 'test-storage-key-code-verifier'
     )!
     const slotCall = mockStorage.setItem.mock.calls.find(
-      (call) => call[0] === `test-storage-key-code-verifier-${flowId}`
+      (call) => call[0] === `test-storage-key-flow-${flowId}-code-verifier`
     )!
     const storedValue = JSON.parse(legacyCall[1])
     expect(JSON.parse(slotCall[1])).toEqual(storedValue)
@@ -325,7 +326,8 @@ describe('getCodeChallengeAndMethod', () => {
 describe('PKCE verifier slots', () => {
   const storageKey = 'test-storage-key'
   const legacyKey = `${storageKey}-code-verifier`
-  const indexKey = `${storageKey}-code-verifier-flows`
+  const indexKey = `${storageKey}-flows-code-verifier`
+  const slotKey = (flowId: string) => `${storageKey}-flow-${flowId}-code-verifier`
 
   it('storePKCEVerifier keeps one slot per flow plus the legacy key', async () => {
     const store: { [key: string]: string } = {}
@@ -334,30 +336,50 @@ describe('PKCE verifier slots', () => {
     await storePKCEVerifier(storage, storageKey, 'flow-id-aaaa', 'verifier-a')
     await storePKCEVerifier(storage, storageKey, 'flow-id-bbbb', 'verifier-b')
 
-    expect(await getItemAsync(storage, `${legacyKey}-flow-id-aaaa`)).toBe('verifier-a')
-    expect(await getItemAsync(storage, `${legacyKey}-flow-id-bbbb`)).toBe('verifier-b')
+    expect(await getItemAsync(storage, slotKey('flow-id-aaaa'))).toBe('verifier-a')
+    expect(await getItemAsync(storage, slotKey('flow-id-bbbb'))).toBe('verifier-b')
     expect(await getItemAsync(storage, legacyKey)).toBe('verifier-b')
     expect(await getItemAsync(storage, indexKey)).toEqual(['flow-id-aaaa', 'flow-id-bbbb'])
   })
 
-  it('storePKCEVerifier evicts the oldest slot beyond the bound', async () => {
+  it('storePKCEVerifier evicts the oldest slot beyond the bound and reports it', async () => {
     const store: { [key: string]: string } = {}
     const storage = memoryLocalStorageAdapter(store)
+    const evicted: string[] = []
 
     const flowIds = ['flow-1111', 'flow-2222', 'flow-3333', 'flow-4444', 'flow-5555', 'flow-6666']
     for (const flowId of flowIds) {
-      await storePKCEVerifier(storage, storageKey, flowId, `verifier-${flowId}`)
+      await storePKCEVerifier(storage, storageKey, flowId, `verifier-${flowId}`, (id) =>
+        evicted.push(id)
+      )
     }
 
-    expect(await getItemAsync(storage, `${legacyKey}-flow-1111`)).toBeNull()
+    expect(await getItemAsync(storage, slotKey('flow-1111'))).toBeNull()
     expect(await getItemAsync(storage, indexKey)).toEqual(flowIds.slice(1))
-    const slotKeys = Object.keys(store).filter(
-      (key) => key.startsWith(`${legacyKey}-`) && key !== indexKey
-    )
-    expect(slotKeys).toHaveLength(5)
+    expect(evicted).toEqual(['flow-1111'])
+    const slots = Object.keys(store).filter((key) => key.startsWith(`${storageKey}-flow-`))
+    expect(slots).toHaveLength(5)
   })
 
-  it('retrievePKCEVerifier prefers the slot and falls back to the legacy key', async () => {
+  it('storePKCEVerifier tolerates a corrupt or hostile index', async () => {
+    const storage = memoryLocalStorageAdapter()
+
+    for (const garbage of [
+      'not-json{',
+      '{"a":1}',
+      '[42,null,"short","../etc/passwd","ok_flow-id"]',
+    ]) {
+      await storage.setItem(indexKey, garbage)
+      await storePKCEVerifier(storage, storageKey, 'flow-id-aaaa', 'verifier-a')
+
+      // only entries shaped like flow ids survive; everything else is dropped
+      const index = (await getItemAsync(storage, indexKey)) as string[]
+      expect(index[index.length - 1]).toBe('flow-id-aaaa')
+      expect(index.every((id) => /^[a-zA-Z0-9_-]{8,64}$/.test(id))).toBe(true)
+    }
+  })
+
+  it('retrievePKCEVerifier is slot-only when a flow id is given', async () => {
     const storage = memoryLocalStorageAdapter()
 
     await storePKCEVerifier(storage, storageKey, 'flow-id-aaaa', 'verifier-a')
@@ -367,11 +389,13 @@ describe('PKCE verifier slots', () => {
       verifier: 'verifier-a',
       flowId: 'flow-id-aaaa',
     })
-    // unknown flow id falls back to the most recent (legacy) verifier
+    // an unknown flow id must NOT borrow another flow's verifier: a mismatched
+    // verifier would burn the single-use auth code
     expect(await retrievePKCEVerifier(storage, storageKey, 'flow-id-gone')).toEqual({
-      verifier: 'verifier-b',
-      flowId: null,
+      verifier: null,
+      flowId: 'flow-id-gone',
     })
+    // without a flow id the legacy key (most recent flow) is used
     expect(await retrievePKCEVerifier(storage, storageKey, null)).toEqual({
       verifier: 'verifier-b',
       flowId: null,
@@ -386,8 +410,8 @@ describe('PKCE verifier slots', () => {
 
     await removePKCEVerifier(storage, storageKey, 'flow-id-aaaa')
 
-    expect(await getItemAsync(storage, `${legacyKey}-flow-id-aaaa`)).toBeNull()
-    expect(await getItemAsync(storage, `${legacyKey}-flow-id-bbbb`)).toBe('verifier-b')
+    expect(await getItemAsync(storage, slotKey('flow-id-aaaa'))).toBeNull()
+    expect(await getItemAsync(storage, slotKey('flow-id-bbbb'))).toBe('verifier-b')
     // the legacy key holds flow b's verifier, so it must survive flow a's cleanup
     expect(await getItemAsync(storage, legacyKey)).toBe('verifier-b')
     expect(await getItemAsync(storage, indexKey)).toEqual(['flow-id-bbbb'])
@@ -412,8 +436,29 @@ describe('PKCE verifier slots', () => {
     await removePKCEVerifier(storage, storageKey, null)
 
     expect(await getItemAsync(storage, legacyKey)).toBeNull()
-    expect(await getItemAsync(storage, `${legacyKey}-flow-id-aaaa`)).toBe('verifier-a')
-    expect(await getItemAsync(storage, `${legacyKey}-flow-id-bbbb`)).toBe('verifier-b')
+    expect(await getItemAsync(storage, slotKey('flow-id-aaaa'))).toBe('verifier-a')
+    expect(await getItemAsync(storage, slotKey('flow-id-bbbb'))).toBe('verifier-b')
+  })
+
+  it('removeAllPKCEVerifiers clears every slot, the index and the legacy key', async () => {
+    const store: { [key: string]: string } = {}
+    const storage = memoryLocalStorageAdapter(store)
+
+    await storePKCEVerifier(storage, storageKey, 'flow-id-aaaa', 'verifier-a')
+    await storePKCEVerifier(storage, storageKey, 'flow-id-bbbb', 'verifier-b')
+
+    await removeAllPKCEVerifiers(storage, storageKey)
+
+    expect(Object.keys(store)).toEqual([])
+  })
+
+  it('slot keys end in -code-verifier and contain no dot', () => {
+    // @supabase/ssr's server adapter only immediately persists keys ending in
+    // -code-verifier, and treats `<key>.<number>` cookies as chunks
+    for (const key of [slotKey('abcdef12'), indexKey, legacyKey]) {
+      expect(key.endsWith('-code-verifier')).toBe(true)
+      expect(key).not.toContain('.')
+    }
   })
 })
 
@@ -454,6 +499,24 @@ describe('appendFlowIdToRedirectTo', () => {
     expect(appendFlowIdToRedirectTo('myapp://auth/callback', 'abc12345')).toBe(
       'myapp://auth/callback?sb_flow_id=abc12345'
     )
+  })
+
+  it('replaces an existing sb_flow_id instead of duplicating it', () => {
+    expect(
+      appendFlowIdToRedirectTo(
+        'https://app.example.com/callback?sb_flow_id=stale123&next=/home',
+        'abc12345'
+      )
+    ).toBe('https://app.example.com/callback?next=/home&sb_flow_id=abc12345')
+    expect(
+      appendFlowIdToRedirectTo('https://app.example.com/callback?sb_flow_id=stale123', 'abc12345')
+    ).toBe('https://app.example.com/callback?sb_flow_id=abc12345')
+  })
+
+  it("does not re-encode the app's own query parameters", () => {
+    expect(
+      appendFlowIdToRedirectTo('https://app.example.com/callback?next=%2Fa%20b', 'abc12345')
+    ).toBe('https://app.example.com/callback?next=%2Fa%20b&sb_flow_id=abc12345')
   })
 })
 

--- a/packages/core/auth-js/test/helpers.test.ts
+++ b/packages/core/auth-js/test/helpers.test.ts
@@ -1,14 +1,21 @@
 import { AuthInvalidJwtError } from '../src'
 import {
+  appendFlowIdToRedirectTo,
   decodeJWT,
   generateCallbackId,
+  generatePKCEFlowId,
   getAlgorithm,
   getItemAsync,
   parseParametersFromURL,
   parseResponseAPIVersion,
   getCodeChallengeAndMethod,
+  removePKCEVerifier,
+  retrievePKCEVerifier,
+  storePKCEVerifier,
+  validatePKCEFlowId,
   validateUUID,
 } from '../src/lib/helpers'
+import { memoryLocalStorageAdapter } from '../src/lib/local-storage'
 
 describe('generateCallbackId', () => {
   it('should return a Symbol', () => {
@@ -286,15 +293,24 @@ describe('getCodeChallengeAndMethod', () => {
       removeItem: jest.fn(),
     }
 
-    const [codeChallenge, codeChallengeMethod] = await getCodeChallengeAndMethod(
+    const [codeChallenge, codeChallengeMethod, flowId] = await getCodeChallengeAndMethod(
       mockStorage,
       'test-storage-key',
       isPasswordRecovery
     )
 
-    const setItemCall = mockStorage.setItem.mock.calls[0]
-    expect(setItemCall[0]).toBe('test-storage-key-code-verifier')
-    const storedValue = JSON.parse(setItemCall[1])
+    const setItemKeys = mockStorage.setItem.mock.calls.map((call) => call[0])
+    expect(setItemKeys).toContain('test-storage-key-code-verifier')
+    expect(setItemKeys).toContain(`test-storage-key-code-verifier-${flowId}`)
+
+    const legacyCall = mockStorage.setItem.mock.calls.find(
+      (call) => call[0] === 'test-storage-key-code-verifier'
+    )!
+    const slotCall = mockStorage.setItem.mock.calls.find(
+      (call) => call[0] === `test-storage-key-code-verifier-${flowId}`
+    )!
+    const storedValue = JSON.parse(legacyCall[1])
+    expect(JSON.parse(slotCall[1])).toEqual(storedValue)
     if (isPasswordRecovery) {
       expect(storedValue).toContain('/recovery')
     } else {
@@ -302,6 +318,142 @@ describe('getCodeChallengeAndMethod', () => {
     }
     expect(codeChallenge).toBeDefined()
     expect(codeChallengeMethod).toBeDefined()
+    expect(flowId).toMatch(/^[a-f0-9]{32}$/)
+  })
+})
+
+describe('PKCE verifier slots', () => {
+  const storageKey = 'test-storage-key'
+  const legacyKey = `${storageKey}-code-verifier`
+  const indexKey = `${storageKey}-code-verifier-flows`
+
+  it('storePKCEVerifier keeps one slot per flow plus the legacy key', async () => {
+    const store: { [key: string]: string } = {}
+    const storage = memoryLocalStorageAdapter(store)
+
+    await storePKCEVerifier(storage, storageKey, 'flow-id-aaaa', 'verifier-a')
+    await storePKCEVerifier(storage, storageKey, 'flow-id-bbbb', 'verifier-b')
+
+    expect(await getItemAsync(storage, `${legacyKey}-flow-id-aaaa`)).toBe('verifier-a')
+    expect(await getItemAsync(storage, `${legacyKey}-flow-id-bbbb`)).toBe('verifier-b')
+    expect(await getItemAsync(storage, legacyKey)).toBe('verifier-b')
+    expect(await getItemAsync(storage, indexKey)).toEqual(['flow-id-aaaa', 'flow-id-bbbb'])
+  })
+
+  it('storePKCEVerifier evicts the oldest slot beyond the bound', async () => {
+    const store: { [key: string]: string } = {}
+    const storage = memoryLocalStorageAdapter(store)
+
+    const flowIds = ['flow-1111', 'flow-2222', 'flow-3333', 'flow-4444', 'flow-5555', 'flow-6666']
+    for (const flowId of flowIds) {
+      await storePKCEVerifier(storage, storageKey, flowId, `verifier-${flowId}`)
+    }
+
+    expect(await getItemAsync(storage, `${legacyKey}-flow-1111`)).toBeNull()
+    expect(await getItemAsync(storage, indexKey)).toEqual(flowIds.slice(1))
+    const slotKeys = Object.keys(store).filter(
+      (key) => key.startsWith(`${legacyKey}-`) && key !== indexKey
+    )
+    expect(slotKeys).toHaveLength(5)
+  })
+
+  it('retrievePKCEVerifier prefers the slot and falls back to the legacy key', async () => {
+    const storage = memoryLocalStorageAdapter()
+
+    await storePKCEVerifier(storage, storageKey, 'flow-id-aaaa', 'verifier-a')
+    await storePKCEVerifier(storage, storageKey, 'flow-id-bbbb', 'verifier-b')
+
+    expect(await retrievePKCEVerifier(storage, storageKey, 'flow-id-aaaa')).toEqual({
+      verifier: 'verifier-a',
+      flowId: 'flow-id-aaaa',
+    })
+    // unknown flow id falls back to the most recent (legacy) verifier
+    expect(await retrievePKCEVerifier(storage, storageKey, 'flow-id-gone')).toEqual({
+      verifier: 'verifier-b',
+      flowId: null,
+    })
+    expect(await retrievePKCEVerifier(storage, storageKey, null)).toEqual({
+      verifier: 'verifier-b',
+      flowId: null,
+    })
+  })
+
+  it('removePKCEVerifier removes only its own slot', async () => {
+    const storage = memoryLocalStorageAdapter()
+
+    await storePKCEVerifier(storage, storageKey, 'flow-id-aaaa', 'verifier-a')
+    await storePKCEVerifier(storage, storageKey, 'flow-id-bbbb', 'verifier-b')
+
+    await removePKCEVerifier(storage, storageKey, 'flow-id-aaaa')
+
+    expect(await getItemAsync(storage, `${legacyKey}-flow-id-aaaa`)).toBeNull()
+    expect(await getItemAsync(storage, `${legacyKey}-flow-id-bbbb`)).toBe('verifier-b')
+    // the legacy key holds flow b's verifier, so it must survive flow a's cleanup
+    expect(await getItemAsync(storage, legacyKey)).toBe('verifier-b')
+    expect(await getItemAsync(storage, indexKey)).toEqual(['flow-id-bbbb'])
+  })
+
+  it('removePKCEVerifier drops the legacy key when it belongs to the removed flow', async () => {
+    const storage = memoryLocalStorageAdapter()
+
+    await storePKCEVerifier(storage, storageKey, 'flow-id-aaaa', 'verifier-a')
+    await removePKCEVerifier(storage, storageKey, 'flow-id-aaaa')
+
+    expect(await getItemAsync(storage, legacyKey)).toBeNull()
+    expect(await getItemAsync(storage, indexKey)).toBeNull()
+  })
+
+  it('removePKCEVerifier without a flow id only touches the legacy key', async () => {
+    const storage = memoryLocalStorageAdapter()
+
+    await storePKCEVerifier(storage, storageKey, 'flow-id-aaaa', 'verifier-a')
+    await storePKCEVerifier(storage, storageKey, 'flow-id-bbbb', 'verifier-b')
+
+    await removePKCEVerifier(storage, storageKey, null)
+
+    expect(await getItemAsync(storage, legacyKey)).toBeNull()
+    expect(await getItemAsync(storage, `${legacyKey}-flow-id-aaaa`)).toBe('verifier-a')
+    expect(await getItemAsync(storage, `${legacyKey}-flow-id-bbbb`)).toBe('verifier-b')
+  })
+})
+
+describe('validatePKCEFlowId', () => {
+  it('accepts generated flow ids', () => {
+    const flowId = generatePKCEFlowId()
+    expect(validatePKCEFlowId(flowId)).toBe(flowId)
+  })
+
+  it.each([null, undefined, 42, '', 'short', 'has spaces here', 'a'.repeat(65), 'slash/../evil'])(
+    'rejects %p',
+    (value) => {
+      expect(validatePKCEFlowId(value)).toBeNull()
+    }
+  )
+})
+
+describe('appendFlowIdToRedirectTo', () => {
+  it('appends as the first query parameter', () => {
+    expect(appendFlowIdToRedirectTo('https://app.example.com/callback', 'abc12345')).toBe(
+      'https://app.example.com/callback?sb_flow_id=abc12345'
+    )
+  })
+
+  it('appends after existing query parameters', () => {
+    expect(
+      appendFlowIdToRedirectTo('https://app.example.com/callback?next=/home', 'abc12345')
+    ).toBe('https://app.example.com/callback?next=/home&sb_flow_id=abc12345')
+  })
+
+  it('keeps a fragment at the end', () => {
+    expect(appendFlowIdToRedirectTo('https://app.example.com/callback#section', 'abc12345')).toBe(
+      'https://app.example.com/callback?sb_flow_id=abc12345#section'
+    )
+  })
+
+  it('works with custom schemes', () => {
+    expect(appendFlowIdToRedirectTo('myapp://auth/callback', 'abc12345')).toBe(
+      'myapp://auth/callback?sb_flow_id=abc12345'
+    )
   })
 })
 


### PR DESCRIPTION
Stores each PKCE code verifier in its own bounded storage slot (`${storageKey}-flow-<flowId>-code-verifier`, ring of 5) instead of a single fixed key, so overlapping OAuth or password recovery flows no longer overwrite each other's verifier. `signInWithOAuth` and `linkIdentity` return the `flowId`, `exchangeCodeForSession` accepts it as an optional selector, and enabling `experimental.appendPkceFlowIdToRedirects` appends a reserved `sb_flow_id` param to `redirectTo` that round-trips through the auth server so browser callbacks pick the right verifier automatically. When a flow id is present but its verifier is gone, the exchange fails fast instead of submitting another flow's verifier, which would consume the single-use auth code.

The redirect param is opt-in because the auth server matches redirect URLs against the allow list including the query string. Slot keys end in `-code-verifier` so `@supabase/ssr`'s server adapter persists them immediately (no ssr change needed) and contain no dot to avoid its chunked cookie naming (`<key>.<number>`). Sign-out and session teardown clear all pending slots; the legacy fixed key is still written and read as a fallback, so single-flow callers and older SDK versions are unaffected.

Closes #2557