### PR TITLE
fix(supabase): forward db retry option

### DIFF
--- a/packages/core/supabase-js/src/SupabaseClient.ts
+++ b/packages/core/supabase-js/src/SupabaseClient.ts
@@ -398,6 +398,7 @@ export default class SupabaseClient<
       fetch: this.fetch,
       timeout: settings.db.timeout,
       urlLengthLimit: settings.db.urlLengthLimit,
+      retry: settings.db.retry,
     })
 
     this.storage = new SupabaseStorageClient(

--- a/packages/core/supabase-js/src/lib/types.ts
+++ b/packages/core/supabase-js/src/lib/types.ts
@@ -124,6 +124,11 @@ export type SupabaseClientOptions<SchemaName> = {
      * ```
      */
     urlLengthLimit?: number
+    /**
+     * Enable or disable automatic retries for transient PostgREST errors.
+     * Defaults to `true`.
+     */
+    retry?: boolean
   }
 
   auth?: {

--- a/packages/core/supabase-js/test/unit/SupabaseClient.test.ts
+++ b/packages/core/supabase-js/test/unit/SupabaseClient.test.ts
@@ -110,6 +110,19 @@ describe('SupabaseClient', () => {
     })
   })
 
+  describe('PostgREST Configuration', () => {
+    test('should forward the retry option to PostgrestClient', () => {
+      const client = createClient(URL, KEY, {
+        db: { retry: false },
+      })
+
+      // @ts-expect-error rest is protected
+      expect(client.rest.retry).toBe(false)
+      // @ts-expect-error retryEnabled is protected
+      expect(client.from('users').select().retryEnabled).toBe(false)
+    })
+  })
+
   describe('Custom Headers', () => {
     test('should have custom header set', () => {
       const customHeader = { 'X-Test-Header': 'value' }


### PR DESCRIPTION
## TL;DR

forward `db.retry` from `createClient()` to `PostgrestClient` so
 client llevel retry configuration applies to queries....

## Ref

- closes #2570