### PR TITLE
docs(repo): fix broken RELEASE.md and example migration links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -336,7 +336,7 @@ This allows you to test package changes without waiting for an official release,
 
 ### Official Releases
 
-Official releases are handled by maintainers using Nx Release. You can read more in the [RELEASE.md](./RELEASE.md)
+Official releases are handled by maintainers using Nx Release. You can read more in the [RELEASE.md](./docs/RELEASE.md)
 
 ## Getting Help
 

--- a/packages/core/realtime-js/example/README.md
+++ b/packages/core/realtime-js/example/README.md
@@ -22,7 +22,7 @@ Create a new project at [database.new](https://database.new)
 
 ### 2. Run the Database Migration
 
-Go to the [SQL Editor](https://supabase.com/dashboard/project/_/sql) in your Supabase dashboard and run the migration you find in [supabase/migrations/001_create_messages_table.sql](packages/core/realtime-js/example/supabase/migrations/001_create_messages_table.sql).
+Go to the [SQL Editor](https://supabase.com/dashboard/project/_/sql) in your Supabase dashboard and run the migration you find in [supabase/migrations/001_create_messages_table.sql](./supabase/migrations/001_create_messages_table.sql).
 
 ### 3. Configure Environment Variables
 


### PR DESCRIPTION
While reading the docs I noticed two relative markdown links that point at paths which do not exist. CONTRIBUTING.md linked to ./RELEASE.md, but the file lives at docs/RELEASE.md, and the realtime-js example README linked to the SQL migration using a repository-root path instead of one relative to that README. I corrected both targets so they resolve on GitHub and in local editors.

I left the ./docs/SECURITY.md link in README.md alone: that file is not present anywhere in the repository, and I did not want to guess whether it should point at an org-level policy or a file still to be added. Worth noting AGENTS.md has the same broken link, so a maintainer may want to decide on both together.

I pushed this to my fork first and the project's own CI workflows pass on the commit.
