### PR TITLE
chore: update sdk-compliance.yaml for renamed capability matrix IDs

### DIFF
--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -267,7 +267,7 @@ features:
     status: implemented
     symbols:
       - GoTrueClient.resend
-  auth.sign_in.reset_password:
+  auth.sign_in.send_password_reset_email:
     status: implemented
     symbols:
       - GoTrueClient.resetPasswordForEmail
@@ -542,11 +542,39 @@ features:
     status: implemented
     symbols:
       - default.deleteBucket
-  storage.analytics.iceberg_namespace:
+  storage.analytics.create_namespace:
     status: implemented
     symbols:
       - default.from
-  storage.analytics.iceberg_table:
+  storage.analytics.list_namespaces:
+    status: implemented
+    symbols:
+      - default.from
+  storage.analytics.delete_namespace:
+    status: implemented
+    symbols:
+      - default.from
+  storage.analytics.create_table:
+    status: implemented
+    symbols:
+      - default.from
+  storage.analytics.list_tables:
+    status: implemented
+    symbols:
+      - default.from
+  storage.analytics.load_table:
+    status: implemented
+    symbols:
+      - default.from
+  storage.analytics.update_table:
+    status: implemented
+    symbols:
+      - default.from
+  storage.analytics.rename_table:
+    status: implemented
+    symbols:
+      - default.from
+  storage.analytics.delete_table:
     status: implemented
     symbols:
       - default.from
@@ -638,9 +666,6 @@ features:
     status: implemented
     symbols:
       - default.list
-  storage.file_buckets.list_files_paginated:
-    status: implemented
-    symbols:
       - default.listV2
   storage.file_buckets.move:
     status: implemented
@@ -754,7 +779,7 @@ features:
     status: implemented
     symbols:
       - RealtimeChannel.httpSend
-  realtime.channel.send:
+  realtime.channel.broadcast:
     status: implemented
     symbols:
       - RealtimeChannel.send


### PR DESCRIPTION
## Summary
[supabase/sdk#74](https://github.com/supabase/sdk/pull/74) renames/splits several feature IDs in the canonical capability matrix. This updates `sdk-compliance.yaml` so the SDK compliance CI check doesn't fail on unknown IDs once that PR merges. No SDK code changes.

- `auth.sign_in.reset_password` → `auth.sign_in.send_password_reset_email`
- `realtime.channel.send` → `realtime.channel.broadcast`
- `storage.file_buckets.list_files_paginated` merged into `list_files` (symbols combined)
- `storage.analytics.iceberg_namespace` split into `create_namespace`/`list_namespaces`/`delete_namespace` (same symbols/status replicated across all three — not yet divided per-operation)
- `storage.analytics.iceberg_table` split into `create_table`/`list_tables`/`load_table`/`update_table`/`rename_table`/`delete_table` (same treatment)

Context: [SDK-1439](https://linear.app/supabase/issue/SDK-1439)

## Test plan
- [x] Validated against the updated registry with `npm run validate-compliance` from `supabase/sdk` (branch with #74's changes): `OK — compliance file is valid.`