### PR TITLE
fix(auth,supabase): merge headers case-insensitively

### DIFF
--- a/packages/core/auth-js/src/lib/fetch.ts
+++ b/packages/core/auth-js/src/lib/fetch.ts
@@ -1,5 +1,11 @@
 import { API_VERSIONS, API_VERSION_HEADER_NAME } from './constants'
-import { expiresAt, looksLikeFetchResponse, parseResponseAPIVersion } from './helpers'
+import {
+  expiresAt,
+  hasHeader,
+  looksLikeFetchResponse,
+  parseResponseAPIVersion,
+  setHeader,
+} from './helpers'
 import {
   AuthResponse,
   AuthResponsePassword,
@@ -153,7 +159,9 @@ const _getRequestParams = (
     return params
   }
 
-  params.headers = { 'Content-Type': 'application/json;charset=UTF-8', ...options?.headers }
+  params.headers = hasHeader(options?.headers ?? {}, 'Content-Type')
+    ? { ...options?.headers }
+    : setHeader({ ...options?.headers }, 'Content-Type', 'application/json;charset=UTF-8')
   params.body = JSON.stringify(body)
   return { ...params, ...parameters }
 }
@@ -175,16 +183,14 @@ export async function _request(
   url: string,
   options?: GotrueRequestOptions
 ) {
-  const headers = {
-    ...options?.headers,
-  }
+  let headers: Record<string, string> = { ...options?.headers }
 
-  if (!headers[API_VERSION_HEADER_NAME]) {
-    headers[API_VERSION_HEADER_NAME] = API_VERSIONS['2024-01-01'].name
+  if (!hasHeader(headers, API_VERSION_HEADER_NAME)) {
+    headers = setHeader(headers, API_VERSION_HEADER_NAME, API_VERSIONS['2024-01-01'].name)
   }
 
   if (options?.jwt) {
-    headers['Authorization'] = `Bearer ${options.jwt}`
+    headers = setHeader(headers, 'Authorization', `Bearer ${options.jwt}`)
   }
 
   const qs = options?.query ?? {}

--- a/packages/core/auth-js/src/lib/helpers.ts
+++ b/packages/core/auth-js/src/lib/helpers.ts
@@ -9,6 +9,53 @@ import { base64UrlToUint8Array, stringFromBase64URL } from './base64url'
 import { JwtHeader, JwtPayload, SupportedStorage, User } from './types'
 import { Uint8Array_ } from './webauthn.dom'
 
+/**
+ * Returns true when `headers` already carries `name`, compared case-insensitively.
+ *
+ * @param headers - Headers object to inspect
+ * @param name - Header name to look for
+ */
+export function hasHeader(headers: Record<string, string>, name: string): boolean {
+  const nameLower = name.toLowerCase()
+  return Object.keys(headers).some((key) => key.toLowerCase() === nameLower)
+}
+
+/**
+ * Sets a header, first dropping any entry whose name matches case-insensitively,
+ * and keeps `name` spelled as given. Does not mutate the input object.
+ *
+ * Header names are case-insensitive (RFC 9110), but a plain assignment only
+ * replaces on an exact key match, so a differently-cased entry would survive
+ * alongside the new one and `fetch` would join the two into a single
+ * comma-separated value.
+ *
+ * Unlike the equivalent helper in storage-js this preserves the caller-supplied
+ * spelling rather than lowercasing it, so the header names this SDK puts on the
+ * wire stay unchanged.
+ *
+ * @param headers - Existing headers object
+ * @param name - Header name to set
+ * @param value - Header value
+ * @returns New headers object with the header set
+ */
+export function setHeader(
+  headers: Record<string, string>,
+  name: string,
+  value: string
+): Record<string, string> {
+  const nameLower = name.toLowerCase()
+  const result: Record<string, string> = {}
+
+  for (const [key, existing] of Object.entries(headers)) {
+    if (key.toLowerCase() !== nameLower) {
+      result[key] = existing
+    }
+  }
+
+  result[name] = value
+  return result
+}
+
 export function expiresAt(expiresIn: number) {
   const timeNow = Math.round(Date.now() / 1000)
   return timeNow + expiresIn

--- a/packages/core/auth-js/test/fetch.test.ts
+++ b/packages/core/auth-js/test/fetch.test.ts
@@ -303,3 +303,49 @@ describe('_sessionResponse', () => {
     expect(result.data.user).toEqual(user)
   })
 })
+
+describe('header merging', () => {
+  // Header names are case-insensitive (RFC 9110), but an object spread only
+  // overrides on an exact key match, so two entries differing only in case both
+  // survive and `fetch` joins them into one comma-separated value.
+  const capture = () => {
+    const sent: Record<string, string>[] = []
+    const fetcher = (async (_url: string, init: RequestInit) => {
+      sent.push(init.headers as Record<string, string>)
+      return new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } })
+    }) as unknown as typeof fetch
+    return { fetcher, headerValue: (name: string) => new Headers(sent[0]).get(name) }
+  }
+
+  test('a caller-supplied lowercase authorization is not duplicated by the jwt', async () => {
+    const { fetcher, headerValue } = capture()
+
+    await _request(fetcher, 'GET', 'http://localhost/user', {
+      headers: { authorization: 'Bearer caller' },
+      jwt: 'from-jwt-option',
+    })
+
+    expect(headerValue('authorization')).toBe('Bearer from-jwt-option')
+  })
+
+  test('a caller-supplied api version header is not duplicated by the default', async () => {
+    const { fetcher, headerValue } = capture()
+
+    await _request(fetcher, 'GET', 'http://localhost/user', {
+      headers: { [API_VERSION_HEADER_NAME.toLowerCase()]: '2024-01-01' },
+    })
+
+    expect(headerValue(API_VERSION_HEADER_NAME)).toBe('2024-01-01')
+  })
+
+  test('a caller-supplied content-type is not duplicated by the json default', async () => {
+    const { fetcher, headerValue } = capture()
+
+    await _request(fetcher, 'POST', 'http://localhost/user', {
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: { a: 1 },
+    })
+
+    expect(headerValue('content-type')).toBe('application/x-www-form-urlencoded')
+  })
+})

