### PR TITLE
test(realtime): mock fetch in WebSocket send scenarios to avoid real network call

### DIFF
--- a/packages/core/realtime-js/test/RealtimeChannel.messaging.test.ts
+++ b/packages/core/realtime-js/test/RealtimeChannel.messaging.test.ts
@@ -294,7 +294,13 @@ describe('trigger', () => {
 describe('send', () => {
   describe('WebSocket connection scenarios', () => {
     beforeEach(async () => {
-      testSetup = setupRealtimeTest()
+      const fetchStub = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        body: { cancel: vi.fn() },
+      })
+
+      testSetup = setupRealtimeTest({ fetch: fetchStub as unknown as typeof fetch })
       testSetup.connect()
       await testSetup.socketConnected()
     })


### PR DESCRIPTION
## Description

Test-only fix in `packages/core/realtime-js/test/RealtimeChannel.messaging.test.ts`.

The test `cannot send via ws conn when subscription times out` (inside `describe('send') > describe('WebSocket connection scenarios')`) sets `channel.state = 'closed'` and calls `send({ type: 'broadcast', event: 'test' })`. Since `!canPush() && type === 'broadcast'`, `RealtimeChannel.send()` takes the REST-fallback path and calls `_fetchWithTimeout` against `broadcastEndpointURL`, which is derived from a random UUID host used by the test's mock-socket setup. That describe block never mocked `fetch` (unlike the sibling `HTTP fallback scenarios` block later in the same file), so the call hit the real global `fetch` and tried to resolve/connect to a bogus hostname.

In at least one sandboxed CI-like environment this reliably hung for ~83s before vitest's 5000ms test timeout fired, reporting the test as failed — even though the test body itself is synchronous. This added ~85s of dead time to every `nx test realtime-js` run.

## Type of Change

- [x] Bug fix (fix) — test-only, no production code changed
- [ ] New feature (feat)
- [ ] Breaking change (feat! or fix!)
- [ ] Documentation update (docs)
- [ ] Other (chore, refactor, etc.)

## Fix

Mock `fetch` in the `WebSocket connection scenarios` describe block's `beforeEach`, matching the pattern already used in the `HTTP fallback scenarios` describe block in the same file. The underlying REST-fallback behavior is intentional and unchanged, and already covered/mocked elsewhere in this file.

## Testing

- [x] Unit tests added/updated (existing test now deterministic, no new test needed)
- [ ] Integration tests added/updated (not applicable — test-only change)
- [x] All tests passing locally: `nx test realtime-js` → 465 passed, 1 skipped, total test duration 4.29s (previously the affected test alone hung ~83s)

## Checklist

- [x] Code formatted (`nx format`)
- [x] Tests passing
- [x] Builds passing (no source changes)
- [x] Used conventional commit format
- [ ] Documentation updated (not needed — test-only change)