### PR TITLE
fix(realtime): clear pendingHeartbeatRef on socket open and close

### DIFF
--- a/packages/core/realtime-js/src/RealtimeClient.ts
+++ b/packages/core/realtime-js/src/RealtimeClient.ts
@@ -184,11 +184,13 @@ export default class RealtimeClient {
     return this.socketAdapter.heartbeatTimer
   }
 
-  get pendingHeartbeatRef() {
-    if (this.worker) {
-      return this._pendingWorkerHeartbeatRef
-    }
+  get pendingHeartbeatRef(): string | null {
     return this.socketAdapter.pendingHeartbeatRef
+  }
+
+  set pendingHeartbeatRef(ref: string | null) {
+    this.socketAdapter.pendingHeartbeatRef = ref
+    this._pendingWorkerHeartbeatRef = ref
   }
 
   get reconnectTimer(): Timer {
@@ -702,6 +704,8 @@ export default class RealtimeClient {
   /** @internal */
   private _setupConnectionHandlers(): void {
     this.socketAdapter.onOpen(() => {
+      this.pendingHeartbeatRef = null
+
       const authPromise =
         this._authPromise ||
         (this.accessToken && !this.accessTokenValue ? this.setAuth() : Promise.resolve())
@@ -715,6 +719,7 @@ export default class RealtimeClient {
       }
     })
     this.socketAdapter.onClose(() => {
+      this.pendingHeartbeatRef = null
       if (this.worker && this.workerRef) {
         this._terminateWorker()
       }

--- a/packages/core/realtime-js/src/phoenix/socketAdapter.ts
+++ b/packages/core/realtime-js/src/phoenix/socketAdapter.ts
@@ -55,6 +55,10 @@ export default class SocketAdapter {
     return this.socket.pendingHeartbeatRef
   }
 
+  set pendingHeartbeatRef(ref: string | null) {
+    this.socket.pendingHeartbeatRef = ref
+  }
+
   get reconnectTimer(): Timer {
     return this.socket.reconnectTimer
   }

--- a/packages/core/realtime-js/test/RealtimeClient.lifecycle.test.ts
+++ b/packages/core/realtime-js/test/RealtimeClient.lifecycle.test.ts
@@ -316,4 +316,31 @@ describe('Race condition prevention', () => {
     assert.equal(client.isDisconnecting(), true)
     cleanup()
   })
+
+  test('clears pendingHeartbeatRef on socket open and close', async () => {
+    const { client, connect, socketConnected, cleanup } = setupRealtimeTest()
+
+    connect()
+    await socketConnected()
+
+    // Simulate a pending heartbeat ref left in flight
+    client.pendingHeartbeatRef = 'stale-ref-from-previous-conn'
+    expect(client.pendingHeartbeatRef).toBe('stale-ref-from-previous-conn')
+
+    // Simulate onOpen event (e.g. reconnect)
+    // @ts-ignore
+    client.socketAdapter.getSocket().triggerStateCallbacks('open')
+    expect(client.pendingHeartbeatRef).toBeNull()
+
+    // Simulate pending heartbeat ref again
+    client.pendingHeartbeatRef = 'another-pending-ref'
+    expect(client.pendingHeartbeatRef).toBe('another-pending-ref')
+
+    // Simulate onClose event (e.g. disconnect)
+    // @ts-ignore
+    client.socketAdapter.getSocket().triggerStateCallbacks('close')
+    expect(client.pendingHeartbeatRef).toBeNull()
+
+    cleanup()
+  })
 })

--- a/packages/core/realtime-js/test/RealtimeClient.lifecycle.test.ts
+++ b/packages/core/realtime-js/test/RealtimeClient.lifecycle.test.ts
@@ -328,7 +328,7 @@ describe('Race condition prevention', () => {
     expect(client.pendingHeartbeatRef).toBe('stale-ref-from-previous-conn')
 
     // Simulate onOpen event (e.g. reconnect)
-    // @ts-ignore
+    // @ts-expect-error - triggering private phoenix socket callback in tests
     client.socketAdapter.getSocket().triggerStateCallbacks('open')
     expect(client.pendingHeartbeatRef).toBeNull()
 
@@ -337,7 +337,7 @@ describe('Race condition prevention', () => {
     expect(client.pendingHeartbeatRef).toBe('another-pending-ref')
 
     // Simulate onClose event (e.g. disconnect)
-    // @ts-ignore
+    // @ts-expect-error - triggering private phoenix socket callback in tests
     client.socketAdapter.getSocket().triggerStateCallbacks('close')
     expect(client.pendingHeartbeatRef).toBeNull()
 

--- a/packages/core/realtime-js/test/RealtimeClient.worker.test.ts
+++ b/packages/core/realtime-js/test/RealtimeClient.worker.test.ts
@@ -2,6 +2,7 @@ import { beforeAll, afterAll, beforeEach, afterEach, test, expect, vi, describe 
 import { type TestSetup, setupRealtimeTest } from './helpers/setup'
 import Worker from 'web-worker'
 import path from 'path'
+import { pathToFileURL } from 'url'
 import RealtimeClient from '../src/RealtimeClient'
 
 let testSetup: TestSetup
@@ -10,7 +11,7 @@ beforeAll(() => {
   window.Worker = Worker
 })
 
-const workerUrl = path.join(__dirname, '/helpers/test_worker.js')
+const workerUrl = pathToFileURL(path.join(__dirname, '/helpers/test_worker.js')).href
 
 beforeEach(() => {
   testSetup = setupRealtimeTest({
@@ -36,7 +37,7 @@ test('sets worker URL', () => {
 })
 
 describe('when no workerUrl provided', () => {
-  const mockObjectURL = `file://${workerUrl}`
+  const mockObjectURL = workerUrl.startsWith('file://') ? workerUrl : `file://${workerUrl}`
   let originalCreateObjectURL: any
 
   beforeAll(() => {

--- a/packages/core/realtime-js/test/RealtimeClient.worker.test.ts
+++ b/packages/core/realtime-js/test/RealtimeClient.worker.test.ts
@@ -116,3 +116,39 @@ test('terminates worker on disconnect', async () => {
   expect(spy).toHaveBeenCalled()
   expect(testSetup.client.workerRef).toBeFalsy()
 })
+
+test('worker reconnect: in-flight heartbeat on socket A does not cause heartbeat timeout teardown on socket B after reconnect', async () => {
+  const heartbeatEvents: string[] = []
+  testSetup.cleanup()
+  testSetup = setupRealtimeTest({
+    worker: true,
+    workerUrl,
+    heartbeatCallback: (status: string) => {
+      heartbeatEvents.push(status)
+    },
+  })
+
+  testSetup.connect()
+  await testSetup.socketConnected()
+
+  // 1. Send first heartbeat on socket A
+  testSetup.client.sendHeartbeat()
+  expect(heartbeatEvents).toContain('sent')
+
+  // 2. Disconnect socket A while heartbeat was in flight (without reply or timeout)
+  await testSetup.disconnect()
+  await testSetup.socketClosed()
+
+  // 3. Reconnect on socket B
+  testSetup.connect()
+  await testSetup.socketConnected()
+
+  // 4. Send heartbeat on socket B - should send cleanly without teardown
+  expect(testSetup.client.pendingHeartbeatRef).toBeNull()
+  testSetup.client.sendHeartbeat()
+
+  // Verify connection remains open and exactly two sent events occurred
+  expect(testSetup.client.isConnected()).toBe(true)
+  expect(heartbeatEvents.filter((s) => s === 'sent').length).toBe(2)
+})
+

--- a/packages/core/realtime-js/test/RealtimeClient.worker.test.ts
+++ b/packages/core/realtime-js/test/RealtimeClient.worker.test.ts
@@ -81,7 +81,7 @@ test('ensures single worker ref is started even with multiple connect calls', as
   await testSetup.socketConnected()
   const ref = testSetup.client.workerRef
 
-  // @ts-ignore - simulate another onOpen call
+  // @ts-expect-error - simulate another onOpen call
   testSetup.client.socketAdapter.getSocket().triggerStateCallbacks('open')
 
   expect(testSetup.client.workerRef).toBe(ref)
@@ -90,7 +90,7 @@ test('ensures single worker ref is started even with multiple connect calls', as
 test('throws error when Web Worker is not supported', () => {
   // Temporarily remove Worker from window
   const originalWorker = window.Worker
-  // @ts-ignore - Deliberately setting to undefined to test error case
+  // @ts-expect-error - Deliberately setting to undefined to test error case
   window.Worker = undefined
 
   expect(() => {
@@ -117,8 +117,9 @@ test('terminates worker on disconnect', async () => {
   expect(testSetup.client.workerRef).toBeFalsy()
 })
 
-test('worker reconnect: in-flight heartbeat on socket A does not cause heartbeat timeout teardown on socket B after reconnect', async () => {
+test('worker reconnect: in-flight heartbeat on socket A does not tear down socket B', async () => {
   const heartbeatEvents: string[] = []
+  let heartbeatsSeen = 0
   testSetup.cleanup()
   testSetup = setupRealtimeTest({
     worker: true,
@@ -126,29 +127,39 @@ test('worker reconnect: in-flight heartbeat on socket A does not cause heartbeat
     heartbeatCallback: (status: string) => {
       heartbeatEvents.push(status)
     },
+    socketHandlers: {
+      heartbeat: (socket, message) => {
+        heartbeatsSeen += 1
+        if (heartbeatsSeen === 1) return // leave socket A's heartbeat in flight
+        const msg = JSON.parse(message as string)
+        socket.send(
+          JSON.stringify({
+            topic: msg.topic,
+            event: 'phx_reply',
+            ref: msg.ref,
+            payload: { status: 'ok', response: {} },
+          })
+        )
+      },
+    },
   })
 
   testSetup.connect()
-  await testSetup.socketConnected()
-
-  // 1. Send first heartbeat on socket A
+  await vi.waitFor(() => expect(testSetup.client.isConnected()).toBe(true))
   testSetup.client.sendHeartbeat()
-  expect(heartbeatEvents).toContain('sent')
+  expect(heartbeatEvents).toEqual(['sent'])
 
-  // 2. Disconnect socket A while heartbeat was in flight (without reply or timeout)
   await testSetup.disconnect()
   await testSetup.socketClosed()
 
-  // 3. Reconnect on socket B
   testSetup.connect()
-  await testSetup.socketConnected()
-
-  // 4. Send heartbeat on socket B - should send cleanly without teardown
+  await vi.waitFor(() => expect(testSetup.client.isConnected()).toBe(true))
   expect(testSetup.client.pendingHeartbeatRef).toBeNull()
   testSetup.client.sendHeartbeat()
 
-  // Verify connection remains open and exactly two sent events occurred
   expect(testSetup.client.isConnected()).toBe(true)
   expect(heartbeatEvents.filter((s) => s === 'sent').length).toBe(2)
+  expect(heartbeatEvents).not.toContain('timeout')
+  await vi.waitFor(() => expect(heartbeatEvents).toContain('ok'))
+  expect(testSetup.client.isConnected()).toBe(true)
 })
-

--- a/packages/core/realtime-js/test/phoenix/socketAdapter.test.ts
+++ b/packages/core/realtime-js/test/phoenix/socketAdapter.test.ts
@@ -62,3 +62,16 @@ describe('connection state', () => {
     expect(socketAdapter.isDisconnecting()).toBe(true)
   })
 })
+
+describe('pendingHeartbeatRef', () => {
+  test('gets and sets pendingHeartbeatRef on underlying socket', () => {
+    expect(socketAdapter.pendingHeartbeatRef).toBeNull()
+    socketAdapter.pendingHeartbeatRef = 'test-ref-123'
+    expect(socketAdapter.pendingHeartbeatRef).toBe('test-ref-123')
+    expect(socketAdapter.getSocket().pendingHeartbeatRef).toBe('test-ref-123')
+
+    socketAdapter.pendingHeartbeatRef = null
+    expect(socketAdapter.pendingHeartbeatRef).toBeNull()
+    expect(socketAdapter.getSocket().pendingHeartbeatRef).toBeNull()
+  })
+})


### PR DESCRIPTION
Closes #2625.

### Problem
When a Realtime client is configured in worker mode (`worker: true`), `autoSendHeartbeat` is disabled on the underlying Phoenix `Socket` (`autoSendHeartbeat = false`) because heartbeats are driven by the worker instead of the socket's internal `setInterval`.

In Phoenix, `onConnOpen()` gates `resetHeartbeat()` behind `if (this.autoSendHeartbeat)`. Because `autoSendHeartbeat` is false in worker mode, `resetHeartbeat()` is never called when the socket opens or reconnects. As a result, if a connection drops with a heartbeat in-flight (e.g. Wi-Fi roam, sleep, server disconnect), the stranded `pendingHeartbeatRef` survives onto the next healthy connection. The next heartbeat triggered by the worker on the new connection sees a non-null `pendingHeartbeatRef`, incorrectly enters the timeout branch, and force-closes the new socket with `"heartbeat timeout"` after having sent 0 frames.

### Solution
1. Added a setter for `pendingHeartbeatRef` to `SocketAdapter` and aligned `RealtimeClient.pendingHeartbeatRef` to delegate to the underlying socket adapter.
2. In `RealtimeClient._setupConnectionHandlers()`, unconditionally clear `pendingHeartbeatRef = null` on both socket `onOpen` and `onClose` events. This ensures that any pending heartbeat ref left in flight from an earlier connection is always reset before frames are sent on the new connection.
3. Added unit tests in `test/phoenix/socketAdapter.test.ts` and lifecycle tests in `test/RealtimeClient.lifecycle.test.ts` verifying that `pendingHeartbeatRef` is properly cleared across connection lifecycle transitions.

### Verification
- Ran vitest across all 26 test suites in `@supabase/realtime-js` (467 tests passed).
- Built packages cleanly via `pnpm --filter @supabase/realtime-js build`.
