### PR TITLE
fix(postgrest): move override fixtures out of generated types, repair codegen

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -465,11 +465,21 @@ jobs:
           REF: ${{ github.base_ref || github.ref_name }}
         run: |
           BASE_REF="${REF}"
-          git fetch origin "$BASE_REF" 2>/dev/null || true
+          # Fail closed. If the base cannot be fetched or diffed we must not fall through to
+          # "nothing changed" and skip the gate: a silently skipped codegen check is exactly how
+          # the drift this step guards against went unnoticed for months.
+          if ! git fetch origin "$BASE_REF"; then
+            echo "::error::Could not fetch origin/${BASE_REF}, so we cannot tell whether the generated types need checking."
+            exit 1
+          fi
+          if ! CHANGED_FILES=$(git diff --name-only "origin/${BASE_REF}...HEAD"); then
+            echo "::error::Could not diff against origin/${BASE_REF}, refusing to skip the codegen check."
+            exit 1
+          fi
           # types.generated.ts depends on the test schema AND on the pinned Supabase CLI version,
           # which selects the postgres-meta image that does the introspection. Watch both, or a
           # CLI bump silently changes the generated output with nothing to catch it.
-          if git diff --name-only "origin/${BASE_REF}...HEAD" 2>/dev/null \
+          if printf '%s\n' "$CHANGED_FILES" \
             | grep -qE '^packages/core/postgrest-js/test/supabase/|^package\.json$'; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -459,14 +459,18 @@ jobs:
                 name=$(echo "$img" | tr '/:' '_')
                 docker image save "$img" | zstd -T0 -3 -o "/tmp/supabase-docker-images/${name}.tar.zst"
               done
-      - name: Check if database schema changed
+      - name: Check if database schema or Supabase CLI version changed
         id: check_codegen
         env:
           REF: ${{ github.base_ref || github.ref_name }}
         run: |
           BASE_REF="${REF}"
           git fetch origin "$BASE_REF" 2>/dev/null || true
-          if git diff --name-only "origin/${BASE_REF}...HEAD" 2>/dev/null | grep -q "packages/core/postgrest-js/test/supabase/"; then
+          # types.generated.ts depends on the test schema AND on the pinned Supabase CLI version,
+          # which selects the postgres-meta image that does the introspection. Watch both, or a
+          # CLI bump silently changes the generated output with nothing to catch it.
+          if git diff --name-only "origin/${BASE_REF}...HEAD" 2>/dev/null \
+            | grep -qE '^packages/core/postgrest-js/test/supabase/|^package\.json$'; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "changed=false" >> "$GITHUB_OUTPUT"
@@ -477,7 +481,7 @@ jobs:
         timeout-minutes: 5
       - name: Skip codegen check
         if: steps.check_codegen.outputs.changed != 'true'
-        run: echo "⏭️  Skipping codegen check — no database schema changes detected"
+        run: echo "⏭️  Skipping codegen check — no test schema or Supabase CLI version changes detected"
       - name: Upload coverage for postgrest-js
         uses: coverallsapp/github-action@8d6379e14d29928660c4ba802d8e85393440b329 # v2.3.8
         with:

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -462,9 +462,19 @@ jobs:
       - name: Check if database schema or Supabase CLI version changed
         id: check_codegen
         env:
-          REF: ${{ github.base_ref || github.ref_name }}
+          BASE_REF: ${{ github.base_ref }}
         run: |
-          BASE_REF="${REF}"
+          # This is a pre-merge gate, so it only has a meaningful base to diff against on
+          # pull_request runs. publish.yml calls this same reusable workflow from a push to master
+          # (and from workflow_dispatch), where github.base_ref is empty and HEAD is already the
+          # branch tip. Skip explicitly there rather than relying on the diff coming back empty:
+          # the pull request that produced the commit already ran this check.
+          if [ -z "$BASE_REF" ]; then
+            echo "Not a pull request run (no base ref), so there is nothing to diff against."
+            echo "The codegen check already ran on the pull request for this commit."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           # Fail closed. If the base cannot be fetched or diffed we must not fall through to
           # "nothing changed" and skip the gate: a silently skipped codegen check is exactly how
           # the drift this step guards against went unnoticed for months.

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -466,7 +466,7 @@ jobs:
         run: |
           BASE_REF="${REF}"
           git fetch origin "$BASE_REF" 2>/dev/null || true
