### PR TITLE
fix(realtime): ensure setAuth doesn't disable token refresh

### DIFF
--- a/packages/core/realtime-js/src/RealtimeClient.ts
+++ b/packages/core/realtime-js/src/RealtimeClient.ts
@@ -482,14 +482,18 @@ export default class RealtimeClient {
    *
    * On callback used, it will set the value of the token internal to the client.
    *
-   * When a token is explicitly provided, it will be preserved across channel operations
-   * (including removeChannel and resubscribe). The `accessToken` callback will not be
-   * invoked until `setAuth()` is called without arguments.
+   * When a token is explicitly provided AND no `accessToken` callback is configured,
+   * it will be preserved across channel operations (including removeChannel and
+   * resubscribe) and the client stays in manual-token mode.
+   *
+   * When an `accessToken` callback IS configured, the callback is the source of truth:
+   * the client remains in callback mode and continues to refresh from it on heartbeat,
+   * even after a bootstrap/override `setAuth(token)` call.
    *
    * @param token A JWT string to override the token set on the client.
    *
    * @example Setting the authorization header
-   * // Use a manual token (preserved across resubscribes, ignores accessToken callback)
+   * // Use a manual token (preserved across resubscribes when no accessToken callback is set)
    * client.realtime.setAuth('my-custom-jwt')
    *
    * // Switch back to using the accessToken callback
@@ -625,12 +629,12 @@ export default class RealtimeClient {
       tokenToSend = this.accessTokenValue
     }
 
-    // Track whether this token was manually set or fetched via callback
-    if (isManualToken) {
-      this._manuallySetToken = true
-    } else if (this.accessToken) {
-      // If we used the callback, clear the manual flag
+    // Track whether this token was manually set or fetched via callback.
+    // The callback is the source of truth for token refresh
+    if (this.accessToken) {
       this._manuallySetToken = false
+    } else if (isManualToken) {
+      this._manuallySetToken = true
     }
 
     if (this.accessTokenValue != tokenToSend) {

--- a/packages/core/supabase-js/test/unit/SupabaseClient.test.ts
+++ b/packages/core/supabase-js/test/unit/SupabaseClient.test.ts
@@ -317,6 +317,22 @@ describe('SupabaseClient', () => {
         client.realtime.disconnect()
       })
 
+      test('keeps Realtime in callback mode (auto-refresh enabled) after the accessToken bootstrap', async () => {
+        const customToken = 'custom-jwt-token'
+        const customAccessTokenFn = jest.fn().mockResolvedValue(customToken)
+
+        const client = createClient(URL, KEY, { accessToken: customAccessTokenFn })
+
+        // Wait for the constructor's async setAuth bootstrap to complete.
+        await new Promise((resolve) => setTimeout(resolve, 0))
+
+        // Still in callback mode -> the accessToken callback will keep being
+        // invoked on heartbeat to refresh the token.
+        expect((client.realtime as any)._isManualToken()).toBe(false)
+
+        client.realtime.disconnect()
+      })
+
       test('should automatically populate token in channels when using custom JWT', async () => {
         const customToken = 'custom-channel-token'
         const customAccessTokenFn = jest.fn().mockResolvedValue(customToken)


### PR DESCRIPTION
<!-- Your PR title should follow the conventional commit format:
<type>(<scope>): <description> -->

## 🔍 Description

Ensure `realtime.setAuth` doesn't disable token refresh. This happens only on 3rd party tokens.

<!-- Provide a clear and concise description of what this PR does -->

### What changed?

<!-- Describe the changes made in this PR -->

Change RealtimeClient's `setAuth` to only consider that tokens will be manually set if there is no `accessToken` promise to resolve.

### Why was this change needed?

Because the `SupabaseClient` bootstraps the token calling `setAuth` which disables the token refresh:

https://github.com/supabase/supabase-js/blob/21e410f5622c163c3e64fc1a3bb78ee3b9ec86c9/packages/core/supabase-js/src/SupabaseClient.ts#L389-L395

<!-- Explain the motivation behind this change. Link any related issues. -->

## 🔄 Breaking changes

<!-- If this PR contains breaking changes, describe them here -->

- [x] This PR contains no breaking changes

## 📋 Checklist

<!-- Ensure all items are checked before submitting -->

- [x] I have read the [Contributing Guidelines](https://github.com/supabase/supabase-js/blob/master/CONTRIBUTING.md)
- [x] My PR title follows the [conventional commit format](https://www.conventionalcommits.org/): `<type>(<scope>): <description>`
- [x] I have run `pnpm nx format` to ensure consistent code formatting
- [x] I have added tests for new functionality (if applicable)
- [x] I have updated documentation (if applicable)

## 📝 Additional notes

<!-- Add any additional notes, context, or concerns for reviewers -->

<!-- Thank you for contributing to Supabase! 💚 -->