--- a/packages/core/supabase-js/src/SupabaseClient.ts
+++ b/packages/core/supabase-js/src/SupabaseClient.ts
@@ -23,6 +23,7 @@ import {
 import { checkApiKeyFormat, fetchWithAuth } from './lib/fetch'
 import {
   applySettingDefaults,
+  mergeHeaders,
   validateSupabaseUrl,
   type ResolvedSupabaseClientOptions,
 } from './lib/helpers'
@@ -625,9 +626,10 @@ export default class SupabaseClient<
       Authorization: `Bearer ${this.supabaseKey}`,
       apikey: `${this.supabaseKey}`,
     }
+
     return new SupabaseAuthClient({
       url: this.authUrl.href,
-      headers: { ...authHeaders, ...headers },
+      headers: mergeHeaders(authHeaders, headers),
       storageKey: storageKey,
       autoRefreshToken,
       persistSession,

--- a/packages/core/supabase-js/src/lib/helpers.ts
+++ b/packages/core/supabase-js/src/lib/helpers.ts
@@ -28,6 +28,40 @@ export type ResolvedSupabaseClientOptions<SchemaName> = Omit<
   tracePropagation: TracePropagationOptions
 }
 
+/**
+ * Merges header objects so that later sources override earlier ones even when
+ * the two spellings differ in case, keeping the spelling of the winning source.
+ *
+ * Header names are case-insensitive (RFC 9110), but an object spread only
+ * overrides on an exact key match, so unmerged sources produce two entries that
+ * `fetch` joins into a single comma-separated value.
+ *
+ * @param sources - Header objects, lowest precedence first
+ * @returns New headers object
+ */
+export function mergeHeaders(
+  ...sources: (Record<string, string> | undefined)[]
+): Record<string, string> {
+  const result: Record<string, string> = {}
+  const keyByLowercase = new Map<string, string>()
+
+  for (const source of sources) {
+    for (const [name, value] of Object.entries(source ?? {})) {
+      const lowercase = name.toLowerCase()
+      const previous = keyByLowercase.get(lowercase)
+
+      if (previous !== undefined) {
+        delete result[previous]
+      }
+
+      result[name] = value
+      keyByLowercase.set(lowercase, name)
+    }
+  }
+
+  return result
+}
+
 export function applySettingDefaults<
   Database = any,
   SchemaName extends string & keyof Database = 'public' extends keyof Database
@@ -71,10 +105,7 @@ export function applySettingDefaults<
     global: {
       ...DEFAULT_GLOBAL_OPTIONS,
       ...globalOptions,
-      headers: {
-        ...(DEFAULT_GLOBAL_OPTIONS?.headers ?? {}),
-        ...(globalOptions?.headers ?? {}),
-      },
+      headers: mergeHeaders(DEFAULT_GLOBAL_OPTIONS?.headers, globalOptions?.headers),
     },
     tracePropagation: {
       enabled:

--- a/packages/core/supabase-js/test/header-case.test.ts
+++ b/packages/core/supabase-js/test/header-case.test.ts
@@ -1,0 +1,61 @@
+import { createClient } from '../src/index'
+import { mergeHeaders } from '../src/lib/helpers'
+
+// Header names are case-insensitive (RFC 9110), but an object spread only
+// overrides on an exact key match, so two entries differing only in case both
+// survive and `fetch` joins them into one comma-separated value.
+describe('mergeHeaders', () => {
+  test('a later source overrides an earlier one spelled differently', () => {
+    expect(
+      mergeHeaders({ Authorization: 'Bearer sdk' }, { authorization: 'Bearer caller' })
+    ).toEqual({ authorization: 'Bearer caller' })
+  })
+
+  test('an unopposed name keeps its original spelling', () => {
+    expect(mergeHeaders({ Authorization: 'Bearer sdk' }, { apikey: 'key' })).toEqual({
+      Authorization: 'Bearer sdk',
+      apikey: 'key',
+    })
+  })
+
+  test('undefined sources are skipped', () => {
+    expect(mergeHeaders(undefined, { apikey: 'key' }, undefined)).toEqual({ apikey: 'key' })
+  })
+})
+
+describe('client headers reaching auth requests', () => {
+  const capture = () => {
+    const sent: Record<string, string>[] = []
+    const fetch = (async (_url: string, init: RequestInit) => {
+      sent.push(init.headers as Record<string, string>)
+      return new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } })
+    }) as unknown as typeof globalThis.fetch
+    return { fetch, headerValue: (name: string) => new Headers(sent[0]).get(name) }
+  }
+
+  const clientWith = (headers: Record<string, string>, fetch: typeof globalThis.fetch) =>
+    createClient('http://localhost:1', 'ANONKEY', {
+      global: { headers, fetch },
+      auth: { persistSession: false, autoRefreshToken: false, detectSessionInUrl: false },
+    })
+
+  test('a lowercase authorization in global.headers replaces the anon key header', async () => {
+    const { fetch, headerValue } = capture()
+
+    await clientWith({ authorization: 'Bearer caller' }, fetch).auth.resetPasswordForEmail(
+      'user@example.com'
+    )
+
+    expect(headerValue('authorization')).toBe('Bearer caller')
+  })
+
+  test('a differently-cased x-client-info in global.headers replaces the default', async () => {
+    const { fetch, headerValue } = capture()
+
+    await clientWith({ 'x-client-info': 'my-app/1.0' }, fetch).auth.resetPasswordForEmail(
+      'user@example.com'
+    )
+
+    expect(headerValue('x-client-info')).toBe('my-app/1.0')
+  })
+})