-          if git diff --name-only "origin/${BASE_REF}...HEAD" 2>/dev/null | grep -q "packages/core/postgrest-js/test/db/"; then
+          if git diff --name-only "origin/${BASE_REF}...HEAD" 2>/dev/null | grep -q "packages/core/postgrest-js/test/supabase/"; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "changed=false" >> "$GITHUB_OUTPUT"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "codegen": "node scripts/sync-common-types.js",
     "codegen:check": "node scripts/sync-common-types.js && git diff --exit-code packages/core/supabase-js/src/lib/rest/types/common && echo '\n✅ Generated types are in sync!' || (echo '\n❌ Generated types are out of sync.\n   Run: pnpm codegen\n   Then commit the changes.\n' && exit 1)",
     "codegen:postgrest": "node scripts/generate-postgrest-types.js",
-    "codegen:check:postgrest": "node scripts/generate-postgrest-types.js && git diff --exit-code packages/core/postgrest-js/test/types.generated.ts && echo '\n✅ Postgrest generated types are in sync!' || (echo '\n❌ Postgrest generated types are out of sync.\n   Run: pnpm codegen:postgrest\n   Then commit the changes.\n' && exit 1)",
+    "codegen:check:postgrest": "node scripts/generate-postgrest-types.js || { echo '\n❌ Type generation itself failed — see the error above. This is NOT a drift failure; re-running codegen will not help.\n'; exit 1; }; git diff --exit-code packages/core/postgrest-js/test/types.generated.ts && echo '\n✅ Postgrest generated types are in sync!' || { echo '\n❌ Postgrest generated types are out of sync.\n   Run: pnpm codegen:postgrest\n   Then commit the changes.\n'; exit 1; }",
     "release-canary": "pnpm exec tsx scripts/release-canary.ts",
     "release-beta": "pnpm exec tsx scripts/release-beta.ts",
     "release-stable": "pnpm exec tsx scripts/release-stable.ts"

--- a/packages/core/postgrest-js/test/embeded_functions_join.test.ts
+++ b/packages/core/postgrest-js/test/embeded_functions_join.test.ts
@@ -1434,9 +1434,14 @@ describe('embeded functions select', () => {
     >(true)
   })
 
