### PR TITLE
ci: pin supabase/sdk reusable workflows to v1.0.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
+      interval: daily
     open-pull-requests-limit: 5
     commit-message:
       prefix: chore

--- a/.github/workflows/sync-compliance.yml
+++ b/.github/workflows/sync-compliance.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: supabase/sdk/.github/workflows/sync-sdk-compliance.yml@faba359a57d270bbbf68fd6b583db0604ddce8af
+    uses: supabase/sdk/.github/workflows/sync-sdk-compliance.yml@93b52588ffda761e61b22cebfc3e5e29aa3cb3f4 # v1.0.0
     with:
       base-branch: master
     secrets:

--- a/.github/workflows/validate-capabilities.yml
+++ b/.github/workflows/validate-capabilities.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   validate:
-    uses: supabase/sdk/.github/workflows/validate-sdk-compliance-javascript.yml@main
+    uses: supabase/sdk/.github/workflows/validate-sdk-compliance-javascript.yml@93b52588ffda761e61b22cebfc3e5e29aa3cb3f4 # v1.0.0
     with:
       build-command: |
         corepack enable


### PR DESCRIPTION
## Summary
- supabase/sdk cut its first tagged release, v1.0.0 (github.com/supabase/sdk/releases/tag/v1.0.0).
- Pins `sync-compliance.yml` and `validate-capabilities.yml`'s `uses:` refs to that release's commit SHA with a `# v1.0.0` comment, instead of a floating `@main` ref (validate-capabilities) or an unlabeled SHA (sync-compliance).
- Dependabot's `github-actions` ecosystem (already configured in `.github/dependabot.yml`) recognizes the version comment and will open PRs here as supabase/sdk cuts new releases, so this stays current automatically.

## Test plan
- [ ] Merge this PR
- [ ] Confirm `SDK Compliance` and `Sync SDK Compliance Matrix` workflows still run successfully against the pinned ref
- [ ] Confirm Dependabot picks up a future supabase/sdk release and opens a bump PR