### PR TITLE
fix(supabase): add trace context headers to canonical CORS allow-list

### DIFF
--- a/packages/core/supabase-js/src/cors.ts
+++ b/packages/core/supabase-js/src/cors.ts
@@ -1,9 +1,10 @@
 /**
  * Canonical CORS configuration for Supabase Edge Functions
  *
- * This module exports CORS headers that stay synchronized with the Supabase SDK.
- * When new headers are added to the SDK, they are automatically included here,
- * preventing CORS errors in Edge Functions.
+ * This module exports CORS headers kept in sync with the headers the Supabase
+ * SDK sends. Using it in Edge Functions prevents CORS preflight errors when the
+ * SDK adds new headers — update SUPABASE_HEADERS whenever the SDK starts
+ * sending one (enforced by the unit tests).
  *
  * @example Basic usage
  * ```typescript
@@ -34,6 +35,9 @@
  * - apikey: Project API key
  * - content-type: Standard HTTP content type
  * - x-retry-count: Retry attempt number sent by postgrest-js on retried requests
+ * - traceparent: W3C trace context sent when `tracePropagation` is enabled
+ * - tracestate: Vendor-specific trace data sent alongside traceparent
+ * - baggage: W3C baggage sent alongside traceparent
  */
 const SUPABASE_HEADERS = [
   'authorization',
@@ -41,6 +45,9 @@ const SUPABASE_HEADERS = [
   'apikey',
   'content-type',
   'x-retry-count',
+  'traceparent',
+  'tracestate',
+  'baggage',
 ].join(', ')
 
 /**

--- a/packages/core/supabase-js/test/unit/cors.test.ts
+++ b/packages/core/supabase-js/test/unit/cors.test.ts
@@ -16,12 +16,29 @@ describe('CORS Module', () => {
     it('should include all Supabase custom headers', () => {
       const allowedHeaders = corsHeaders['Access-Control-Allow-Headers']
 
-      // All 10 Supabase headers must be present
-      expect(allowedHeaders).toContain('authorization')
-      expect(allowedHeaders).toContain('x-client-info')
-      expect(allowedHeaders).toContain('apikey')
-      expect(allowedHeaders).toContain('content-type')
-      expect(allowedHeaders).toContain('x-retry-count')
+      // Pin the exact list: when the SDK starts sending a new header, this
+      // test must fail until the header is added to SUPABASE_HEADERS —
+      // otherwise browser preflights break for Edge Functions using corsHeaders.
+      expect(allowedHeaders.split(', ').sort()).toEqual(
+        [
+          'authorization',
+          'x-client-info',
+          'apikey',
+          'content-type',
+          'x-retry-count',
+          'traceparent',
+          'tracestate',
+          'baggage',
+        ].sort()
+      )
+    })
+
+    it('should include the trace context headers sent when tracePropagation is enabled', () => {
+      const allowedHeaders = corsHeaders['Access-Control-Allow-Headers']
+
+      expect(allowedHeaders).toContain('traceparent')
+      expect(allowedHeaders).toContain('tracestate')
+      expect(allowedHeaders).toContain('baggage')
     })
 
     it('should include all HTTP methods including OPTIONS', () => {


### PR DESCRIPTION
The canonical CORS allow-list exported by `@supabase/supabase-js/cors` predates trace propagation, so browser calls to Edge Functions that use `corsHeaders` fail the CORS preflight when `tracePropagation` is enabled (`traceparent` is not a safelisted request header, and the function's own allow-list answers the preflight). This adds the three W3C trace context headers (`traceparent`, `tracestate`, `baggage`) to the list, which also fixes the default CORS handling in `@supabase/server`, since `withSupabase` imports this exact list. The unit test now pins the full header list, so the next header the SDK starts sending cannot slip through without being added here.

Note on scope: this changes only the response-side allow-list (what a browser is permitted to send), not what the SDK sends. Trace headers are sent exclusively by clients that explicitly opt in via `tracePropagation: true` (disabled by default) — clients that have not opted in send exactly the same headers as before, so this cannot repeat the class of breakage where a newly sent default header failed preflights against existing allow-lists.
