### PR TITLE
test(realtime): stabilize supabase client instance in chat example

### DIFF
--- a/packages/core/realtime-js/example/components/chat.tsx
+++ b/packages/core/realtime-js/example/components/chat.tsx
@@ -32,7 +32,9 @@ export function Chat() {
   const [username, setUsername] = useState("");
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const channelRef = useRef<RealtimeChannel | null>(null);
-  const supabase = createClient();
+  // A stable client instance — recreating it on each render retriggers the
+  // subscription effect below, tearing down and reopening the channel in a loop.
+  const [supabase] = useState(() => createClient());
 
   // Get username on mount
   useEffect(() => {


### PR DESCRIPTION
The realtime chat example created a new SupabaseClient on every render (createClient() in the component body) and passed that unstable reference into the subscription effect's dependency array. Every state update (message fetch, presence sync) re-ran the effect, tearing down and re-opening the realtime channel in a self-sustaining loop.

Under CI load this exhausted Chrome's WebSocket budget — a failing trace shows 2,539 failed WebSocket attempts ("Insufficient resources") and 7,527 "Multiple GoTrueClient instances" warnings within a single test — so the channel never reached SUBSCRIBED, track() never ran, and the presence: user appears in online list Playwright test failed with "Online (0)". Whether the first subscription won the race against the churn depended on runner timing, which is why the integration job flaked intermittently on unrelated PRs.

Fix: create the client once per component instance with a useState initializer, so the effect only re-runs on room/username changes.