### PR TITLE
fix(functions): honour an already-aborted signal when timeout is set

### DIFF
--- a/packages/core/functions-js/src/FunctionsClient.ts
+++ b/packages/core/functions-js/src/FunctionsClient.ts
@@ -272,10 +272,17 @@ export class FunctionsClient {
         // If user provided their own signal, we need to respect both
         if (signal) {
           effectiveSignal = timeoutController.signal
-          // If the user's signal is aborted, abort our timeout controller too.
-          // Store the listener so we can clean it up in finally.
-          onAbort = () => timeoutController!.abort()
-          signal.addEventListener('abort', onAbort)
+          if (signal.aborted) {
+            // A signal that was already aborted never fires another `abort`
+            // event, so mirror its state onto the timeout controller up front —
+            // otherwise the request would go out despite being cancelled.
+            timeoutController.abort(signal.reason)
+          } else {
+            // If the user's signal is aborted, abort our timeout controller too.
+            // Store the listener so we can clean it up in finally.
+            onAbort = () => timeoutController!.abort(signal.reason)
+            signal.addEventListener('abort', onAbort)
+          }
         } else {
           effectiveSignal = timeoutController.signal
         }

--- a/packages/core/functions-js/test/FunctionsClient.test.ts
+++ b/packages/core/functions-js/test/FunctionsClient.test.ts
@@ -1,4 +1,4 @@
-import { FunctionsClient } from '../src/index'
+import { FunctionsClient, FunctionsFetchError } from '../src/index'
 
 describe('FunctionsClient', () => {
   describe('invoke – abort listener cleanup when timeout + signal are both set', () => {
@@ -45,6 +45,50 @@ describe('FunctionsClient', () => {
 
       expect(addedFn).toBeDefined()
       expect(addedFn).toBe(removedFn)
+    })
+  })
+
+  describe('invoke – caller signal already aborted when timeout is also set', () => {
+    // Mirrors the platform contract: fetch rejects with the signal's reason
+    // instead of issuing a request when the signal is already aborted.
+    const abortAwareFetch = () =>
+      jest.fn().mockImplementation((_url: string, init?: RequestInit) => {
+        if (init?.signal?.aborted) {
+          return Promise.reject(init.signal.reason)
+        }
+        return Promise.resolve({
+          ok: true,
+          headers: { get: () => 'application/json' },
+          json: () => Promise.resolve({ ok: true }),
+        })
+      })
+
+    it('does not let the request reach the function', async () => {
+      const mockFetch = abortAwareFetch()
+      const client = new FunctionsClient('http://localhost', { customFetch: mockFetch })
+      const controller = new AbortController()
+      controller.abort()
+
+      const { data, error } = await client.invoke('test-fn', {
+        timeout: 5000,
+        signal: controller.signal,
+      })
+
+      expect(data).toBeNull()
+      expect(error).toBeInstanceOf(FunctionsFetchError)
+      expect(mockFetch.mock.calls[0][1]?.signal?.aborted).toBe(true)
+    })
+
+    it('forwards the caller abort reason', async () => {
+      const mockFetch = abortAwareFetch()
+      const client = new FunctionsClient('http://localhost', { customFetch: mockFetch })
+      const controller = new AbortController()
+      const reason = new Error('caller cancelled')
+      controller.abort(reason)
+
+      await client.invoke('test-fn', { timeout: 5000, signal: controller.signal })
+
+      expect(mockFetch.mock.calls[0][1]?.signal?.reason).toBe(reason)
     })
   })
 })

--- a/packages/core/functions-js/test/FunctionsClient.test.ts
+++ b/packages/core/functions-js/test/FunctionsClient.test.ts
@@ -50,21 +50,27 @@ describe('FunctionsClient', () => {
 
   describe('invoke – caller signal already aborted when timeout is also set', () => {
     // Mirrors the platform contract: fetch rejects with the signal's reason
-    // instead of issuing a request when the signal is already aborted.
-    const abortAwareFetch = () =>
-      jest.fn().mockImplementation((_url: string, init?: RequestInit) => {
+    // instead of issuing a request when the signal is already aborted. `reached`
+    // stands in for the hit counter on the repro's local server: it only counts
+    // requests that would actually have run the Edge Function.
+    const abortAwareFetch = () => {
+      const server = { reached: 0 }
+      const fetch = jest.fn().mockImplementation((_url: string, init?: RequestInit) => {
         if (init?.signal?.aborted) {
           return Promise.reject(init.signal.reason)
         }
+        server.reached++
         return Promise.resolve({
           ok: true,
           headers: { get: () => 'application/json' },
           json: () => Promise.resolve({ ok: true }),
         })
       })
+      return { fetch, server }
+    }
 
     it('does not let the request reach the function', async () => {
-      const mockFetch = abortAwareFetch()
+      const { fetch: mockFetch, server } = abortAwareFetch()
       const client = new FunctionsClient('http://localhost', { customFetch: mockFetch })
       const controller = new AbortController()
       controller.abort()
@@ -77,10 +83,11 @@ describe('FunctionsClient', () => {
       expect(data).toBeNull()
       expect(error).toBeInstanceOf(FunctionsFetchError)
       expect(mockFetch.mock.calls[0][1]?.signal?.aborted).toBe(true)
+      expect(server.reached).toBe(0)
     })
 
     it('forwards the caller abort reason', async () => {
-      const mockFetch = abortAwareFetch()
+      const { fetch: mockFetch } = abortAwareFetch()
       const client = new FunctionsClient('http://localhost', { customFetch: mockFetch })
       const controller = new AbortController()
       const reason = new Error('caller cancelled')
@@ -89,6 +96,42 @@ describe('FunctionsClient', () => {
       await client.invoke('test-fn', { timeout: 5000, signal: controller.signal })
 
       expect(mockFetch.mock.calls[0][1]?.signal?.reason).toBe(reason)
+    })
+  })
+
+  describe('invoke – caller signal aborts while the request is in flight', () => {
+    // The listener path, unlike the guard above, was never broken — this pins the
+    // behaviour down so a future change to the guard cannot silently drop it.
+    it('aborts the in-flight request and forwards the caller reason', async () => {
+      let inFlightSignal: AbortSignal | undefined
+      let markRequestStarted!: () => void
+      const requestStarted = new Promise<void>((resolve) => {
+        markRequestStarted = resolve
+      })
+
+      const mockFetch = jest.fn().mockImplementation(
+        (_url: string, init?: RequestInit) =>
+          new Promise((_resolve, reject) => {
+            inFlightSignal = init?.signal ?? undefined
+            init?.signal?.addEventListener('abort', () => reject(init.signal!.reason))
+            markRequestStarted()
+          })
+      )
+
+      const client = new FunctionsClient('http://localhost', { customFetch: mockFetch })
+      const controller = new AbortController()
+      const reason = new Error('caller cancelled mid-flight')
+
+      const pending = client.invoke('test-fn', { timeout: 5000, signal: controller.signal })
+      await requestStarted
+      controller.abort(reason)
+
+      const { data, error } = await pending
+
+      expect(data).toBeNull()
+      expect(error).toBeInstanceOf(FunctionsFetchError)
+      expect(inFlightSignal?.aborted).toBe(true)
+      expect(inFlightSignal?.reason).toBe(reason)
     })
   })
 })


### PR DESCRIPTION
<!-- <type>(<scope>): <description> -->

## 🔍 Description

### What changed?

`FunctionsClient.invoke()` bridges a caller-supplied `signal` onto its internal timeout `AbortController` with an `abort` listener:

```ts
onAbort = () => timeoutController!.abort()
signal.addEventListener('abort', onAbort)
```

An `AbortSignal` that is **already aborted** never dispatches another `abort` event, so that listener never fires. `fetch` then receives the fresh, un-aborted `timeoutController.signal` and the request goes out — the Edge Function runs, and `invoke()` resolves with its response as if nothing had been cancelled.

This PR mirrors the aborted state onto the timeout controller up front, and forwards `signal.reason` in both branches:

```ts
if (signal.aborted) {
  timeoutController.abort(signal.reason)
} else {
  onAbort = () => timeoutController!.abort(signal.reason)
  signal.addEventListener('abort', onAbort)
}
```

### Why was this change needed?

Passing `timeout` silently disabled pre-flight cancellation. The **same call without `timeout` already behaves correctly** (`effectiveSignal = signal`, and `fetch` rejects without issuing a request), so the two paths disagreed — this restores consistency rather than introducing new behaviour.

This is the ordinary "cancel in-flight work" pattern: a React `useEffect` cleanup controller, `AbortSignal.timeout(...)`, or one request-scoped controller shared across a batch. Whenever the controller is aborted before control reaches `invoke()` — the component unmounted while an earlier `await` was pending, an earlier item in the batch failed — the function was still invoked. That burns an invocation and runs whatever side effects the function has (writes, emails, payment calls) after the caller cancelled, while reporting success back to the caller.

The dropped `signal.reason` is the second half of the same block: `timeoutController.abort()` took no argument, so a caller aborting with `controller.abort(myReason)` could never observe `myReason`.

Closes #2622

## 📸 Screenshots/Examples

Self-contained repro (no Supabase project needed) — a local HTTP server counts requests that actually arrive:

```js
// repro.cjs
const http = require('node:http')
const { FunctionsClient } = require('@supabase/functions-js')

let hits = 0
const server = http.createServer((req, res) => {
  hits++
  res.writeHead(200, { 'Content-Type': 'application/json' })
  res.end(JSON.stringify({ ok: true }))
})

async function run(label, opts, url) {
  const controller = new AbortController()
  controller.abort() // aborted BEFORE invoke
  const before = hits
  const client = new FunctionsClient(url)
  const { data, error } = await client.invoke('my-function', { ...opts, signal: controller.signal })
  console.log(`${label}\n  server hits: ${hits - before}\n  error: ${error ? error.name : 'null'}\n  data: ${JSON.stringify(data)}\n`)
}

server.listen(0, async () => {
  const url = `http://127.0.0.1:${server.address().port}`
  await run('no timeout   (expect 0 hits, aborted)', {}, url)
  await run('with timeout (expect 0 hits, aborted)', { timeout: 5000 }, url)
  server.close()
})
```

Before:

```
no timeout   (expect 0 hits, aborted)
  server hits: 0
  error: FunctionsFetchError
  data: null

with timeout (expect 0 hits, aborted)
  server hits: 1          <-- the function ran
  error: null             <-- and invoke() reported success
  data: {"ok":true}
```

After — `server hits: 0`, `error: FunctionsFetchError`, `data: null` in both cases.

## 🔄 Breaking changes

- [x] This PR contains no breaking changes

Two behaviour notes, both aligning `timeout + signal` with the existing `signal`-only path:

- An already-aborted signal now prevents the request instead of letting it through. Code that (knowingly or not) relied on the request still going out would change — but that path already reported a success the caller had cancelled.
- The abort reason handed to `fetch` is now the caller's `signal.reason` rather than a generic `AbortError`. `invoke()` still returns a `FunctionsFetchError`, so the shape of the result is unchanged; `test/spec/timeout.spec.ts` (which asserts `error.name === 'FunctionsFetchError'` on a mid-flight abort) still holds.

`AbortSignal.any([signal, timeoutController.signal])` would also fix this, but it needs Chrome 116+ / Safari 17.4+ / Firefox 124+; the explicit guard leaves the browser support matrix untouched.

## 📋 Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/supabase/supabase-js/blob/master/CONTRIBUTING.md)
- [x] My PR title follows the [conventional commit format](https://www.conventionalcommits.org/): `<type>(<scope>): <description>`
- [x] I have run `pnpm nx format` to ensure consistent code formatting
- [x] I have added tests for new functionality (if applicable)
- [ ] I have updated documentation (if applicable) — no public API or documented behaviour changed

## 📝 Additional notes

Two regression tests were added to `packages/core/functions-js/test/FunctionsClient.test.ts`, next to the existing listener-cleanup tests for this same block. They use a mock fetch that mirrors the platform contract (reject with `signal.reason` instead of issuing a request when the signal is already aborted), and cover both the request being prevented and the reason being forwarded. Both fail on `master` and pass with this change.

Verified locally: `jest test/FunctionsClient.test.ts` (4/4 passing), `nx build functions-js`, `nx format:check`, and `nx lint functions-js` (no new findings — the two pre-existing `prefer-const` errors in this file are unchanged).

I used Claude Code while investigating and preparing this change; the diagnosis, repro, and tests above are ones I ran and verified myself.
