### PR TITLE
fix(auth): preserve 5xx error message

### DIFF
--- a/packages/core/auth-js/src/lib/fetch.ts
+++ b/packages/core/auth-js/src/lib/fetch.ts
@@ -81,16 +81,19 @@ export async function handleError(error: unknown) {
     throw new AuthRetryableFetchError(_getErrorMessage(error), 0)
   }
 
-  if (NETWORK_ERROR_CODES.includes(error.status)) {
-    // status in 500...599 range - server had an error, request might be retryed.
-    throw new AuthRetryableFetchError(_getErrorMessage(error), error.status)
-  }
-
   let data: any
   try {
     data = await error.json()
   } catch (e) {
+    if (NETWORK_ERROR_CODES.includes(error.status)) {
+      throw new AuthRetryableFetchError(_getErrorMessage(error), error.status)
+    }
     throw new AuthUnknownError(_getErrorMessage(e), e)
+  }
+
+  if (NETWORK_ERROR_CODES.includes(error.status)) {
+    // status in 500...599 range - server had an error, request might be retryed.
+    throw new AuthRetryableFetchError(_getErrorMessage(data), error.status)
   }
 
   let errorCode: string | undefined = undefined

--- a/packages/core/auth-js/src/lib/fetch.ts
+++ b/packages/core/auth-js/src/lib/fetch.ts
@@ -86,7 +86,8 @@ export async function handleError(error: unknown) {
     data = await error.json()
   } catch (e) {
     if (NETWORK_ERROR_CODES.includes(error.status)) {
-      throw new AuthRetryableFetchError(_getErrorMessage(error), error.status)
+      // statusText can be empty — HTTP/2 has no reason phrase
+      throw new AuthRetryableFetchError(error.statusText || `HTTP ${error.status}`, error.status)
     }
     throw new AuthUnknownError(_getErrorMessage(e), e)
   }

--- a/packages/core/auth-js/test/fetch.test.ts
+++ b/packages/core/auth-js/test/fetch.test.ts
@@ -65,6 +65,32 @@ describe('fetch', () => {
       expect(route).toHaveBeenCalledTimes(1)
     })
 
+    test('should preserve the server-sent JSON message on a retryable 500 error', async () => {
+      const route = server
+        .get('/')
+        .mockImplementationOnce((ctx) => {
+          ctx.status = 500
+          ctx.body = {
+            code: 500,
+            error_code: 'unexpected_failure',
+            msg: 'Error sending confirmation email',
+          }
+        })
+        .mockImplementation((ctx) => {
+          ctx.status = 200
+        })
+
+      const url = server.getURL().toString()
+
+      const error = await _request(fetch, 'GET', url).catch((e) => e)
+
+      expect(error).toBeInstanceOf(AuthRetryableFetchError)
+      expect(error.status).toEqual(500)
+      expect(error.message).toEqual('Error sending confirmation email')
+
+      expect(route).toHaveBeenCalledTimes(1)
+    })
+
     test('should throw AuthRetryableFetchError upon Cloudflare edge errors (525)', async () => {
       const route = server
         .get('/')
@@ -256,6 +282,35 @@ describe('handleError', () => {
       expect(error.name).toEqual(example.ename)
       expect(error.code).toEqual(example.code)
     })
+  })
+
+  it('preserves the server-sent message for a retryable 5xx with a JSON body', async () => {
+    const response = new Response(
+      JSON.stringify({
+        code: 500,
+        error_code: 'unexpected_failure',
+        msg: 'Error sending confirmation email',
+      }),
+      { status: 500, statusText: 'Internal Server Error' }
+    )
+
+    const error: any = await handleError(response).catch((e) => e)
+
+    expect(error).toBeInstanceOf(AuthRetryableFetchError)
+    expect(error.status).toEqual(500)
+    expect(error.message).toEqual('Error sending confirmation email')
+  })
+
+  it('stays retryable for a 5xx without a JSON body', async () => {
+    const response = new Response('<html><body><h1>502 Bad Gateway</h1></body></html>', {
+      status: 502,
+      statusText: 'Bad Gateway',
+    })
+
+    const error: any = await handleError(response).catch((e) => e)
+
+    expect(error).toBeInstanceOf(AuthRetryableFetchError)
+    expect(error.status).toEqual(502)
   })
 })
 

--- a/packages/core/auth-js/test/fetch.test.ts
+++ b/packages/core/auth-js/test/fetch.test.ts
@@ -70,10 +70,10 @@ describe('fetch', () => {
         .get('/')
         .mockImplementationOnce((ctx) => {
           ctx.status = 500
+          ctx.set(API_VERSION_HEADER_NAME, '2024-01-01')
           ctx.body = {
-            code: 500,
-            error_code: 'unexpected_failure',
-            msg: 'Error sending confirmation email',
+            code: 'unexpected_failure',
+            message: 'Error sending confirmation email',
           }
         })
         .mockImplementation((ctx) => {
@@ -284,7 +284,29 @@ describe('handleError', () => {
     })
   })
 
-  it('preserves the server-sent message for a retryable 5xx with a JSON body', async () => {
+  it('preserves the server-sent message for a retryable 5xx with API version 2024-01-01', async () => {
+    const response = new Response(
+      JSON.stringify({
+        code: 'unexpected_failure',
+        message: 'Error sending confirmation email',
+      }),
+      {
+        status: 500,
+        statusText: 'Internal Server Error',
+        headers: {
+          [API_VERSION_HEADER_NAME]: '2024-01-01',
+        },
+      }
+    )
+
+    const error: any = await handleError(response).catch((e) => e)
+
+    expect(error).toBeInstanceOf(AuthRetryableFetchError)
+    expect(error.status).toEqual(500)
+    expect(error.message).toEqual('Error sending confirmation email')
+  })
+
+  it('preserves the server-sent message for a retryable 5xx without API version', async () => {
     const response = new Response(
       JSON.stringify({
         code: 500,
@@ -301,7 +323,7 @@ describe('handleError', () => {
     expect(error.message).toEqual('Error sending confirmation email')
   })
 
-  it('stays retryable for a 5xx without a JSON body', async () => {
+  it('falls back to the status text for a 5xx without a JSON body', async () => {
     const response = new Response('<html><body><h1>502 Bad Gateway</h1></body></html>', {
       status: 502,
       statusText: 'Bad Gateway',
@@ -311,6 +333,19 @@ describe('handleError', () => {
 
     expect(error).toBeInstanceOf(AuthRetryableFetchError)
     expect(error.status).toEqual(502)
+    expect(error.message).toEqual('Bad Gateway')
+  })
+
+  it('falls back to the status code when there is no status text (HTTP/2)', async () => {
+    const response = new Response('<html><body><h1>502 Bad Gateway</h1></body></html>', {
+      status: 502,
+    })
+
+    const error: any = await handleError(response).catch((e) => e)
+
+    expect(error).toBeInstanceOf(AuthRetryableFetchError)
+    expect(error.status).toEqual(502)
+    expect(error.message).toEqual('HTTP 502')
   })
 })
 


### PR DESCRIPTION
## TL;DR:

 `handleError` threw retryable 5xx errors before reading the response body, so every server error surfaced as `message: "{}"`. 

Parse the body first, keep the `NETWORK_ERROR_CODES` classification
 a 5xx with a JSON body now carries the server's message, a body-less 5xx 
(gateway HTML page) throws exactly what it did before. 
Error class and status unchanged on every path.

## ref: 
- closes #2585
