### PR TITLE
fix(realtime): clear stale join payload on sign-out

### DIFF
--- a/packages/core/realtime-js/src/RealtimeClient.ts
+++ b/packages/core/realtime-js/src/RealtimeClient.ts
@@ -645,7 +645,7 @@ export default class RealtimeClient {
           version: DEFAULT_VERSION,
         }
 
-        tokenToSend && channel.updateJoinPayload(payload)
+        channel.updateJoinPayload(payload)
 
         if (channel.joinedOnce && channel.channelAdapter.isJoined()) {
           channel.channelAdapter.push(CHANNEL_EVENTS.access_token, {

--- a/packages/core/realtime-js/src/RealtimeClient.ts
+++ b/packages/core/realtime-js/src/RealtimeClient.ts
@@ -226,6 +226,7 @@ export default class RealtimeClient {
 
   private _manuallySetToken: boolean = false
   private _authPromise: Promise<void> | null = null
+  private _authGeneration: number = 0
   private _workerHeartbeatTimer: HeartbeatTimer = undefined
   private _pendingWorkerHeartbeatRef: string | null = null
   private _pendingDisconnectTimer: ReturnType<typeof setTimeout> | null = null
@@ -502,11 +503,17 @@ export default class RealtimeClient {
    * @category Realtime
    */
   async setAuth(token: string | null = null): Promise<void> {
-    this._authPromise = this._performAuth(token)
+    const authGeneration = ++this._authGeneration
+    const authPromise = this._performAuth(token, authGeneration)
+    if (authGeneration === this._authGeneration) {
+      this._authPromise = authPromise
+    }
     try {
-      await this._authPromise
+      await authPromise
     } finally {
-      this._authPromise = null
+      if (this._authPromise === authPromise) {
+        this._authPromise = null
+      }
     }
   }
 
@@ -608,7 +615,7 @@ export default class RealtimeClient {
    * Perform the actual auth operation
    * @internal
    */
-  private async _performAuth(token: string | null = null): Promise<void> {
+  private async _performAuth(token: string | null, authGeneration: number): Promise<void> {
     let tokenToSend: string | null
     let isManualToken = false
 
@@ -627,6 +634,10 @@ export default class RealtimeClient {
       }
     } else {
       tokenToSend = this.accessTokenValue
+    }
+
+    if (authGeneration !== this._authGeneration) {
+      return
     }
 
     // Track whether this token was manually set or fetched via callback.

--- a/packages/core/realtime-js/test/RealtimeClient.auth.test.ts
+++ b/packages/core/realtime-js/test/RealtimeClient.auth.test.ts
@@ -119,6 +119,41 @@ describe('token setting and updates', () => {
     testSetup.cleanup()
   })
 
+  test("clears joined channels' auth payload when the access token callback returns null", async () => {
+    const token = utils.generateJWT('3h')
+    let currentToken: string | null = token
+    const testSetup = setupRealtimeTest({
+      accessToken: () => Promise.resolve(currentToken),
+    })
+    const channel = await testHelpers.setupAuthTestChannel(testSetup.client)
+
+    await vi.waitFor(() => expect(testSetup.client.accessTokenValue).toBe(token))
+
+    currentToken = null
+    await testSetup.client.setAuth()
+
+    expect(testSetup.client.accessTokenValue).toBeNull()
+    expect(channel.joinPush.payload()).toStrictEqual({
+      config: expect.any(Object),
+      access_token: null,
+      version: DEFAULT_VERSION,
+    })
+
+    testSetup.emitters.message.mockClear()
+    channel.channelAdapter.getChannel().rejoin()
+    await vi.waitFor(() => expect(testSetup.emitters.message).toHaveBeenCalled())
+    const [topic, event, payload] = testSetup.emitters.message.mock.calls.at(-1)!
+    expect(topic).toBe('realtime:test-topic')
+    expect(event).toBe('phx_join')
+    expect(payload).toStrictEqual({
+      config: expect.any(Object),
+      access_token: null,
+      version: DEFAULT_VERSION,
+    })
+
+    testSetup.cleanup()
+  })
+
   test("overrides access token, updates channels' join payload, and pushes token to channels", async () => {
     const testSetup = setupRealtimeTest()
 

--- a/packages/core/realtime-js/test/RealtimeClient.auth.test.ts
+++ b/packages/core/realtime-js/test/RealtimeClient.auth.test.ts
@@ -154,6 +154,120 @@ describe('token setting and updates', () => {
     testSetup.cleanup()
   })
 
+  test('ignores stale access token callback results after sign-out', async () => {
+    const token = utils.generateJWT('3h')
+    const tokenResolvers: Array<(token: string | null) => void> = []
+    const testSetup = setupRealtimeTest({
+      accessToken: () =>
+        new Promise((resolve) => {
+          tokenResolvers.push(resolve)
+        }),
+    })
+    const channel = testSetup.client.channel('test-topic')
+
+    await testSetup.client.setAuth(token)
+
+    const staleAuth = testSetup.client.setAuth()
+    const signOutAuth = testSetup.client.setAuth()
+    expect(tokenResolvers).toHaveLength(2)
+
+    tokenResolvers[1](null)
+    await signOutAuth
+
+    expect(testSetup.client.accessTokenValue).toBeNull()
+
+    tokenResolvers[0](token)
+    await staleAuth
+
+    expect(testSetup.client.accessTokenValue).toBeNull()
+    expect(channel.joinPush.payload()).toStrictEqual({
+      config: expect.any(Object),
+      access_token: null,
+      version: DEFAULT_VERSION,
+    })
+
+    testSetup.cleanup()
+  })
+
+  test('keeps callback auth enabled after an explicit token supersedes a pending result', async () => {
+    const staleToken = utils.generateJWT('1h')
+    const explicitToken = utils.generateJWT('2h')
+    const refreshedToken = utils.generateJWT('3h')
+    let resolveToken!: (token: string | null) => void
+    const testSetup = setupRealtimeTest({
+      accessToken: () =>
+        new Promise((resolve) => {
+          resolveToken = resolve
+        }),
+    })
+
+    const staleAuth = testSetup.client.setAuth()
+    await testSetup.client.setAuth(explicitToken)
+    resolveToken(staleToken)
+    await staleAuth
+
+    expect(testSetup.client.accessTokenValue).toBe(explicitToken)
+    expect(testSetup.client._isManualToken()).toBe(false)
+
+    const refreshedAuth = testSetup.client.setAuth()
+    resolveToken(refreshedToken)
+    await refreshedAuth
+
+    expect(testSetup.client.accessTokenValue).toBe(refreshedToken)
+
+    testSetup.cleanup()
+  })
+
+  test('keeps the latest auth request tracked when a stale request resolves first', async () => {
+    const staleToken = utils.generateJWT('1h')
+    const latestToken = utils.generateJWT('2h')
+    const tokenResolvers: Array<(token: string | null) => void> = []
+    const accessToken = () => new Promise<string | null>((resolve) => tokenResolvers.push(resolve))
+    const testSetup = setupRealtimeTest({ accessToken })
+
+    const staleAuth = testSetup.client.setAuth()
+    const latestAuth = testSetup.client.setAuth()
+    tokenResolvers[0](staleToken)
+    await staleAuth
+
+    testSetup.connect()
+    expect(tokenResolvers).toHaveLength(2)
+
+    tokenResolvers[1](latestToken)
+    await latestAuth
+    expect(testSetup.client.accessTokenValue).toBe(latestToken)
+
+    testSetup.cleanup()
+  })
+
+  test('does not track stale auth work after a callback re-enters setAuth', async () => {
+    const explicitToken = utils.generateJWT('2h')
+    let resolveStaleToken!: (token: string | null) => void
+    const accessToken = vi.fn(() => {
+      if (accessToken.mock.calls.length === 1) {
+        void testSetup.client.setAuth(explicitToken)
+        return new Promise<string | null>((resolve) => {
+          resolveStaleToken = resolve
+        })
+      }
+      return Promise.resolve(explicitToken)
+    })
+    const testSetup = setupRealtimeTest({ accessToken })
+
+    const staleAuth = testSetup.client.setAuth()
+    expect(testSetup.client.accessTokenValue).toBe(explicitToken)
+    await Promise.resolve()
+
+    testSetup.connect()
+    expect(accessToken).toHaveBeenCalledTimes(2)
+
+    resolveStaleToken(null)
+    await staleAuth
+    expect(testSetup.client.accessTokenValue).toBe(explicitToken)
+
+    testSetup.cleanup()
+  })
+
   test("overrides access token, updates channels' join payload, and pushes token to channels", async () => {
     const testSetup = setupRealtimeTest()
 


### PR DESCRIPTION
## TL;DR

Clear existing channel join payloads when the callback-based access token becomes `null` after sign-out
Subsequent rejoins then use the signed-out API-key path instead of replaying the previous JWT

## Problem

When the access-token callback returned `null`, `RealtimeClient` cleared its cached token but
 skipped updating the channels' stored join payloads. A later `phx_join` therefore replayed the previous JWT

## sol

Always update each channel's join payload when the resolved token changes, including `null`.

Track `_authGeneration` so only the latest `setAuth()` call can apply its result, 
preventing an older refresh from restoring a stale JWT after sign-out.

The join-payload change only affects future joins; manual-token semantics, callback refresh behavior, and the existing in-place `access_token: null` message are unchanged...

## ref:

- Closes supabase/supabase-js#2596 
