### PR TITLE
ci(release): fix gotrue publishing

### DIFF
--- a/scripts/publish-gotrue-legacy.ts
+++ b/scripts/publish-gotrue-legacy.ts
@@ -110,7 +110,9 @@ async function publishGotrueLegacy(): Promise<void> {
     // nx-release-publish does for the other six packages — `npm publish` from
     // inside a pnpm workspace can sign provenance but then 404s on the registry
     // PUT (observed continuously since the pnpm migration).
-    const publishCommand = `pnpm publish --provenance --tag ${tag} --no-git-checks`
+    // --registry must be explicit: without it, pnpm inherits CI's dependency-firewall
+    // registry (a read-only proxy), which 405s on publish PUTs.
+    const publishCommand = `pnpm publish --provenance --tag ${tag} --no-git-checks --registry=https://registry.npmjs.org/`
 
     log(`\n🚀 Publishing to npm...`)
     log(`   Command: ${publishCommand}`)


### PR DESCRIPTION
The `gotrue-js` legacy mirror publish step (`scripts/publish-gotrue-legacy.ts`) has been failing since CI started routing installs through the dependency firewall: the firewall step sets pnpm's global registry to `firewall.depthfirst.com`, and since this script shells out to `pnpm publish` directly without an explicit `--registry` override, the OIDC exchange targets the wrong audience and the publish PUT gets rejected with a 405.

This adds `--registry=https://registry.npmjs.org/` to the publish command, matching what nx's `release-publish` executor already does automatically for the other six packages.