### PR TITLE
docs(postgrest): document that statusText may be empty over HTTP/2

### DIFF
--- a/packages/core/postgrest-js/src/PostgrestQueryBuilder.ts
+++ b/packages/core/postgrest-js/src/PostgrestQueryBuilder.ts
@@ -192,7 +192,7 @@ export default class PostgrestQueryBuilder<
      *     "message": "permission denied for table characters"
      *   },
      *   "status": 401,
-     *   "statusText": "Unauthorized"
+     *   "statusText": ""
      * }
      * ```
      *
@@ -1008,7 +1008,7 @@ export default class PostgrestQueryBuilder<
    * ```json
    * {
    *   "status": 201,
-   *   "statusText": "Created"
+   *   "statusText": ""
    * }
    * ```
    *
@@ -1045,7 +1045,7 @@ export default class PostgrestQueryBuilder<
    *     }
    *   ],
    *   "status": 201,
-   *   "statusText": "Created"
+   *   "statusText": ""
    * }
    * ```
    *
@@ -1079,7 +1079,7 @@ export default class PostgrestQueryBuilder<
    *     "message": "duplicate key value violates unique constraint \"countries_pkey\""
    *   },
    *   "status": 409,
-   *   "statusText": "Conflict"
+   *   "statusText": ""
    * }
    * ```
    */
@@ -1258,7 +1258,7 @@ export default class PostgrestQueryBuilder<
    *     }
    *   ],
    *   "status": 201,
-   *   "statusText": "Created"
+   *   "statusText": ""
    * }
    * ```
    *
@@ -1307,7 +1307,7 @@ export default class PostgrestQueryBuilder<
    *     }
    *   ],
    *   "status": 201,
-   *   "statusText": "Created"
+   *   "statusText": ""
    * }
    * ```
    *
@@ -1352,7 +1352,7 @@ export default class PostgrestQueryBuilder<
    *     "message": "duplicate key value violates unique constraint \"users_handle_key\""
    *   },
    *   "status": 409,
-   *   "statusText": "Conflict"
+   *   "statusText": ""
    * }
    * ```
    */
@@ -1469,7 +1469,7 @@ export default class PostgrestQueryBuilder<
    * ```json
    * {
    *   "status": 204,
-   *   "statusText": "No Content"
+   *   "statusText": ""
    * }
    * ```
    *
@@ -1659,7 +1659,7 @@ export default class PostgrestQueryBuilder<
    * ```json
    * {
    *   "status": 204,
-   *   "statusText": "No Content"
+   *   "statusText": ""
    * }
    * ```
    *
@@ -1729,7 +1729,7 @@ export default class PostgrestQueryBuilder<
    * ```json
    * {
    *   "status": 204,
-   *   "statusText": "No Content"
+   *   "statusText": ""
    * }
    * ```
    */

--- a/packages/core/postgrest-js/src/PostgrestTransformBuilder.ts
+++ b/packages/core/postgrest-js/src/PostgrestTransformBuilder.ts
@@ -78,7 +78,7 @@ export default class PostgrestTransformBuilder<
    *     }
    *   ],
    *   "status": 201,
-   *   "statusText": "Created"
+   *   "statusText": ""
    * }
    * ```
    */
@@ -633,8 +633,8 @@ export default class PostgrestTransformBuilder<
    *       "hint": "",
    *       "code": ""
    *     },
-   *     "status": 400,
-   *     "statusText": "Bad Request"
+   *     "status": 0,
+   *     "statusText": ""
    *   }
    *
    * ```

--- a/packages/core/postgrest-js/src/types/types.ts
+++ b/packages/core/postgrest-js/src/types/types.ts
@@ -9,7 +9,15 @@ import { ClientServerOptions } from './common/common'
  * {@link https://github.com/supabase/supabase-js/issues/32}
  */
 interface PostgrestResponseBase {
+  /** HTTP status code of the response. */
   status: number
+  /**
+   * HTTP reason phrase of the response, e.g. `"OK"`.
+   *
+   * May be an empty string: HTTP/2 and HTTP/3 don't carry reason phrases, so
+   * responses over those protocols (e.g. browser requests to Supabase) have no
+   * `statusText`. Rely on `status` instead of this value.
+   */
   statusText: string
 }
 export interface PostgrestResponseSuccess<T> extends PostgrestResponseBase {


### PR DESCRIPTION
Docs-only change. `statusText` mirrors the HTTP reason phrase, which HTTP/2 and HTTP/3 removed from the protocol entirely, so browser clients talking to Supabase always receive an empty string, while the JSDoc examples promised values like `"Created"` and `"Conflict"`. This adds a field-level caveat on the response type explaining that `statusText` may be empty and that `status` is the value to rely on, empties the misleading example phrases (these examples render on supabase.com through the TSDoc pipeline), and corrects the `abortSignal` timeout example, which showed `status: 400` for a local abort that actually returns `status: 0`.

This is the documentation fix chosen instead of the client-side reason-phrase fallback proposed in #2478 (now closed). No runtime behavior is touched.

Closes supabase/postgrest-js#405