### PR TITLE
fix(postgrest): quote array filter values that need array-literal escaping

### DIFF
--- a/packages/core/postgrest-js/src/PostgrestFilterBuilder.ts
+++ b/packages/core/postgrest-js/src/PostgrestFilterBuilder.ts
@@ -35,6 +35,20 @@ export type IsStringOperator<Path extends string> = Path extends `${string}->>${
 
 const PostgrestReservedCharsRegexp = new RegExp('[,()]')
 
+// PostgreSQL array literal syntax: an element must be double-quoted when it is
+// empty, spells `NULL`, or contains a delimiter, brace, quote, backslash or
+// whitespace. Inside the quotes, `\` and `"` are backslash-escaped.
+// https://www.postgresql.org/docs/current/arrays.html#ARRAYS-IO
+const PostgresArrayReservedCharsRegexp = /[,{}"\\\s]/
+
+const toArrayLiteralElement = (value: unknown): string => {
+  if (typeof value !== 'string') return `${value}`
+  if (value === '' || /^null$/i.test(value) || PostgresArrayReservedCharsRegexp.test(value)) {
+    return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`
+  }
+  return value
+}
+
 // Match relationship filters with `table.column` syntax and resolve underlying
 // column value. If not matched, fallback to generic type.
 // TODO: Validate the relationship itself ala select-query-parser. Currently we
@@ -1016,7 +1030,7 @@ export default class PostgrestFilterBuilder<
       this.url.searchParams.append(column, `cs.${value}`)
     } else if (Array.isArray(value)) {
       // array
-      this.url.searchParams.append(column, `cs.{${value.join(',')}}`)
+      this.url.searchParams.append(column, `cs.{${value.map(toArrayLiteralElement).join(',')}}`)
     } else {
       // json
       this.url.searchParams.append(column, `cs.${JSON.stringify(value)}`)
@@ -1165,7 +1179,7 @@ export default class PostgrestFilterBuilder<
       this.url.searchParams.append(column, `cd.${value}`)
     } else if (Array.isArray(value)) {
       // array
-      this.url.searchParams.append(column, `cd.{${value.join(',')}}`)
+      this.url.searchParams.append(column, `cd.{${value.map(toArrayLiteralElement).join(',')}}`)
     } else {
       // json
       this.url.searchParams.append(column, `cd.${JSON.stringify(value)}`)
@@ -1592,7 +1606,7 @@ export default class PostgrestFilterBuilder<
       this.url.searchParams.append(column, `ov.${value}`)
     } else {
       // array
-      this.url.searchParams.append(column, `ov.{${value.join(',')}}`)
+      this.url.searchParams.append(column, `ov.{${value.map(toArrayLiteralElement).join(',')}}`)
     }
     return this
   }

--- a/packages/core/postgrest-js/test/array-value-quoting.test.ts
+++ b/packages/core/postgrest-js/test/array-value-quoting.test.ts
@@ -1,0 +1,62 @@
+import { PostgrestClient } from '../src/index'
+
+// Unit test (custom fetch capture) — the array overloads of contains/containedBy/
+// overlaps build a PostgreSQL array literal, so elements containing delimiters,
+// quotes, backslashes or whitespace have to be quoted and escaped.
+describe('array filter values needing array-literal quoting', () => {
+  const REST_URL = 'http://localhost:3000'
+
+  const sentFilter = async (
+    build: (client: PostgrestClient<any, any, any>) => PromiseLike<unknown>
+  ): Promise<string | null> => {
+    const urls: string[] = []
+    const fetch = (async (url: string) => {
+      urls.push(url)
+      return new Response('[]', {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    }) as unknown as typeof globalThis.fetch
+    await build(new PostgrestClient(REST_URL, { fetch }) as PostgrestClient<any, any, any>)
+    return new URL(urls[0]).searchParams.get('tags')
+  }
+
+  test.each([
+    ['a comma', 'a,b', '"a,b"'],
+    ['a double quote', 'x"y', '"x\\"y"'],
+    ['a backslash', 'e\\f', '"e\\\\f"'],
+    ['a brace', 'p{q', '"p{q"'],
+    ['whitespace', 'a b', '"a b"'],
+    ['nothing', '', '""'],
+    ['the word null', 'null', '"null"'],
+    ['no reserved character', 'plain', 'plain'],
+  ])('contains() quotes an element containing %s', async (_label, input, expected) => {
+    expect(await sentFilter((c) => c.from('t').select().contains('tags', [input]))).toBe(
+      `cs.{${expected}}`
+    )
+  })
+
+  test('containedBy() quotes the same way', async () => {
+    expect(await sentFilter((c) => c.from('t').select().containedBy('tags', ['a,b']))).toBe(
+      'cd.{"a,b"}'
+    )
+  })
+
+  test('overlaps() quotes the same way', async () => {
+    expect(await sentFilter((c) => c.from('t').select().overlaps('tags', ['a,b']))).toBe(
+      'ov.{"a,b"}'
+    )
+  })
+
+  test('non-string elements are left alone', async () => {
+    expect(await sentFilter((c) => c.from('t').select().contains('tags', [1, 2]))).toBe('cs.{1,2}')
+  })
+
+  test('in() keeps its own quoting rules', async () => {
+    // PostgREST's value-list syntax, not an array literal: only `,` `(` `)` need
+    // quoting there, and bare quotes are accepted as-is.
+    expect(await sentFilter((c) => c.from('t').select().in('tags', ['a,b', 'x"y']))).toBe(
+      'in.("a,b",x"y)'
+    )
+  })
+})


### PR DESCRIPTION
## Description

The array overloads of `contains`, `containedBy` and `overlaps` build a PostgreSQL array literal, but joined the elements raw:

```ts
.contains("tags", ["a,b"])   //  tags=cs.{a,b}
```

Postgres reads `{a,b}` as **two** elements, so the query silently matches the wrong rows and returns no error. An element containing a bare `"` is worse — PostgREST rejects the request with `22P02 malformed array literal`.

`in()`/`notIn()` already quote their values, which is why this asymmetry is easy to miss.

## Verification of the wire format

I ran a standalone PostgREST 12.2.3 over Postgres 16 with `t(id int, tags text[])` seeded so each row holds a single awkward element, and probed the wire format directly:

| filter sent | row matched | correct? |
| --- | --- | --- |
| `cs.{a,b}` | `{a,b}` (2 elements) | ✗ |
| `cs.{"a,b"}` | `{"a,b"}` (1 element) | ✓ |
| `cs.{x"y}` | — `22P02 malformed array literal` | ✗ |
| `cs.{"x\"y"}` | `{"x\"y"}` | ✓ |
| `cs.{e\f}` | — empty result | ✗ |
| `cs.{"e\\f"}` | `{"e\\f"}` | ✓ |
| `cs.{"p{q"}` | `{"p{q"}` | ✓ |

Then the same end-to-end through the client: on `master` the assertions fail against that server, with this patch they pass.

## What changed

`toArrayLiteralElement` quotes an element when it is empty, spells `NULL`, or contains a delimiter, brace, quote, backslash or whitespace, escaping `\` and `"` inside the quotes. Non-string elements are stringified unchanged.

**`in()`/`notIn()` are deliberately untouched.** They use PostgREST value-list syntax, not an array literal. I checked that against the same live server: `in.(x"y)` and `in.(e\f)` match correctly unquoted, so the existing `[,()]` rule is right for that path and sharing one helper would break it.

Range (string) arguments to these methods are untouched — only the array overloads change.

## Testing

New unit test `packages/core/postgrest-js/test/array-value-quoting.test.ts` (custom fetch capture), covering comma, double quote, backslash, brace, whitespace, empty string, the literal `null`, non-string elements, and an `in()` case pinning the unchanged behaviour.

Full `nx test:ci:postgrest postgrest-js` (Docker-backed PostgREST + Postgres), before vs. after:

| | Suites | Tests | Snapshots |
|---|---|---|---|
| `master` | 19 passed / 19 | 346 passed | 285 passed |
| this branch | 20 passed / 20 | 358 passed | 285 passed |

Both fully green; the delta is exactly this PR’s suite and its 12 tests.

`nx test:ci:v12 postgrest-js` (the PostgREST v12 compatibility suite) also passes: 4/4.

`nx lint postgrest-js` reports 420 errors both here and on `master` — all pre-existing. `nx format:check` and `nx build postgrest-js` pass.

## Known limitations

Verified against PostgREST 12.2.3 and the version pinned by the repo’s own test setup. Older PostgREST releases were not checked.

## Type of Change

- [x] Bug fix (fix)

## Checklist

- [x] Code formatted (`nx format`)
- [x] Unit tests added and passing
- [x] Integration tests passing (`nx test:ci:postgrest` and `nx test:ci:v12`, fully green)
- [x] Builds passing (`nx build postgrest-js`)
- [x] Used conventional commits