### PR TITLE
fix(supabase): improve trace propagation sampling and diagnostics

### DIFF
--- a/packages/core/supabase-js/README.md
+++ b/packages/core/supabase-js/README.md
@@ -149,13 +149,15 @@ interface TracePropagationOptions {
   enabled?: boolean
 
   // Respect upstream sampling decisions (default: true).
-  // When true, headers are skipped if the upstream trace is not sampled.
+  // When true, non-sampled requests carry only `traceparent` (flag preserved,
+  // so nothing is recorded downstream) — Supabase logs still get a trace_id,
+  // while `tracestate` and `baggage` are withheld.
   respectSamplingDecision?: boolean
 }
 ```
 
 ```js
-// Always propagate, even for non-sampled traces.
+// Always propagate the full trace context, even for non-sampled traces.
 const supabase = createClient('https://xyzcompany.supabase.co', 'public-anon-key', {
   tracePropagation: { enabled: true, respectSamplingDecision: false },
 })

--- a/packages/core/supabase-js/src/lib/fetch.ts
+++ b/packages/core/supabase-js/src/lib/fetch.ts
@@ -115,6 +115,7 @@ export const fetchWithAuth = (
 }
 
 let warnedMissingTracingRuntime = false
+let warnedNonW3CPropagator = false
 
 /**
  * For tests only. Resets the one-time missing-tracing-runtime warning.
@@ -123,6 +124,15 @@ let warnedMissingTracingRuntime = false
  */
 export function _resetTracingRuntimeWarning(): void {
   warnedMissingTracingRuntime = false
+}
+
+/**
+ * For tests only. Resets the one-time non-W3C-propagator warning.
+ *
+ * @internal
+ */
+export function _resetNonW3CPropagatorWarning(): void {
+  warnedNonW3CPropagator = false
 }
 
 function getTraceHeaders(
@@ -161,13 +171,34 @@ function getTraceHeaders(
   const traceContext = extractTraceContext()
 
   if (!traceContext || !traceContext.traceparent) {
+    // An active propagator that writes vendor headers but no W3C
+    // `traceparent` (e.g. Sentry without `propagateTraceparent: true`) is
+    // otherwise indistinguishable from "no active trace" — warn once so the
+    // user learns why no trace headers are attached. An empty carrier means
+    // no active trace: normal, stay silent.
+    if (traceContext?.carrierKeys?.length && !warnedNonW3CPropagator) {
+      warnedNonW3CPropagator = true
+      const sentryHint = traceContext.carrierKeys.includes('sentry-trace')
+        ? ' Sentry detected: set `propagateTraceparent: true` in Sentry.init() to emit it.'
+        : ' Configure your tracing SDK to emit W3C trace context on outgoing requests.'
+      console.warn(
+        '@supabase/supabase-js: tracePropagation is enabled and a tracing SDK is active, but its ' +
+          `propagator wrote [${traceContext.carrierKeys.join(', ')}] and no W3C traceparent header, ` +
+          'so trace headers will not be attached.' +
+          sentryHint
+      )
+    }
     return null
   }
 
   if (respectSampling) {
     const parsed = parseTraceParent(traceContext.traceparent)
     if (parsed && !parsed.isSampled) {
-      return null
+      // Unsampled traces still carry `traceparent` so Supabase logs get a
+      // trace_id to correlate on; the flag stays `00`, so downstream tracing
+      // never records it as sampled. `tracestate` and `baggage` (the
+      // vendor/application data channels) are withheld on these requests.
+      return { traceparent: traceContext.traceparent }
     }
   }
 

--- a/packages/core/supabase-js/src/lib/types.ts
+++ b/packages/core/supabase-js/src/lib/types.ts
@@ -80,17 +80,20 @@ export interface TracePropagationOptions {
   /**
    * Respect upstream sampling decisions.
    *
-   * When true (the default), trace context is not propagated if the upstream
-   * trace indicates non-sampling (sampled flag = `0` in the `traceparent`
-   * header). This avoids overhead when traces are being recorded but dropped.
+   * When true (the default), requests whose upstream trace is not sampled
+   * (sampled flag = `0` in the `traceparent` header) carry only the
+   * `traceparent` header — the sampled flag is preserved, so downstream
+   * tracing never records them, while Supabase logs still get a `trace_id`
+   * to correlate on. The `tracestate` and `baggage` headers are withheld on
+   * these requests.
    *
-   * Set to `false` to always propagate, regardless of the sampling decision
-   * — useful when you want every Supabase request tagged with a `trace_id`
-   * for log correlation, even if the trace itself will not be exported.
+   * Set to `false` to always propagate the full trace context
+   * (`traceparent`, `tracestate`, `baggage`) regardless of the sampling
+   * decision.
    *
    * @default true
    *
-   * @example Always propagate, ignore sampling
+   * @example Always propagate the full context, ignore sampling
    * ```ts
    * import '@supabase/supabase-js/tracing'
    *

--- a/packages/core/supabase-js/test/unit/fetch.test.ts
+++ b/packages/core/supabase-js/test/unit/fetch.test.ts
@@ -4,6 +4,7 @@ import {
   fetchWithAuth,
   checkApiKeyFormat,
   _resetTracingRuntimeWarning,
+  _resetNonW3CPropagatorWarning,
 } from '../../src/lib/fetch'
 import {
   registerTraceContextExtractor,
@@ -362,6 +363,7 @@ describe('fetch module', () => {
       afterEach(() => {
         _unregisterTraceContextExtractor()
         _resetTracingRuntimeWarning()
+        _resetNonW3CPropagatorWarning()
       })
 
       test('should not inject trace headers by default (no options)', async () => {
@@ -487,7 +489,14 @@ describe('fetch module', () => {
         expect(mockSet).not.toHaveBeenCalledWith('traceparent', expect.anything())
       })
 
-      test('should respect sampling decision when enabled', async () => {
+      test('should send only traceparent for non-sampled traces by default', async () => {
+        // Full context from the propagator; only traceparent may go out.
+        registerTraceContextExtractor(() => ({
+          traceparent: UNSAMPLED_TRACEPARENT,
+          tracestate: 'vendor1=value1',
+          baggage: 'key1=value1',
+        }))
+
         const mockResponse = { ok: true }
         const mockFetchImpl = jest.fn().mockResolvedValue(mockResponse)
         const mockSet = jest.fn()
@@ -517,11 +526,20 @@ describe('fetch module', () => {
         )
         await authFetch('https://myproject.supabase.co/rest/v1/table')
 
-        // Should not inject because trace is not sampled
-        expect(mockSet).not.toHaveBeenCalledWith('traceparent', expect.anything())
+        // trace_id still flows for log correlation, sampled flag untouched…
+        expect(mockSet).toHaveBeenCalledWith('traceparent', UNSAMPLED_TRACEPARENT)
+        // …but the vendor/application data channels are withheld.
+        expect(mockSet).not.toHaveBeenCalledWith('tracestate', expect.anything())
+        expect(mockSet).not.toHaveBeenCalledWith('baggage', expect.anything())
       })
 
-      test('should inject trace headers when sampling decision is disabled', async () => {
+      test('should inject the full trace context when sampling decision is disabled', async () => {
+        registerTraceContextExtractor(() => ({
+          traceparent: UNSAMPLED_TRACEPARENT,
+          tracestate: 'vendor1=value1',
+          baggage: 'key1=value1',
+        }))
+
         const mockResponse = { ok: true }
         const mockFetchImpl = jest.fn().mockResolvedValue(mockResponse)
         const mockSet = jest.fn()
@@ -551,11 +569,10 @@ describe('fetch module', () => {
         )
         await authFetch('https://myproject.supabase.co/rest/v1/table')
 
-        // Should inject even though trace is not sampled
-        expect(mockSet).toHaveBeenCalledWith(
-          'traceparent',
-          '00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-00'
-        )
+        // All three headers go out even though the trace is not sampled
+        expect(mockSet).toHaveBeenCalledWith('traceparent', UNSAMPLED_TRACEPARENT)
+        expect(mockSet).toHaveBeenCalledWith('tracestate', 'vendor1=value1')
+        expect(mockSet).toHaveBeenCalledWith('baggage', 'key1=value1')
       })
 
       test('should not override existing trace headers', async () => {
@@ -670,6 +687,92 @@ describe('fetch module', () => {
         registerTraceContextExtractor(() => ({ traceparent: SAMPLED_TRACEPARENT }))
         await authFetch('https://myproject.supabase.co/rest/v1/table')
         expect(mockSet).toHaveBeenCalledWith('traceparent', SAMPLED_TRACEPARENT)
+
+        warnSpy.mockRestore()
+      })
+
+      test('warns once when an active propagator emits no traceparent', async () => {
+        // What the extractor returns under a Sentry propagator with the
+        // default `propagateTraceparent: false`: vendor headers were written
+        // to the carrier, but no W3C traceparent.
+        registerTraceContextExtractor(() => ({ carrierKeys: ['sentry-trace', 'baggage'] }))
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+
+        const mockSet = jest.fn()
+        ;(global as any).fetch = jest.fn().mockResolvedValue({ ok: true })
+        ;(global as any).Headers = jest.fn().mockReturnValue({
+          has: jest.fn().mockReturnValue(false),
+          set: mockSet,
+        })
+
+        const authFetch = fetchWithAuth(
+          'test-key',
+          'https://myproject.supabase.co',
+          jest.fn().mockResolvedValue('test-token'),
+          undefined,
+          { enabled: true }
+        )
+        await authFetch('https://myproject.supabase.co/rest/v1/table')
+        await authFetch('https://myproject.supabase.co/rest/v1/table')
+
+        expect(mockSet).not.toHaveBeenCalledWith('traceparent', expect.anything())
+        expect(mockSet).not.toHaveBeenCalledWith('baggage', expect.anything())
+        expect(warnSpy).toHaveBeenCalledTimes(1)
+        expect(warnSpy.mock.calls[0][0]).toContain('sentry-trace')
+        expect(warnSpy.mock.calls[0][0]).toContain('propagateTraceparent: true')
+
+        warnSpy.mockRestore()
+      })
+
+      test('non-traceparent warning is generic when the propagator is not Sentry', async () => {
+        registerTraceContextExtractor(() => ({ carrierKeys: ['b3'] }))
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+
+        ;(global as any).fetch = jest.fn().mockResolvedValue({ ok: true })
+        ;(global as any).Headers = jest.fn().mockReturnValue({
+          has: jest.fn().mockReturnValue(false),
+          set: jest.fn(),
+        })
+
+        const authFetch = fetchWithAuth(
+          'test-key',
+          'https://myproject.supabase.co',
+          jest.fn().mockResolvedValue('test-token'),
+          undefined,
+          { enabled: true }
+        )
+        await authFetch('https://myproject.supabase.co/rest/v1/table')
+
+        expect(warnSpy).toHaveBeenCalledTimes(1)
+        expect(warnSpy.mock.calls[0][0]).toContain('b3')
+        expect(warnSpy.mock.calls[0][0]).not.toContain('Sentry')
+        expect(warnSpy.mock.calls[0][0]).toContain('W3C trace context')
+
+        warnSpy.mockRestore()
+      })
+
+      test('does not warn when there is no active trace', async () => {
+        // Empty carrier: the propagator had nothing to write. Normal — the
+        // warning must not fire for apps that simply have no span open.
+        registerTraceContextExtractor(() => null)
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+
+        ;(global as any).fetch = jest.fn().mockResolvedValue({ ok: true })
+        ;(global as any).Headers = jest.fn().mockReturnValue({
+          has: jest.fn().mockReturnValue(false),
+          set: jest.fn(),
+        })
+
+        const authFetch = fetchWithAuth(
+          'test-key',
+          'https://myproject.supabase.co',
+          jest.fn().mockResolvedValue('test-token'),
+          undefined,
+          { enabled: true }
+        )
+        await authFetch('https://myproject.supabase.co/rest/v1/table')
+
+        expect(warnSpy).not.toHaveBeenCalled()
 
         warnSpy.mockRestore()
       })

--- a/packages/shared/tracing/src/create-extractor.ts
+++ b/packages/shared/tracing/src/create-extractor.ts
@@ -18,16 +18,33 @@ export interface OtelApiLike {
 }
 
 /**
+ * Result of a trace context extraction attempt.
+ *
+ * Extends the W3C headers with diagnostic metadata: when a propagator is
+ * registered and wrote headers to the carrier but none of them is a W3C
+ * `traceparent`, `carrierKeys` lists the header *names* it wrote (never the
+ * values), so callers can explain why no trace headers will be attached —
+ * e.g. Sentry's propagator writes `sentry-trace` but omits `traceparent`
+ * unless `propagateTraceparent: true` is set.
+ */
+export interface TraceExtractionResult extends TraceContext {
+  carrierKeys?: string[]
+}
+
+/**
  * Reads the active trace context, or null when there is none.
  */
-export type TraceContextExtractor = () => TraceContext | null
+export type TraceContextExtractor = () => TraceExtractionResult | null
 
 /**
  * Build a {@link TraceContextExtractor} from an OpenTelemetry API object.
  *
  * The extractor injects the active context into a fresh carrier on every
- * call and returns the W3C trace headers found there, or null when there is
- * no active trace (no `traceparent`) or the API throws.
+ * call and returns the W3C trace headers found there. When there is no
+ * `traceparent`, it returns null for an empty carrier (no active trace) or
+ * a headerless result carrying only {@link TraceExtractionResult.carrierKeys}
+ * when the propagator wrote non-W3C headers. Returns null when the API
+ * throws.
  */
 export function createTraceContextExtractor(otel: OtelApiLike): TraceContextExtractor {
   return () => {
@@ -37,7 +54,11 @@ export function createTraceContextExtractor(otel: OtelApiLike): TraceContextExtr
 
       const traceparent = carrier['traceparent']
       if (!traceparent) {
-        return null
+        const carrierKeys = Object.keys(carrier)
+        if (carrierKeys.length === 0) {
+          return null
+        }
+        return { carrierKeys }
       }
 
       return {

--- a/packages/shared/tracing/test/create-extractor.test.ts
+++ b/packages/shared/tracing/test/create-extractor.test.ts
@@ -40,14 +40,23 @@ describe('createTraceContextExtractor', () => {
     expect(seen).toEqual([{ marker: 'active-context' }])
   })
 
-  it('returns null when no traceparent is injected', () => {
+  it('returns null when the carrier is empty (no active trace)', () => {
+    const extract = createTraceContextExtractor(fakeOtel(() => {}))
+
+    expect(extract()).toBeNull()
+  })
+
+  it('returns the carrier key names when headers are injected without a traceparent', () => {
     const extract = createTraceContextExtractor(
       fakeOtel((_context, carrier) => {
-        carrier['tracestate'] = 'vendor1=value1'
+        // A Sentry-like propagator: vendor headers, no W3C traceparent.
+        carrier['sentry-trace'] = '0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331'
+        carrier['baggage'] = 'sentry-public_key=abc'
       })
     )
 
-    expect(extract()).toBeNull()
+    // Key names only — header values must never leak into the result.
+    expect(extract()).toEqual({ carrierKeys: ['sentry-trace', 'baggage'] })
   })
 
   it('returns null when inject throws', () => {


### PR DESCRIPTION
## Description

Two fixes to the opt-in `tracePropagation` feature: a diagnostic warning when an active tracing SDK does not emit W3C trace context, and trace ID propagation for non-sampled requests so server logs stay correlatable.

### What changed?

- **Non-sampled requests now carry `traceparent`.** With `respectSamplingDecision: true` (the default), requests whose trace has the sampled flag `0` previously sent no trace headers at all. They now send only `traceparent`, with the flag preserved as `00`, so downstream tracing still records nothing. `tracestate` and `baggage` (the vendor and application data channels) are withheld on these requests. With `respectSamplingDecision: false`, the full context is sent regardless of sampling, as before.
- **One-time warning for non-W3C propagators.** The trace context extractor (`@supabase/tracing`) now distinguishes "no active trace" (empty carrier, stays silent) from "a propagator is active but did not write `traceparent`". In the latter case the SDK logs a single warning naming the header keys the propagator wrote. When `sentry-trace` is among them, the warning points at Sentry's `propagateTraceparent: true` option, which is off by default and is required for Sentry's OpenTelemetry propagator to emit W3C trace context.
- Updated the `respectSamplingDecision` JSDoc and README to the new semantics, and extended unit tests in both packages.

### Why was this change needed?

- At a typical 10% sampling rate, 90% of requests carried no `trace_id`, so the corresponding Supabase log entries could not be correlated with client traces. Log correlation is the primary purpose of the feature and does not require the trace to be recorded.
- Sentry's SDKs register their own OpenTelemetry propagator, which omits `traceparent` unless `propagateTraceparent: true` is set. Enabling `tracePropagation` in that setup silently attached no headers with no indication why. The failure mode was indistinguishable from having no active trace.

## Screenshots/Examples

Warning emitted when a Sentry propagator is active without W3C output:

```
@supabase/supabase-js: tracePropagation is enabled and a tracing SDK is active, but its propagator wrote [sentry-trace, baggage] and no W3C traceparent header, so trace headers will not be attached. Sentry detected: set `propagateTraceparent: true` in Sentry.init() to emit it.
```

Header behavior per request:

| Trace state | Before | After |
| --- | --- | --- |
| Sampled (`01`) | `traceparent`, `tracestate`, `baggage` | unchanged |
| Not sampled (`00`), default | none | `traceparent` only |
| Not sampled (`00`), `respectSamplingDecision: false` | all three | unchanged |
| Propagator without `traceparent` | none, silent | none, one-time warning |

## Breaking changes

- [x] This PR contains no breaking changes

No API or type signatures change. The `TraceContextExtractor` return type gains an optional diagnostic field; the addition is backward and forward compatible across package copies sharing the global extractor registry. The new `traceparent`-only behavior for non-sampled requests is a behavioral change to an opt-in feature, documented in the option's JSDoc and README.

## Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/supabase/supabase-js/blob/master/CONTRIBUTING.md)
- [x] My PR title follows the [conventional commit format](https://www.conventionalcommits.org/): `<type>(<scope>): <description>`
- [x] I have run `pnpm nx format` to ensure consistent code formatting
- [x] I have added tests for new functionality (if applicable)
- [x] I have updated documentation (if applicable)

## Additional notes

- The warning carries header key names only, never header values, so no trace or baggage content can leak into logs.
- The warning fires at most once per process, mirroring the existing missing-runtime warning, and only for requests targeting the configured Supabase domains.
- The extractor returns key names for any non-W3C propagator (B3, custom); the Sentry hint is appended only when `sentry-trace` is present, since other setups need different configuration.
- Verified against a production project that log ingestion stamps `trace_id` (and `span_id`) from an unsampled (`00` flag) `traceparent` identically to a sampled one, so the new traceparent-only behavior delivers log correlation as intended.
