### PR TITLE
fix(postgrest): honour throwOnError when maybeSingle finds multiple rows

### DIFF
--- a/packages/core/postgrest-js/src/PostgrestBuilder.ts
+++ b/packages/core/postgrest-js/src/PostgrestBuilder.ts
@@ -529,6 +529,12 @@ export default abstract class PostgrestBuilder<
           count = null
           status = 406
           statusText = 'Not Acceptable'
+
+          if (this.shouldThrowOnError) {
+            // `hint` is null in the returned error to match PostgREST, but
+            // PostgrestError types it as a string, like the other throws here.
+            throw new PostgrestError({ ...error, hint: error.hint ?? '' })
+          }
         } else if (data.length === 1) {
           data = data[0]
         } else {

--- a/packages/core/postgrest-js/test/maybe-single.test.ts
+++ b/packages/core/postgrest-js/test/maybe-single.test.ts
@@ -1,0 +1,61 @@
+import { PostgrestClient } from '../src/index'
+import PostgrestError from '../src/PostgrestError'
+import { Database } from './types.override'
+
+const REST_URL = 'https://example.com'
+
+const okJson = (payload: unknown) => ({
+  ok: true,
+  status: 200,
+  statusText: 'OK',
+  text: () => Promise.resolve(JSON.stringify(payload)),
+  headers: new Headers(),
+})
+
+describe('maybeSingle cardinality handling', () => {
+  test('unwraps a single row', async () => {
+    const fetchMock = jest.fn().mockResolvedValue(okJson([{ username: 'supabot' }]))
+    const postgrest = new PostgrestClient<Database>(REST_URL, { fetch: fetchMock as any })
+
+    const res = await postgrest.from('users').select('username').maybeSingle()
+
+    expect(res.error).toBeNull()
+    expect(res.data).toEqual({ username: 'supabot' })
+    expect(res.status).toBe(200)
+  })
+
+  test('returns null data when no rows match', async () => {
+    const fetchMock = jest.fn().mockResolvedValue(okJson([]))
+    const postgrest = new PostgrestClient<Database>(REST_URL, { fetch: fetchMock as any })
+
+    const res = await postgrest.from('users').select('username').maybeSingle()
+
+    expect(res.error).toBeNull()
+    expect(res.data).toBeNull()
+  })
+
+  test('returns a PGRST116 error when multiple rows are returned', async () => {
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValue(okJson([{ username: 'supabot' }, { username: 'kiwicopple' }]))
+    const postgrest = new PostgrestClient<Database>(REST_URL, { fetch: fetchMock as any })
+
+    const res = await postgrest.from('users').select('username').maybeSingle()
+
+    expect(res.data).toBeNull()
+    expect(res.status).toBe(406)
+    expect(res.statusText).toBe('Not Acceptable')
+    expect(res.error?.code).toBe('PGRST116')
+  })
+
+  test('honours throwOnError() when multiple rows are returned', async () => {
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValue(okJson([{ username: 'supabot' }, { username: 'kiwicopple' }]))
+    const postgrest = new PostgrestClient<Database>(REST_URL, { fetch: fetchMock as any })
+
+    await expect(
+      postgrest.from('users').select('username').maybeSingle().throwOnError()
+    ).rejects.toThrow(PostgrestError)
+  })
+})


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Fixes #2579

Since the fix for postgrest-js#361, `.maybeSingle()` no longer sends `Accept: application/vnd.pgrst.object+json` — it fetches a list and enforces cardinality client-side, synthesising `PGRST116` when more than one row comes back:

```ts
if (this.isMaybeSingle && Array.isArray(data)) {
  if (data.length > 1) {
    error = { code: 'PGRST116', /* … */ }
    data = null
    count = null
    status = 406
    statusText = 'Not Acceptable'
  } else if (…)
```

That branch never consults `this.shouldThrowOnError`. Every other error path in `processResponse` does — the non-2xx path ends with `if (error && this.shouldThrowOnError) throw new PostgrestError(error)` — and `then()` has no post-hoc throw, so throwing only ever happens at those sites.

The result is that `.maybeSingle().throwOnError()` **resolves with an error object instead of rejecting**, which contradicts what `throwOnError()` documents ("reject the promise by throwing the error instead of returning it as part of a successful response").

That fails in the unhelpful direction. Code written as

```ts
const { data } = await supabase.from('users').select().maybeSingle().throwOnError()
```

destructures only `data` precisely because it trusts `throwOnError()` to raise. With duplicate rows it quietly gets `data === null` and no exception, so the condition is swallowed rather than surfaced.

## What is the new behavior?

The synthesised `PGRST116` now rejects with a `PostgrestError` when `throwOnError()` is active, matching what happens when PostgREST itself returns that error.

Behaviour without `throwOnError()` is unchanged: still `status: 406`, `statusText: 'Not Acceptable'`, `error.code: 'PGRST116'`, `data: null`. The returned error object is untouched — including `hint: null`, which existing snapshots in `basic.test.ts` and `transforms.test.ts` assert. `PostgrestError` types `hint` as `string`, so the throw passes `hint: error.hint ?? ''`, consistent with the other synthesised throw in this file which uses `hint: ''`.

## Additional context

`maybeSingle()` + `throwOnError()` had no test coverage — the existing `PGRST116` assertions check the returned error object rather than the throwing path, and they need the Dockerised PostgREST. The new `test/maybe-single.test.ts` uses a mocked fetch, so it runs offline and pins all four cardinality outcomes: one row, zero rows, multiple rows, and multiple rows with `throwOnError()`.

Verification, from `packages/core/postgrest-js`:

```console
$ npx jest --runInBand test/maybe-single.test.ts
Tests:  4 passed, 4 total
```

Before the source change, the new suite is `1 failed, 3 passed`, with:

```
● maybeSingle cardinality handling › honours throwOnError() when multiple rows are returned
  expect(received).rejects.toThrow()
  Received promise resolved instead of rejected
```

Across the suites that run without Docker (`fetch-errors`, `headers-serialization`, `retry`, `max-affected`, `permission-hints`, `maybe-single`): **45 passed / 6 failed** with this change, versus **44 passed / 7 failed** on an unmodified checkout — the one flipped test is the new one, and nothing else moved. The 6 remaining failures are all in `max-affected.test.ts` and fail with `ECONNREFUSED`; they need the local PostgREST from `docker compose`, which isn't available in my environment, so those are untouched-but-unverified by me.

Also checked:

* `tsc --noEmit --project tsconfig.json` — clean.
* `tsc --noEmit --project tsconfig.test.json` — clean.
* `prettier --check` — clean on both files.