-  test('scalar_computed_count - non-SETOF non-nullable scalar returns number (not null)', async () => {
-    const res = await postgrest.from('users').select('username, scalar_computed_count()')
-    let result: Exclude<typeof res.data, null>
+  // The two tests below are type-only. They cover the scalar computed field contract declared by
+  // hand in types.override.ts — PostgREST does not expose scalar computed fields in its schema
+  // cache, so pg-meta cannot emit these entries and there is no live function to call. The query
+  // builder is deliberately left un-awaited: it is lazy (PostgrestBuilder only fetches in then()),
+  // so no request is made, and the assertions read the resolved type via Awaited<>.
+  test('scalar_computed_count - non-SETOF non-nullable scalar returns number (not null)', () => {
+    const query = postgrest.from('users').select('username, scalar_computed_count()')
+    let result: Exclude<Awaited<typeof query>['data'], null>
     const ExpectedSchema = z.array(
       z.object({
         username: z.string(),
@@ -1447,9 +1452,9 @@ describe('embeded functions select', () => {
     expectType<TypeEqual<typeof result, typeof expected>>(true)
   })
 
-  test('scalar_computed_ids - SETOF scalar returns string[] (not null)', async () => {
-    const res = await postgrest.from('users').select('username, scalar_computed_ids()')
-    let result: Exclude<typeof res.data, null>
+  test('scalar_computed_ids - SETOF scalar returns string[] (not null)', () => {
+    const query = postgrest.from('users').select('username, scalar_computed_ids()')
+    let result: Exclude<Awaited<typeof query>['data'], null>
     const ExpectedSchema = z.array(
       z.object({
         username: z.string(),

--- a/packages/core/postgrest-js/test/rpc.test.ts
+++ b/packages/core/postgrest-js/test/rpc.test.ts
@@ -248,7 +248,9 @@ test('RPC call with field aggregate', async () => {
 })
 
 test('RPC call with bigint param is accepted by a bigint Postgres argument', async () => {
-  const res = await postgrest.rpc('echo_bigint_as_text' as any, { bigint_param: BIGINT_PARAM } as any)
+  // The args cast is deliberate: pg-meta types a Postgres bigint column as `number`, and this test
+  // exercises passing a JS bigint through to it. Only the function name no longer needs casting.
+  const res = await postgrest.rpc('echo_bigint_as_text', { bigint_param: BIGINT_PARAM } as any)
 
   expect(res).toMatchInlineSnapshot(`
     {
@@ -263,10 +265,9 @@ test('RPC call with bigint param is accepted by a bigint Postgres argument', asy
 })
 
 test('RPC call with bigint nested in jsonb param is serialized as a JSON string', async () => {
-  const res = await postgrest.rpc(
-    'extract_jsonb_bigint_as_text' as any,
-    { payload: { id: BIGINT_PARAM } } as any
-  )
+  const res = await postgrest.rpc('extract_jsonb_bigint_as_text', {
+    payload: { id: BIGINT_PARAM },
+  })
 
   expect(res).toMatchInlineSnapshot(`
     {

--- a/packages/core/postgrest-js/test/types.generated.ts
+++ b/packages/core/postgrest-js/test/types.generated.ts
@@ -723,6 +723,8 @@ export type Database = {
           error: true
         } & 'the function public.days_since_event with parameter or with a single unnamed json/jsonb parameter, but no matches were found in the schema cache'
       }
+      echo_bigint_as_text: { Args: { bigint_param: number }; Returns: string }
+      extract_jsonb_bigint_as_text: { Args: { payload: Json }; Returns: string }
       function_returning_row: {
         Args: never
         Returns: {
@@ -752,25 +754,6 @@ export type Database = {
           from: '*'
           to: 'users'
           isOneToOne: false
-          isSetofReturn: true
-        }
-      }
-      scalar_computed_count: {
-        Args: { '': Database['public']['Tables']['users']['Row'] }
-        Returns: number
-        SetofOptions: {
-          from: 'users'
-          to: ''
-          isSetofReturn: false
-          isNotNullable: true
-        }
-      }
-      scalar_computed_ids: {
-        Args: { '': Database['public']['Tables']['users']['Row'] }
-        Returns: string[]
-        SetofOptions: {
-          from: 'users'
-          to: ''
           isSetofReturn: true
         }
       }

--- a/packages/core/postgrest-js/test/types.override.ts
+++ b/packages/core/postgrest-js/test/types.override.ts
@@ -62,7 +62,32 @@ export type Database = MergeDeep<
           }
         }
       }
-      Functions: {}
+      Functions: {
+        // Hand-written fixtures: these functions do not exist in the test schema, and
+        // `isNotNullable` is an override-only contract that pg-meta never emits (it
+        // cannot prove non-nullability — PostgREST may still return null at runtime).
+        // They live here rather than in types.generated.ts so `pnpm codegen:postgrest`
+        // does not wipe them.
+        scalar_computed_count: {
+          Args: { '': GeneratedDatabase['public']['Tables']['users']['Row'] }
+          Returns: number
+          SetofOptions: {
+            from: 'users'
+            to: ''
+            isSetofReturn: false
+            isNotNullable: true
+          }
+        }
+        scalar_computed_ids: {
+          Args: { '': GeneratedDatabase['public']['Tables']['users']['Row'] }
+          Returns: string[]
+          SetofOptions: {
+            from: 'users'
+            to: ''
+            isSetofReturn: true
+          }
+        }
+      }
       Views: {}
       Enums: {}
       CompositeTypes: {}

--- a/scripts/generate-postgrest-types.js
+++ b/scripts/generate-postgrest-types.js
@@ -43,18 +43,19 @@ function main() {
 
   // Clean up any existing containers
   console.log('🧹 Cleaning up existing containers...')
-  // When running `pnpm exec` with workspaces enabled, the cwd is changed to the directory of the package.json file.
-  // So we need to pass the workdir relative to the package.json file to supabase cli.
-  execAllowFail(`pnpm exec supabase --workdir ${TEST_DIR_NAME} stop --no-backup`, { cwd: TEST_DIR })
+  // Pass an absolute workdir to the supabase cli: `pnpm exec` no longer rewrites the cwd to the
+  // nearest package.json directory (it did before pnpm 11), so a relative `--workdir test` would
+  // resolve against whatever cwd we are handed and chdir into `test/test`.
+  execAllowFail(`pnpm exec supabase --workdir ${TEST_DIR} stop --no-backup`, { cwd: TEST_DIR })
 
   // Start Supabase (blocks until ready)
   console.log('📦 Starting Supabase...')
-  exec(`pnpm exec supabase --workdir ${TEST_DIR_NAME} start`, { cwd: TEST_DIR })
+  exec(`pnpm exec supabase --workdir ${TEST_DIR} start`, { cwd: TEST_DIR })
 
   // Generate types from database using Supabase CLI
   console.log('🔧 Generating types from database...')
   exec(
-    `pnpm exec supabase --workdir ${TEST_DIR_NAME} gen types typescript --local --schema public,personal > ${OUTPUT_FILE}`,
+    `pnpm exec supabase --workdir ${TEST_DIR} gen types typescript --local --schema public,personal > ${OUTPUT_FILE}`,
     {
       cwd: TEST_DIR,
       shell: true,
@@ -71,7 +72,7 @@ function main() {
 
   // Clean up Supabase containers
   console.log('🧹 Cleaning up Supabase...')
-  execAllowFail(`pnpm exec supabase --workdir ${TEST_DIR_NAME} stop --no-backup`, { cwd: TEST_DIR })
+  execAllowFail(`pnpm exec supabase --workdir ${TEST_DIR} stop --no-backup`, { cwd: TEST_DIR })
 
   console.log('\n✅ Type generation complete!')
   console.log(`   Output: ${OUTPUT_FILE}`)


### PR DESCRIPTION
Moves the hand-written `scalar_computed_*` fixtures out of the machine-generated `types.generated.ts` into `types.override.ts` and regenerates the file, which also picks up `echo_bigint_as_text` and `extract_jsonb_bigint_as_text` (added to the test schema in #2245 but never regenerated). Repairs `codegen:postgrest`, which had been failing for everyone since pnpm 11 stopped rewriting the cwd to the nearest package directory: the relative `--workdir test` resolved to `test/test`, so every run died with `chdir test: no such file or directory`, locally and in CI alike.

Re-enables the codegen sync check, which was gated on `packages/core/postgrest-js/test/db/`, a path deleted when the tests moved to the Supabase CLI, so it never ran on any PR. It now watches `test/supabase/` plus the root `package.json`, since the pinned CLI version selects the postgres-meta image that performs the introspection. Also converts the two scalar computed field tests to type-only assertions (they were awaiting a request to a function that does not exist, then never asserting on the response) and drops the function-name `as any` casts in `rpc.test.ts` that the regenerated types make unnecessary.

Verified with two consecutive regens producing byte-identical output, so the `git diff --exit-code` gate is stable rather than flaky, plus tstyche at 29/29 files and the postgrest-js integration suite at 350 passing tests.