### PR DESCRIPTION
## Description

Header names are case-insensitive (RFC 9110), but an object spread only overrides on an exact key match. Two entries differing only in case both survive the merge, and `fetch` joins same-name headers into one comma-separated value — so the result is a *malformed* header rather than the intended override.

This is reachable straight from `createClient` using the documented `global.headers` option:

```ts
const supabase = createClient(url, anonKey, {
  global: { headers: { authorization: 'Bearer caller' } },
})
await supabase.auth.resetPasswordForEmail('user@example.com')
// sent: authorization: Bearer <anon key>, Bearer caller
```

Every auth request goes out with an Authorization header no server accepts. A caller who spells the header lowercase has no way to override it.

The same happens to `x-client-info`, where the SDK version string is prepended to the caller's value.

## Three merge sites

| where | what went wrong |
| --- | --- |
| `applySettingDefaults` (supabase-js) | merged `DEFAULT_HEADERS` with `global.headers`, so a lowercase `x-client-info` was appended rather than replacing the SDK value |
| `SupabaseClient._initSupabaseAuthClient` | merged the anon-key `Authorization` with the caller's headers |
| `auth-js` `_request` / `_getRequestParams` | set `Authorization` and the API version header by exact case, and spread a `Content-Type` default the same way |

Worth noting the second one: `hasCustomAuthorizationHeader`, two lines below that merge, already compares case-insensitively. The flag and the merge disagreed, so the header broke for exactly the callers the flag exists to support.

