### PR TITLE
fix(storage): url-encode object keys in file API request paths

### DIFF
--- a/packages/core/storage-js/src/packages/StorageFileApi.ts
+++ b/packages/core/storage-js/src/packages/StorageFileApi.ts
@@ -1101,8 +1101,7 @@ export default class StorageFileApi extends BaseApiClient<StorageError> {
     return {
       data: {
         publicUrl:
-          encodeURI(`${this.url}/${renderPath}/public/${_path}`) +
-          (queryString ? `?${queryString}` : ''),
+          `${this.url}/${renderPath}/public/${_path}` + (queryString ? `?${queryString}` : ''),
       },
     }
   }
@@ -1216,7 +1215,7 @@ export default class StorageFileApi extends BaseApiClient<StorageError> {
       }
   > {
     return this.handleOperation(async () => {
-      const _path = encodeStoragePath(this._getFinalPath(path))
+      const _path = this._getFinalPath(path)
       const query = new URLSearchParams()
       if (options?.transformations) {
         query.set('transformations', 'true')
@@ -1493,7 +1492,7 @@ export default class StorageFileApi extends BaseApiClient<StorageError> {
   }
 
   private _getFinalPath(path: string) {
-    return `${this.bucketId}/${path.replace(/^\/+/, '')}`
+    return encodeStoragePath(`${this.bucketId}/${path.replace(/^\/+/, '')}`)
   }
 
   private _removeEmptyFolders(path: string) {

--- a/packages/core/storage-js/test/encode-object-key.test.ts
+++ b/packages/core/storage-js/test/encode-object-key.test.ts
@@ -1,0 +1,120 @@
+import { StorageClient } from '../src/index'
+
+// `?` ` ` `&` `=` `+` are all accepted by the Storage server as part of an object
+// key, and all of them change the meaning of a URL if interpolated raw.
+const KEY = 'folder/a?b&c=d e+f.txt'
+const ENCODED = 'folder/a%3Fb%26c%3Dd%20e%2Bf.txt'
+
+// Unit test (custom fetch capture) — proves such a key stays inside the path
+// instead of starting a querystring.
+describe('object keys containing URL delimiters', () => {
+  const URL = 'http://localhost/storage/v1'
+
+  const makeClient = () => {
+    const urls: string[] = []
+    const fetch = (async (url: string) => {
+      urls.push(url)
+      return new Response(JSON.stringify({}), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    }) as unknown as typeof globalThis.fetch
+    return { client: new StorageClient(URL, {}, fetch), urls }
+  }
+
+  test('getPublicUrl keeps the key in the path', () => {
+    const { client } = makeClient()
+    const { data } = client.from('bucket').getPublicUrl(KEY)
+    const parsed = new global.URL(data.publicUrl)
+    expect(parsed.pathname).toBe(`/storage/v1/object/public/bucket/${ENCODED}`)
+    expect(parsed.search).toBe('')
+  })
+
+  test('info sends the key as path only', async () => {
+    const { client, urls } = makeClient()
+    await client.from('bucket').info(KEY)
+    expect(new global.URL(urls[0]).pathname).toBe(`/storage/v1/object/info/bucket/${ENCODED}`)
+  })
+
+  test('exists sends the key as path only', async () => {
+    const { client, urls } = makeClient()
+    await client.from('bucket').exists(KEY)
+    expect(new global.URL(urls[0]).pathname).toBe(`/storage/v1/object/bucket/${ENCODED}`)
+  })
+
+  test('createSignedUrl sends the key as path only', async () => {
+    const { client, urls } = makeClient()
+    await client.from('bucket').createSignedUrl(KEY, 60)
+    expect(new global.URL(urls[0]).pathname).toBe(`/storage/v1/object/sign/bucket/${ENCODED}`)
+  })
+})
+
+// Integration test — the encoding above is only useful if the Storage server
+// decodes each segment back to the original key, so round-trip the key against a
+// real server rather than assuming it.
+describe('object keys containing URL delimiters, against the server', () => {
+  // Supabase CLI local development defaults
+  const SERVER_URL = 'http://127.0.0.1:54321/storage/v1'
+  // secret key - bypasses RLS for testing
+  const SERVICE_KEY =
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU'
+
+  const storage = new StorageClient(SERVER_URL, { Authorization: `Bearer ${SERVICE_KEY}` })
+  const body = 'delimiter key contents'
+
+  let bucketName: string
+
+  beforeAll(async () => {
+    bucketName = `delimiter-bucket-${Date.now()}`
+    const { error } = await storage.createBucket(bucketName, { public: true })
+    expect(error).toBeNull()
+  })
+
+  test('upload, then read the same object back through every path-based method', async () => {
+    const { data: uploaded, error: uploadError } = await storage
+      .from(bucketName)
+      .upload(KEY, body, { contentType: 'text/plain' })
+    expect(uploadError).toBeNull()
+    expect(uploaded?.path).toBe(KEY)
+
+    // The server stored the whole key, delimiters and all.
+    const { data: listed } = await storage.from(bucketName).list('folder')
+    expect(listed?.map((entry) => entry.name)).toContain('a?b&c=d e+f.txt')
+
+    expect(await storage.from(bucketName).exists(KEY)).toEqual({ data: true, error: null })
+
+    const { data: info, error: infoError } = await storage.from(bucketName).info(KEY)
+    expect(infoError).toBeNull()
+    expect(info?.name).toBe(KEY)
+
+    const { data: blob, error: downloadError } = await storage.from(bucketName).download(KEY)
+    expect(downloadError).toBeNull()
+    expect(await blob?.text()).toBe(body)
+
+    const { publicUrl } = storage.from(bucketName).getPublicUrl(KEY).data
+    expect(await (await fetch(publicUrl)).text()).toBe(body)
+  })
+
+  // `createSignedUrl` is deliberately excluded above. The server signs a token
+  // over the percent-encoded key but validates the request against the decoded
+  // path, so the signature never matches for a key whose encoding is anything
+  // other than `%20` — the URL the server itself returns fails the same way, so
+  // this is not something the client can encode its way out of.
+  test('createSignedUrl still cannot serve a key containing `?`', async () => {
+    const { data: signed, error } = await storage.from(bucketName).createSignedUrl(KEY, 60)
+    expect(error).toBeNull()
+    expect((await fetch(signed!.signedUrl)).status).toBe(400)
+  })
+
+  test('createSignedUrl works for a key whose only escape is `%20`', async () => {
+    const spaceKey = 'folder/a b.txt'
+    const { error: uploadError } = await storage
+      .from(bucketName)
+      .upload(spaceKey, body, { contentType: 'text/plain' })
+    expect(uploadError).toBeNull()
+
+    const { data: signed, error } = await storage.from(bucketName).createSignedUrl(spaceKey, 60)
+    expect(error).toBeNull()
+    expect(await (await fetch(signed!.signedUrl)).text()).toBe(body)
+  })
+})


### PR DESCRIPTION
## Description

Object keys may contain characters the Storage server accepts but that change the meaning of a URL. `_getFinalPath` interpolated them into the request path raw, so a valid key was sent as key-plus-querystring and the server resolved **a different object**, with no error:

```
exists("folder/a?b.txt")
  → GET /object/bucket/folder/a?b.txt     // server sees key "folder/a"
```

This is the same failure #2545 fixed for the CDN purge methods — the helper and rationale added there (`encodeStoragePath`) were never applied to the rest of the file API.

Affected: `upload`/`update`, `createSignedUploadUrl`, `createSignedUrl`, `createSignedUrls`, `info`, `exists`, `getPublicUrl`.

## Which characters this is about

I probed a local Storage server rather than guessing. It **accepts** these in an object key and stores them verbatim:

`?` &nbsp; `space` &nbsp; `&` &nbsp; `=` &nbsp; `+` &nbsp; `,` &nbsp; `(` &nbsp; `)` &nbsp; `@` &nbsp; `:` &nbsp; `;` &nbsp; `$` &nbsp; `*` &nbsp; `!` &nbsp; and the apostrophe

It **rejects** `#`, `%`, `[`, `]`, `~`, backtick, `^`, `|` and all non-ASCII with `400 InvalidKey`. So `#` was never the interesting case — `?`, a space, `&`, `=` and `+` are.

## What changed

Encoding moved into `_getFinalPath`, so every call site is covered and a new one cannot silently reintroduce the bug. All 8 uses of `_getFinalPath` feed a URL; none goes into a request body.

Two follow-on removals, both required to avoid double-encoding:

- `purgeCache` no longer wraps with `encodeStoragePath` (now redundant).
- `getPublicUrl` no longer wraps with `encodeURI`. That wrapper was insufficient anyway — `encodeURI` leaves `?`, `&`, `=` and `+` untouched — and it would double-encode the new output.

The `encodeURI` in `createSignedUrl` **stays**. It wraps `data.signedURL` from the server response, and the server returns that path with `%20` already decoded to a literal space, so it is still required there.

## Testing

`packages/core/storage-js/test/encode-object-key.test.ts` — 4 unit tests (captured `fetch`, URL shape) plus 3 integration tests against the Docker-backed Storage server that upload `folder/a?b&c=d e+f.txt` and read the same object back.

On `master`, 6 of the 7 fail. The integration failure is the telling one: the upload lands as an object literally named `a`, and `list("folder")` returns `["a"]`.

Full `nx test:storage storage-js`:

| | Suites | Tests | Snapshots |
|---|---|---|---|
| `master` | 18 passed / 18 | 411 passed, 2 skipped | 6 passed |
| this branch | 19 passed / 19 | 418 passed, 2 skipped | 6 passed |

Both fully green; the delta is exactly this suite and its 7 tests.

`nx lint storage-js` reports 15 errors both here and on `master` — all pre-existing. `nx format:check` and `nx build storage-js` pass.

## A server-side bug this does *not* fix

With this patch, `upload`, `exists`, `info`, `download` and `getPublicUrl` work for every accepted character. `createSignedUrl` does not: it returns 400 for `?` `&` `=` `+` `,` `;` `@` `:` `$`, and works only for keys whose sole escape is `%20` — plus the characters that need no escaping at all.

The cause is server-side: the token is signed over the percent-encoded key, but the request is validated against the decoded path, so the signature never matches. **The URL the server itself returns fails identically**, so no client-side encoding can work around it. Two tests pin this behaviour explicitly, including the 400, so the limitation is documented rather than silently shipped. Happy to open a separate `storage-api` issue if that would help.

## Also worth knowing

Since `%` is an invalid key character, callers who percent-encode their keys before passing them in were already broken and remain so — they now fail at the client-encoding step instead of reaching the server. I do not believe that is a regression, but it is a behaviour change worth a maintainer eye.

## Type of Change

- [x] Bug fix (fix)

## Checklist

- [x] Code formatted (`nx format`)
- [x] Unit tests added and passing
- [x] Integration tests added and passing (`nx test:storage storage-js`, fully green)
- [x] Builds passing (`nx build storage-js`)
- [x] Used conventional commits
