### PR TITLE
fix(realtime): respect custom logger for send() REST fallback warning

### DIFF
--- a/packages/core/realtime-js/src/RealtimeChannel.ts
+++ b/packages/core/realtime-js/src/RealtimeChannel.ts
@@ -1017,11 +1017,16 @@ export default class RealtimeChannel {
     opts: { [key: string]: any } = {}
   ): Promise<RealtimeChannelSendResponse> {
     if (!this.channelAdapter.canPush() && args.type === 'broadcast') {
-      console.warn(
+      const fallbackWarning =
         'Realtime send() is automatically falling back to REST API. ' +
-          'This behavior will be deprecated in the future. ' +
-          'Please use httpSend() explicitly for REST delivery.'
-      )
+        'This behavior will be deprecated in the future. ' +
+        'Please use httpSend() explicitly for REST delivery.'
+
+      if (this.socket.hasLogger()) {
+        this.socket.log('channel', fallbackWarning)
+      } else {
+        console.warn(fallbackWarning)
+      }
 
       const { event, payload: endpoint_payload } = args
       const headers: Record<string, string> = {

--- a/packages/core/realtime-js/src/RealtimeClient.ts
+++ b/packages/core/realtime-js/src/RealtimeClient.ts
@@ -406,6 +406,15 @@ export default class RealtimeClient {
   }
 
   /**
+   * Returns true if a custom `logger` has been configured on this client.
+   *
+   * @category Realtime
+   */
+  hasLogger(): boolean {
+    return this.socketAdapter.hasLogger()
+  }
+
+  /**
    * Returns the current state of the socket.
    *
    * @category Realtime

--- a/packages/core/realtime-js/src/phoenix/socketAdapter.ts
+++ b/packages/core/realtime-js/src/phoenix/socketAdapter.ts
@@ -114,6 +114,10 @@ export default class SocketAdapter {
     this.socket.log(kind, msg, data)
   }
 
+  hasLogger(): boolean {
+    return this.socket.hasLogger()
+  }
+
   makeRef(): string {
     return this.socket.makeRef()
   }

--- a/packages/core/realtime-js/test/RealtimeChannel.messaging.test.ts
+++ b/packages/core/realtime-js/test/RealtimeChannel.messaging.test.ts
@@ -343,6 +343,10 @@ describe('send', () => {
   })
 
   describe('HTTP fallback scenarios', () => {
+    afterEach(() => {
+      testSetup.cleanup()
+    })
+
     test.each([
       {
         description: 'without access token',
@@ -403,6 +407,51 @@ describe('send', () => {
         expect(fetchStub).toHaveBeenCalledWith(expectedUrl, expectedBody)
       }
     )
+
+    test('warns via console.warn when no custom logger is configured', async () => {
+      const fetchStub = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        body: { cancel: vi.fn() },
+      })
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      testSetup = setupRealtimeTest({ fetch: fetchStub as unknown as typeof fetch })
+      const channel = testSetup.client.channel('topic', { config: { private: true } })
+
+      await channel.send({ type: 'broadcast', event: 'test' })
+
+      expect(warnSpy).toHaveBeenCalledTimes(1)
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('httpSend()'))
+
+      warnSpy.mockRestore()
+    })
+
+    test('routes the fallback warning through a custom logger instead of console.warn', async () => {
+      const fetchStub = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        body: { cancel: vi.fn() },
+      })
+      const loggerStub = vi.fn()
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      testSetup = setupRealtimeTest({
+        fetch: fetchStub as unknown as typeof fetch,
+        logger: loggerStub,
+      })
+      const channel = testSetup.client.channel('topic', { config: { private: true } })
+
+      await channel.send({ type: 'broadcast', event: 'test' })
+
+      expect(loggerStub).toHaveBeenCalledTimes(1)
+      const [kind, message] = loggerStub.mock.calls[0]
+      expect(kind).toBe('channel')
+      expect(message).toContain('httpSend()')
+      expect(warnSpy).not.toHaveBeenCalled()
+
+      warnSpy.mockRestore()
+    })
   })
 
   describe('Error handling scenarios', () => {

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -856,6 +856,8 @@ features:
     status: implemented
     symbols:
       - RealtimeClientOptions
+    supporting_symbols:
+      - RealtimeClient.hasLogger
   realtime.configuration.custom_websocket_transport:
     status: implemented
     symbols:


### PR DESCRIPTION
Closes https://github.com/supabase/supabase-js/issues/2611.

The REST fallback warning in `RealtimeChannel.send()` was a hardcoded `console.warn()`, so it always printed and couldn't be disabled or redirected even if a custom `logger` was configured on the client. This routes the warning through the client's existing logging mechanism when a custom logger is set, falling back to the original `console.warn()` otherwise, so default behavior is unchanged for everyone who hasn't configured a logger.