## What changed

`mergeHeaders` (supabase-js `lib/helpers.ts`) and `setHeader` / `hasHeader` (auth-js `lib/helpers.ts`) drop any existing case variant before writing.

Both **keep the spelling of the winning source** rather than lowercasing everything. That matters: the passkey tests assert a capitalized `Authorization` on the wire, and they pass here untouched. My first attempt normalized to lowercase and broke 5 of them — the header names these packages emit are observable, so this version leaves them alone.

The helpers are per-package rather than shared: `packages/shared` currently holds only `tracing`, and the two need different semantics from the existing `storage-js` helper, which lowercases. Happy to consolidate if you would rather have one.

## Testing

- `packages/core/auth-js/test/fetch.test.ts` — 3 tests added to the existing file, driving `_request` with a captured fetch.
- `packages/core/supabase-js/test/header-case.test.ts` — 3 unit tests for `mergeHeaders` plus 2 that go through `createClient` and assert what reaches the wire.

Assertions read through `new Headers(...)` so they see the value the platform actually sends.

On `master` the behavioural tests fail with the joined values:

| case | `master` | this branch |
| --- | --- | --- |
| lowercase `authorization` in `global.headers` | `Bearer ANONKEY, Bearer caller` | `Bearer caller` |
| lowercase `x-client-info` in `global.headers` | `supabase-js/…, my-app/1.0` | `my-app/1.0` |
| caller `authorization` + per-request jwt | `Bearer caller, Bearer <jwt>` | `Bearer <jwt>` |
| caller `content-type` + json default | `application/json;charset=UTF-8, …` | the caller value |

Suites, before vs. after:

| suite | `master` | this branch |
| --- | --- | --- |
| `nx test:suite auth-js` (Docker-backed GoTrue + Postgres) | 20 passed / 20, 553 tests | 20 passed / 20, 556 tests |
| `supabase-js` jest, excluding `integration.test.ts` | 9 passed suites, 131 tests | 10 passed suites, 136 tests |

Both deltas are exactly the tests added here; nothing changed status.

`nx lint` reports 106 errors for `auth-js` and 0 for `supabase-js` both here and on `master` — all pre-existing. `nx format:check`, `nx build auth-js` and `nx build supabase-js` pass.

## Known limitations

`supabase-js`'s `integration.test.ts` fails identically on this branch and on `master` in my environment (24 tests) — it needs a Supabase stack that the auth-js test stack does not provide, so I compared with it excluded rather than claiming a green run.

This is one PR across two packages because it is a single bug on a single request path, and the repo notes cross-library fixes belong in one PR. Happy to split it if you prefer.

## Type of Change

- [x] Bug fix (fix)

## Checklist

- [x] Code formatted (`nx format`)
- [x] Unit tests added and passing
- [x] Integration suite passing (`nx test:suite auth-js`, fully green)
- [x] Builds passing (`nx build auth-js`, `nx build supabase-js`)
- [x] Used conventional commits
