### PR TITLE
fix(functions): merge headers case-insensitively

### DIFF
--- a/packages/core/functions-js/src/FunctionsClient.ts
+++ b/packages/core/functions-js/src/FunctionsClient.ts
@@ -1,4 +1,4 @@
-import { resolveFetch } from './helper'
+import { normalizeHeaders, resolveFetch } from './helper'
 import {
   Fetch,
   FunctionInvokeOptions,
@@ -54,7 +54,7 @@ export class FunctionsClient {
     } = {}
   ) {
     this.url = url
-    this.headers = headers
+    this.headers = normalizeHeaders(headers)
     this.region = region
     this.fetch = resolveFetch(customFetch)
   }
@@ -71,7 +71,7 @@ export class FunctionsClient {
    * ```
    */
   setAuth(token: string) {
-    this.headers.Authorization = `Bearer ${token}`
+    this.headers = normalizeHeaders({ ...this.headers, authorization: `Bearer ${token}` })
   }
 
   /**
@@ -234,11 +234,11 @@ export class FunctionsClient {
         ) {
           // will work for File as File inherits Blob
           // also works for ArrayBuffer as it is the same underlying structure as a Blob
-          _headers['Content-Type'] = 'application/octet-stream'
+          _headers['content-type'] = 'application/octet-stream'
           body = functionArgs
         } else if (typeof functionArgs === 'string') {
           // plain string
-          _headers['Content-Type'] = 'text/plain'
+          _headers['content-type'] = 'text/plain'
           body = functionArgs
         } else if (typeof FormData !== 'undefined' && functionArgs instanceof FormData) {
           // don't set content-type headers
@@ -246,7 +246,7 @@ export class FunctionsClient {
           body = functionArgs
         } else {
           // default, assume this is JSON
-          _headers['Content-Type'] = 'application/json'
+          _headers['content-type'] = 'application/json'
           body = JSON.stringify(functionArgs)
         }
       } else {
@@ -287,7 +287,7 @@ export class FunctionsClient {
         // 1. invoke-level headers
         // 2. client-level headers
         // 3. default Content-Type header
-        headers: { ..._headers, ...this.headers, ...headers },
+        headers: { ..._headers, ...this.headers, ...normalizeHeaders(headers ?? {}) },
         body,
         signal: effectiveSignal,
       }).catch((fetchError) => {

--- a/packages/core/functions-js/src/helper.ts
+++ b/packages/core/functions-js/src/helper.ts
@@ -1,5 +1,25 @@
 import { Fetch } from './types'
 
+/**
+ * Normalizes all header keys to lowercase with case-insensitive deduplication.
+ * When duplicate keys exist (differing only in case), the last value wins.
+ * Does not mutate the input object.
+ *
+ * Header names are case-insensitive (RFC 9110), but a plain object spread only
+ * overrides on an exact key match, so unnormalized sources merge into two
+ * entries that `fetch` then joins into one comma-separated value.
+ *
+ * @param headers - Headers object to normalize
+ * @returns New headers object with all keys lowercased
+ */
+export const normalizeHeaders = (headers: Record<string, string>): Record<string, string> => {
+  const result: Record<string, string> = {}
+  for (const [key, value] of Object.entries(headers)) {
+    result[key.toLowerCase()] = value
+  }
+  return result
+}
+
 export const resolveFetch = (customFetch?: Fetch): Fetch => {
   if (customFetch) {
     return (...args) => customFetch(...args)

--- a/packages/core/functions-js/test/header-case.test.ts
+++ b/packages/core/functions-js/test/header-case.test.ts
@@ -1,0 +1,58 @@
+import { FunctionsClient } from '../src/index'
+
+// Header names are case-insensitive (RFC 9110), but an object spread only
+// overrides on an exact key match. Two entries differing only in case both
+// survive the merge, and `fetch` joins them into one comma-separated value —
+// producing a malformed header rather than the documented override.
+describe('header merging is case-insensitive', () => {
+  const capture = () => {
+    const inits: RequestInit[] = []
+    const customFetch = (async (_url: string, init: RequestInit) => {
+      inits.push(init)
+      return new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } })
+    }) as unknown as typeof globalThis.fetch
+    return { customFetch, sentHeaders: () => inits[0].headers as Record<string, string> }
+  }
+
+  const headerValue = (headers: Record<string, string>, name: string) =>
+    new Headers(headers).get(name)
+
+  test('an invoke-level Content-Type overrides a differently-cased client one', async () => {
+    const { customFetch, sentHeaders } = capture()
+    const client = new FunctionsClient('http://localhost', {
+      headers: { 'content-type': 'application/json' },
+      customFetch,
+    })
+
+    await client.invoke('fn', { headers: { 'Content-Type': 'text/plain' }, body: 'payload' })
+
+    expect(headerValue(sentHeaders(), 'content-type')).toBe('text/plain')
+  })
+
+  test('setAuth replaces a differently-cased authorization header', async () => {
+    const { customFetch, sentHeaders } = capture()
+    const client = new FunctionsClient('http://localhost', {
+      headers: { authorization: 'Bearer stale' },
+      customFetch,
+    })
+
+    client.setAuth('fresh')
+    await client.invoke('fn', { body: 'payload' })
+
+    // Without normalization both entries survive and fetch joins them into
+    // `Bearer stale, Bearer fresh`, which no server accepts.
+    expect(headerValue(sentHeaders(), 'authorization')).toBe('Bearer fresh')
+  })
+
+  test('an invoke-level header overrides a differently-cased client one', async () => {
+    const { customFetch, sentHeaders } = capture()
+    const client = new FunctionsClient('http://localhost', {
+      headers: { 'X-Custom': 'client' },
+      customFetch,
+    })
+
+    await client.invoke('fn', { headers: { 'x-custom': 'invoke' }, body: 'payload' })
+
+    expect(headerValue(sentHeaders(), 'x-custom')).toBe('invoke')
+  })
+})


### PR DESCRIPTION
## Description

Header names are case-insensitive (RFC 9110), but an object spread only overrides on an exact key match. `invoke` merged three unnormalized sources, so an entry differing only in case survived alongside its counterpart — and `fetch` joins two same-name headers into one comma-separated value, so the result is a *malformed* header rather than a wrong-but-valid one.

```ts
new FunctionsClient(url, { headers: { 'content-type': 'application/json' } })
  .invoke('fn', { headers: { 'Content-Type': 'text/plain' }, body: 'x' })
// sent: content-type: application/json, text/plain
```

That silently contradicts both the precedence comment above the merge (invoke > client > default) and the `invoke` docstring, which tells callers they can override the SDK-chosen `Content-Type`.

`setAuth` had the same root cause and a worse consequence. It assigned `headers.Authorization`, so a client constructed with a lowercase `authorization` kept sending the stale token alongside the new one:

```ts
const client = new FunctionsClient(url, { headers: { authorization: 'Bearer stale' } })
client.setAuth('fresh')
// sent: authorization: Bearer stale, Bearer fresh
```

No server accepts that, so `setAuth` breaks the client for anyone who spelled the header in lowercase.

## What changed

Header keys are normalized to lowercase at the two boundaries where headers enter the client — the constructor and each `invoke` — so the existing spread expresses the documented precedence again. The internally chosen `Content-Type` defaults are written lowercase for the same reason.

`normalizeHeaders` mirrors the helper of the same name in `storage-js` (`src/lib/common/headers.ts`), including its semantics: last value wins, input not mutated. It is duplicated rather than shared because `functions-js` has no dependency on `storage-js` and `packages/shared` currently holds only `tracing` — happy to extract it into `packages/shared` instead if you would prefer that.

The existing case-insensitive `hasContentTypeHeader` check is untouched; it was already correct.

## Testing

New `packages/core/functions-js/test/header-case.test.ts` — 3 unit tests using a captured `fetch`, asserting through `new Headers(...)` so the assertion sees what the platform actually sends.

On `master` all three fail, with exactly the joined values:

| case | `master` | this branch |
| --- | --- | --- |
| invoke `Content-Type` over client `content-type` | `application/json, text/plain` | `text/plain` |
| `setAuth` over client `authorization` | `Bearer stale, Bearer fresh` | `Bearer fresh` |
| invoke `x-custom` over client `X-Custom` | `client, invoke` | `invoke` |

Full `nx test functions-js` (testcontainers-backed Deno relay):

| | Suites | Tests |
|---|---|---|
| `master` | 7 passed / 7 | 42 passed, 1 skipped |
| this branch | 8 passed / 8 | 45 passed, 1 skipped |

Both fully green; the delta is exactly this suite and its 3 tests.

`nx lint functions-js` reports 17 errors both here and on `master` — all pre-existing. `nx format:check` and `nx build functions-js` pass.

`nx test supabase-js` fails identically on this branch and on `master` with `The type definition dist/index.d.cts does not exist`, which is a local build-order issue unrelated to this change.

## Related, not fixed here

The same class of bug exists in `auth-js`. `lib/fetch.ts` merges headers with plain spreads and sets `headers['Authorization']` by exact case, so a client created with `global.headers: { authorization: '…' }` (lowercase, a documented option) sends every auth request with `authorization: Bearer <jwt>, Bearer <custom>`. Reachable straight from `createClient`.

I have left that out of this PR because `auth-js` is security-critical and has a wider header surface, so it deserves its own review. Happy to open it separately — or to fold it in here if you would rather have one change.

## Type of Change

- [x] Bug fix (fix)

## Checklist

- [x] Code formatted (`nx format`)
- [x] Unit tests added and passing
- [x] Package suite passing (`nx test functions-js`, fully green)
- [x] Builds passing (`nx build functions-js`)
- [x] Used conventional commits
