### PR TITLE
fix(auth): convert stolen lock AbortError when acquireTimeout is 0

### DIFF
--- a/packages/core/auth-js/src/lib/locks.ts
+++ b/packages/core/auth-js/src/lib/locks.ts
@@ -200,8 +200,7 @@ export async function navigatorLock<R>(
       e !== null &&
       typeof e === 'object' &&
       'name' in e &&
-      e.name === 'AbortError' &&
-      acquireTimeout > 0
+      e.name === 'AbortError' // <--- Fixed!
     ) {
       if (abortController.signal.aborted) {
         // OUR timeout fired — the lock is genuinely orphaned. Steal it.


### PR DESCRIPTION
## 🔍 Description

### What changed?
Removed the `acquireTimeout > 0` condition inside the `AbortError` catch/check block within `navigatorLock` (`packages/core/auth-js/src/lib/locks.ts`).

### Why was this change needed?
When `acquireTimeout` is set to `0` (such as in `_autoRefreshTokenTick`), stolen Web Locks produce an `AbortError`. Previously, because `acquireTimeout > 0` was required to process the `AbortError`, stolen locks bypassed error handling when `acquireTimeout` was `0`. This caused unhandled raw `AbortError` exceptions to leak to client application error trackers (e.g., Sentry) instead of properly resolving or throwing a structured `NavigatorLockAcquireTimeoutError`.

### How was it tested?
- Tested locally using unit tests for lock mechanisms: `npx nx test auth-js -- test/lib/locks.test.ts`
- Verified all lock tests pass (`locks.test.ts`).
- Ran `npx nx format:write` to ensure code style compliance.

Closes supabase/supabase-js#2620