### PR TITLE
fix(realtime): parse Postgres array literals instead of guessing

### DIFF
--- a/packages/core/realtime-js/src/lib/transformers.ts
+++ b/packages/core/realtime-js/src/lib/transformers.ts
@@ -217,21 +217,71 @@ export const toArray = (value: RecordValue, type: string): RecordValue => {
 
   // Confirm value is a Postgres array by checking curly brackets
   if (openBrace === '{' && closeBrace === '}') {
-    let arr
-    const valTrim = value.slice(1, lastIdx)
-
-    // TODO: find a better solution to separate Postgres array data
-    try {
-      arr = JSON.parse('[' + valTrim + ']')
-    } catch (_) {
-      // WARNING: splitting on comma does not cover all edge cases
-      arr = valTrim ? valTrim.split(',') : []
-    }
-
-    return arr.map((val: BaseValue) => convertCell(type, val))
+    const elements = parseArrayElements(value.slice(1, lastIdx))
+    // `type` has already had its array marker stripped by the caller, so each
+    // element converts to a scalar.
+    return elements.map((element) =>
+      element === null ? null : (convertCell(type, element) as BaseValue)
+    )
   }
 
   return value
+}
+
+/**
+ * Splits the inside of a Postgres array literal into its elements.
+ *
+ * An element is double-quoted whenever it is empty, spells `NULL`, or contains a
+ * delimiter, brace, quote, backslash or whitespace; inside the quotes `\\` and
+ * `\"` are escapes. Unquoted `NULL` is the null element, whereas the quoted
+ * `"NULL"` is the four-character string.
+ *
+ * https://www.postgresql.org/docs/current/arrays.html#ARRAYS-IO
+ *
+ * @param inner - The literal with its outermost braces already removed
+ */
+const parseArrayElements = (inner: string): (string | null)[] => {
+  if (inner === '') {
+    return []
+  }
+
+  const elements: (string | null)[] = []
+  let index = 0
+
+  while (index <= inner.length) {
+    if (inner[index] === '"') {
+      let element = ''
+      index++
+
+      while (index < inner.length && inner[index] !== '"') {
+        if (inner[index] === '\\') {
+          index++
+        }
+        element += inner[index]
+        index++
+      }
+
+      index++
+      elements.push(element)
+    } else {
+      const start = index
+
+      while (index < inner.length && inner[index] !== ',') {
+        index++
+      }
+
+      const element = inner.slice(start, index)
+      elements.push(element.toUpperCase() === 'NULL' ? null : element)
+    }
+
+    if (inner[index] !== ',') {
+      break
+    }
+
+    index++
+  }
+
+  return elements
 }
 
 /**

--- a/packages/core/realtime-js/test/array-literal.test.ts
+++ b/packages/core/realtime-js/test/array-literal.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from 'vitest'
+import { toArray } from '../src/lib/transformers'
+
+// Postgres quotes an array element whenever it is empty, spells `NULL`, or
+// contains a delimiter, brace, quote, backslash or whitespace — so a single
+// literal routinely mixes quoted and unquoted elements.
+describe('toArray with quoted and unquoted elements mixed', () => {
+  test.each([
+    ['{"a,b",c}', ['a,b', 'c']],
+    ['{"hello world",plain}', ['hello world', 'plain']],
+    ['{plain,"hello world"}', ['plain', 'hello world']],
+    ['{"x\\"y",z}', ['x"y', 'z']],
+    ['{"e\\\\f",z}', ['e\\f', 'z']],
+    ['{"p{q",z}', ['p{q', 'z']],
+    ['{"",z}', ['', 'z']],
+  ])('parses %s', (literal, expected) => {
+    expect(toArray(literal, 'text')).toEqual(expected)
+  })
+
+  test('an unquoted NULL is the null element', () => {
+    expect(toArray('{a,NULL,b}', 'text')).toEqual(['a', null, 'b'])
+  })
+
+  test('a quoted NULL is the four-character string', () => {
+    expect(toArray('{"NULL"}', 'text')).toEqual(['NULL'])
+  })
+})


### PR DESCRIPTION
## Description

`toArray` turned a Postgres array literal into a JS array by trying `JSON.parse` on it and, when that threw, splitting on commas. Neither is the array literal grammar, and the file already said so — a `TODO` above the first attempt and a `WARNING` above the fallback.

Postgres quotes an element whenever it is empty, spells `NULL`, or contains a delimiter, brace, quote, backslash or whitespace. A single literal therefore routinely mixes quoted and unquoted elements — and that is exactly where both strategies fail: `JSON.parse` rejects the unquoted ones, then the comma split tears the quoted ones apart mid-element.

| column value | literal Postgres sends | `toArray` on `master` |
| --- | --- | --- |
| `['a,b', 'c']` | `{"a,b",c}` | `['"a', 'b"', 'c']` |
| `['hello world', 'plain']` | `{"hello world",plain}` | `['"hello world"', 'plain']` |
| `['x"y', 'z']` | `{"x\"y",z}` | `['"x\"y"', 'z']` |
| `['a', null, 'b']` | `{a,NULL,b}` | `['a', 'NULL', 'b']` |

I generated the middle column from a real Postgres 16 rather than reasoning about it, so these are the strings the server actually puts on the wire.

This is on the live `postgres_changes` path — `RealtimeChannel` → `convertChangeData` → `convertCell` → `toArray` — so any subscription to a table with a `text[]` column whose values contain a space or a comma receives corrupted data, silently. `NULL` elements arrive as the string `'NULL'`.

The existing tests pass because every case they cover happens to be one where one of the two strategies works: `{a,b,c}` and `{1,2,3,4}` are entirely unquoted, and the daterange case is entirely quoted.

## What changed

`parseArrayElements` scans the literal per the [documented grammar](https://www.postgresql.org/docs/current/arrays.html#ARRAYS-IO): quoted elements honour `\\` and `\"`, an unquoted `NULL` becomes the null element, and a quoted `"NULL"` stays the four-character string. `null` elements skip `convertCell` rather than being fed to `toNumber`/`toBoolean`.

**Multidimensional arrays remain unsupported.** `{{1,2},{3,4}}` was already mangled before this change (`JSON.parse` fails, the split produces `['{1', '2}', '{3', '4}']`) and still is. Handling them properly needs a decision about what the element type means one level down, which felt out of scope for a fix; happy to follow up if you want it.

## Testing

New `packages/core/realtime-js/test/array-literal.test.ts` — 9 tests covering comma, whitespace, embedded quote, embedded backslash, brace, empty string, both orderings of quoted/unquoted, unquoted `NULL` and quoted `"NULL"`.

8 of the 9 fail on `master`. The one that passes there is `{"NULL"}`, which `JSON.parse` happens to get right.

Full `realtime-js` suite:

| | Test files | Tests |
| --- | --- | --- |
| `master` | 26 passed | 447 passed, 1 skipped |
| this branch | 27 passed | 456 passed, 1 skipped |

Both fully green; the delta is exactly this file and its 9 tests. No existing test changed status.

`nx lint realtime-js` reports 536 errors both here and on `master` — all pre-existing. `nx format:check` and `nx build realtime-js` pass.

## Type of Change

- [x] Bug fix (fix)

## Checklist

- [x] Code formatted (`nx format`)
- [x] Unit tests added and passing
- [x] Package suite passing (`vitest run`, fully green)
- [x] Builds passing (`nx build realtime-js`)
- [x] Used conventional commits
