### PR TITLE
fix(functions): parse media types using the +json structured syntax suffix

### DIFF
--- a/packages/core/functions-js/src/FunctionsClient.ts
+++ b/packages/core/functions-js/src/FunctionsClient.ts
@@ -1,4 +1,4 @@
-import { resolveFetch } from './helper'
+import { isJsonMediaType, resolveFetch } from './helper'
 import {
   Fetch,
   FunctionInvokeOptions,
@@ -310,7 +310,7 @@ export class FunctionsClient {
         .trim()
         .toLowerCase()
       let data: any
-      if (responseType === 'application/json') {
+      if (isJsonMediaType(responseType)) {
         data = await response.json()
       } else if (
         responseType === 'application/octet-stream' ||

--- a/packages/core/functions-js/src/helper.ts
+++ b/packages/core/functions-js/src/helper.ts
@@ -6,3 +6,16 @@ export const resolveFetch = (customFetch?: Fetch): Fetch => {
   }
   return (...args) => fetch(...args)
 }
+
+/**
+ * Media types carrying JSON either are `application/json` or use the `+json`
+ * structured syntax suffix defined in RFC 6839, for example
+ * `application/problem+json` (RFC 9457) or `application/vnd.api+json`.
+ *
+ * `application/json-seq` is deliberately excluded: it is a sequence of JSON
+ * texts, not a single JSON document, so `Response.json()` cannot parse it.
+ *
+ * @param mediaType a media type already lowercased and stripped of parameters
+ */
+export const isJsonMediaType = (mediaType: string): boolean =>
+  mediaType === 'application/json' || /^application\/.+\+json$/.test(mediaType)

--- a/packages/core/functions-js/test/spec/response-content-type.spec.ts
+++ b/packages/core/functions-js/test/spec/response-content-type.spec.ts
@@ -39,4 +39,42 @@ describe('response Content-Type parsing', () => {
     expect(error).toBeNull()
     expect(data).toEqual({ foo: 'bar' })
   })
+
+  test('parses a media type using the +json structured syntax suffix', async () => {
+    const client = makeClient('application/problem+json', JSON.stringify({ title: 'Not Found' }))
+    const { data, error } = await client.invoke('fn', {})
+    expect(error).toBeNull()
+    expect(data).toEqual({ title: 'Not Found' })
+  })
+
+  test('parses a vendor media type using the +json suffix', async () => {
+    const client = makeClient(
+      'application/vnd.api+json; charset=utf-8',
+      JSON.stringify({ data: { id: '1' } })
+    )
+    const { data, error } = await client.invoke('fn', {})
+    expect(error).toBeNull()
+    expect(data).toEqual({ data: { id: '1' } })
+  })
+
+  test('parses a +json suffix regardless of casing', async () => {
+    const client = makeClient('Application/LD+JSON', JSON.stringify({ '@type': 'Thing' }))
+    const { data, error } = await client.invoke('fn', {})
+    expect(error).toBeNull()
+    expect(data).toEqual({ '@type': 'Thing' })
+  })
+
+  test('does not treat application/json-seq as a single JSON document', async () => {
+    const client = makeClient('application/json-seq', '{"a":1}\n{"a":2}')
+    const { data, error } = await client.invoke('fn', {})
+    expect(error).toBeNull()
+    expect(typeof data).toBe('string')
+  })
+
+  test('still falls back to text for an unrelated media type', async () => {
+    const client = makeClient('text/plain', 'hello')
+    const { data, error } = await client.invoke('fn', {})
+    expect(error).toBeNull()
+    expect(data).toBe('hello')
+  })
 })


### PR DESCRIPTION
## 🔍 Description

### What changed?

`invoke()` now recognises media types that carry JSON through the `+json` structured syntax suffix, not just the exact string `application/json`.

`isJsonMediaType()` is added to `helper.ts` and used for the response-parsing branch:

```ts
export const isJsonMediaType = (mediaType: string): boolean =>
  mediaType === 'application/json' || /^application\/.+\+json$/.test(mediaType)
```

### Why was this change needed?

The response body is parsed by matching the normalised Content-Type against one exact string:

```ts
if (responseType === 'application/json') {
  data = await response.json()
}
```

Media types carrying JSON are not limited to `application/json`. RFC 6839 defines the `+json` structured syntax suffix, and several of those types are common in Edge Function responses:

- `application/problem+json` — RFC 9457 problem details, a normal way to return an error body
- `application/vnd.api+json` — JSON:API
- `application/ld+json` — JSON-LD

Today all of these fall through to the `text` branch, so the caller receives a raw string and has to `JSON.parse()` it by hand, without any indication that the SDK decided not to parse it. The failure is silent: `error` is `null` and `data` looks superficially fine until it is used.

`application/json-seq` is deliberately **not** matched. It is a sequence of JSON texts rather than a single JSON document, so `Response.json()` cannot parse it, and it keeps falling back to text as before.

This follows the same shape as the earlier fix that made the comparison case-insensitive per RFC 9110.

## 📸 Screenshots/Examples

Before this change:

```ts
// Edge Function replies with: Content-Type: application/problem+json
const { data, error } = await supabase.functions.invoke('my-function')

error // null
typeof data // "string"  <-- unparsed
```

After:

```ts
typeof data // "object"
data.title  // "Not Found"
```

## 🔄 Breaking changes

- [x] This PR contains no breaking changes

A response that previously arrived as an unparsed string will now arrive parsed, which is the documented behaviour for JSON responses. Types that were already parsed are unaffected, and `application/json-seq` keeps its current behaviour.

## 📋 Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/supabase/supabase-js/blob/master/CONTRIBUTING.md)
- [x] My PR title follows the [conventional commit format](https://www.conventionalcommits.org/): `<type>(<scope>): <description>`
- [x] I have run `pnpm nx format` to ensure consistent code formatting
- [x] I have added tests for new functionality (if applicable)
- [ ] I have updated documentation (if applicable)

## 📝 Additional notes

Five tests were added to the existing `test/spec/response-content-type.spec.ts`, which already covers this area:

- three for `+json` suffix types, including one with a `charset` parameter and one with mixed casing — these fail on `master` and pass with the change
- one asserting `application/json-seq` is still returned as text
- one asserting `text/plain` still falls back to text

Verified locally on the `functions-js` package:

- `response-content-type.spec.ts`: 8 passed
- full package suite before the change: 14 passed, 28 failed
- full package suite after the change: 19 passed, 28 failed

The 28 failures are identical in both runs and come from the relay-based integration specs, which need Docker (`No Docker client strategy found`) and were not run in this environment.

Formatting was applied with `pnpm nx format --uncommitted`. It also reported `nx.json` and `tsconfig.base.json` as unformatted; those are unrelated to this change and were left untouched.
