### PR TITLE
fix(realtime): refresh the access token before reconnecting, not only when a refresh is already in flight

### DIFF
--- a/packages/core/realtime-js/src/RealtimeClient.ts
+++ b/packages/core/realtime-js/src/RealtimeClient.ts
@@ -869,6 +869,21 @@ export default class RealtimeClient {
   /** @internal */
   private async _reconnectAuth() {
     await this._waitForAuthIfNeeded()
+    // `_waitForAuthIfNeeded()` only awaits a refresh that is *already* in flight, so
+    // when nothing is pending it falls straight through and the rejoin goes out with
+    // whatever `accessTokenValue` was cached before the socket dropped. That is the
+    // common case after a tab has been hidden: `auth-js` stops its refresh ticker
+    // while hidden, so the token is refreshed on wake and the reconnect races it.
+    if (!this._isManualToken()) {
+      try {
+        await this.setAuth()
+      } catch (e) {
+        // A failed refresh must not prevent the reconnect: reconnecting with a stale
+        // token still recovers (the heartbeat refresh takes over), whereas not
+        // reconnecting at all does not.
+        this.log('error', 'Error refreshing auth before reconnect', e)
+      }
+    }
     if (!this.isConnected()) {
       this.connect()
     }


### PR DESCRIPTION
> **Context:** full analysis, production data and a runnable repro in #2613.
> **Companion PR:** supabase/phoenix#51 (the other half — that repo's `visibilitychange` path never calls `beforeReconnect`, so this file never gets a chance to run there).

## 🔍 Description

`RealtimeClient._reconnectAuth` — the `beforeReconnect` hook the socket runs before re-establishing a connection — only awaits an auth call that is *already* in flight. When none is, it reconnects immediately and channels rejoin with the cached `accessTokenValue`, which can be an expired JWT.

### What changed?

`_reconnectAuth` now performs an awaited refresh before reconnecting:

```ts
private async _reconnectAuth() {
  await this._waitForAuthIfNeeded()
  if (!this._isManualToken()) {
    try {
      await this.setAuth()
    } catch (e) {
      this.log('error', 'Error refreshing auth before reconnect', e)
    }
  }
  if (!this.isConnected()) {
    this.connect()
  }
}
```

The `!this._isManualToken()` condition mirrors `_setAuthSafely`, so this refreshes under the same rule as the heartbeat refresh and the connect-time refresh. Since #2592, `_manuallySetToken` is `false` for every `supabase-js` client (the `accessToken` callback is always configured), so the guard only excludes standalone `RealtimeClient` users who set a manual token and have no callback to refresh from.

Plus one regression test in `RealtimeClient.auth.test.ts`.

### Why was this change needed?

`_waitForAuthIfNeeded()` is a no-op unless `_authPromise` is set. `connect()` does start a refresh (`_setAuthSafely('connect')`), but deliberately does not await it — so the WebSocket handshake races the token fetch and normally wins. `_performAuth` writes `accessTokenValue` and calls `updateJoinPayload` only after `await this.accessToken()` resolves, so the rejoin goes out with the previous token.

The existing test `uses new token after reconnect` does not catch this: it asserts the token *eventually* becomes fresh, which it does — after the join has already been sent with the old one.

Reproduction (standalone Node, no project, no server, ~2 s): [link to repro]. Measured against the published `@supabase/realtime-js@2.111.0` / `@supabase/phoenix@0.4.5`:

| scenario | before | after this PR |
|---|---|---|
| `reconnectTimer` reconnect, no auth call in flight | rejoins with the **stale** token | rejoins with the **fresh** token |
| `visibilitychange` reconnect, no auth call in flight | rejoins with the **stale** token | still stale — needs supabase/phoenix#51 |

The second row is the companion fix: `@supabase/phoenix`'s `visibilitychange` reconnect path never calls `beforeReconnect`, so nothing in this file gets a chance to run there. See supabase/phoenix#51 and the umbrella issue supabase/supabase-js#2613. This PR is useful on its own for the first row, which is the ordinary network-drop reconnect.

Context: we saw 282 `InvalidJWTToken: Token has expired` channel errors across 65 users over 17 days on a self-hosted deployment. Of the 262 events still inside the retention window — all of which kept breadcrumbs, so this is a census rather than a sample — **244 (93.1 %)** had a **successful** token refresh complete before the channel error, at a median gap of **5.0 s**. The fresh token existed and was not carried into the join.

Related: #1732 (closed as `not_planned` by the stale bot while still labelled `repro needed`) describes the same symptom for offline/standby.

## 🔄 Breaking changes

- [x] This PR contains no breaking changes

## 📋 Checklist

- [x] I have read the Contributing Guidelines
- [x] My PR title follows the conventional commit format
- [x] I have run `pnpm nx format`
- [x] I have added tests for new functionality
- [ ] I have updated documentation — not applicable, `_reconnectAuth` is `@internal`

## 📝 Additional notes

Two things we would rather you decide than have us guess:

1. **Bounding the wait — which side owns it.** `try/catch` handles a rejecting `accessToken()` callback (`_performAuth` already falls back to the cached value), but not one that never settles: there is no `AbortSignal` or timeout anywhere in `_reconnectAuth → setAuth → _performAuth → accessToken()`. On the scenario this fixes (a laptop waking with the network not yet usable) that is realistic, and measured against the published packages the result is not a delay but a socket that never reconnects — on that wake or any later one, because `setAuth()` clears `_authPromise` only in a `finally` and every subsequent `_reconnectAuth` then awaits the same hung promise. The companion phoenix PR bounds its own call site with the socket's existing `this.timeout`; because this package pins `@supabase/phoenix` to exactly `0.4.5`, that does not protect users here until the pin moves. So we are happy to add `await Promise.race([this.setAuth(), …])` in this file too — tell us if you want it in this PR.
2. **One extra callback invocation per reconnect.** After the awaited `setAuth()`, `_authPromise` is null again, so `connect()`'s own `_setAuthSafely('connect')` fires as well — measured 2 → 3 `accessToken()` calls per reconnect. Harmless for `supabase-js` (`auth.getSession()` is cached), potentially not for a user callback that always hits the network. De-duplicating means a short-circuit inside `connect()`, which we left alone on purpose. Happy to add it.
