### PR TITLE
fix(auth): warn on deprecated lock option and prevent unhandled refresh rejection

### DIFF
--- a/packages/core/auth-js/migrations/lockless-coordination.md
+++ b/packages/core/auth-js/migrations/lockless-coordination.md
@@ -1,6 +1,6 @@
 # Lockless auth coordination
 
-**Since:** v2.X.Y (update at release time)
+**Since:** v2.107.0
 **Action required by:** v3.0.0
 
 `@supabase/auth-js` now coordinates session refreshes without a shared mutex by default. The legacy `lock` option is still honored when supplied, but it is deprecated and will be removed in v3.
@@ -19,7 +19,7 @@
 
 **Callers passing a custom `lock`** (typically React Native `processLock`, Node multi-process setups with shared AsyncStorage, or a custom lock implementation):
 
-- v2.x (this release): your custom `lock` is still invoked exactly as before. The legacy `_acquireLock` machinery is preserved on an opt-in path gated by `settings.lock != null`. No code change required.
+- v2.x (since v2.107.0): your custom `lock` is still invoked exactly as before. The legacy `_acquireLock` machinery is preserved on an opt-in path gated by `settings.lock != null`. No code change required. Since v2.112.4 the client logs a one-time deprecation warning when a `lock` is supplied.
 - v3.0.0 (planned): the `lock` and `lockAcquireTimeout` options will be removed entirely. Drop them from your client options before upgrading to v3.
 
 ## New APIs worth knowing

--- a/packages/core/auth-js/src/GoTrueClient.ts
+++ b/packages/core/auth-js/src/GoTrueClient.ts
@@ -230,6 +230,10 @@ async function lockNoOp<R>(name: string, acquireTimeout: number, fn: () => Promi
  */
 const GLOBAL_JWKS: { [storageKey: string]: { cachedAt: number; jwks: { keys: JWK[] } } } = {}
 
+// Warn once per JS realm, not per client instance — server-side apps can
+// construct many clients per process and must not be spammed.
+let deprecatedLockWarned = false
+
 export default class GoTrueClient {
   private static nextInstanceID: Record<string, number> = {}
 
@@ -457,6 +461,13 @@ export default class GoTrueClient {
     // by default, no implicit `processLock`.
     if (settings.lock != null) {
       this.lock = settings.lock
+
+      if (!deprecatedLockWarned) {
+        deprecatedLockWarned = true
+        console.warn(
+          `${this._logPrefix()} The "lock" option is deprecated and will be removed in v3. The client now coordinates session refreshes without a lock, so most apps can drop the option. See https://github.com/supabase/supabase-js/blob/master/packages/core/auth-js/migrations/lockless-coordination.md`
+        )
+      }
     }
 
     if (!this.jwks) {
@@ -4992,6 +5003,14 @@ export default class GoTrueClient {
 
     try {
       this.refreshingDeferred = new Deferred<CallRefreshTokenResult>()
+
+      // Only callers that arrive while this refresh is in flight await the
+      // deferred; the original caller is served by the `throw` in the catch
+      // below. Pre-attach a no-op rejection handler so a failing refresh with
+      // no concurrent callers cannot surface as an unhandled rejection —
+      // concurrent callers attach their own handlers via `.promise` and still
+      // observe the rejection.
+      this.refreshingDeferred.promise.then(undefined, () => {})
 
       // Snapshot storage before the fetch. The commit guard discards the
       // rotated tokens only when a non-null pre-fetch snapshot changed under

--- a/packages/core/auth-js/test/GoTrueClient.lockWarning.test.ts
+++ b/packages/core/auth-js/test/GoTrueClient.lockWarning.test.ts
@@ -1,0 +1,46 @@
+import GoTrueClient from '../src/GoTrueClient'
+import { memoryLocalStorageAdapter } from '../src/lib/local-storage'
+import type { LockFunc } from '../src/lib/types'
+
+const passthroughLock: LockFunc = async (_name, _acquireTimeout, fn) => await fn()
+
+const makeClient = (storageKey: string, lock?: LockFunc) =>
+  new GoTrueClient({
+    url: 'http://localhost:9999',
+    autoRefreshToken: false,
+    persistSession: false,
+    storage: memoryLocalStorageAdapter(),
+    storageKey,
+    ...(lock ? { lock } : {}),
+  })
+
+describe('deprecated lock option warning', () => {
+  let warnSpy: jest.SpyInstance
+  const clients: GoTrueClient[] = []
+
+  beforeEach(() => {
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(async () => {
+    warnSpy.mockRestore()
+    await Promise.all(clients.splice(0).map((client) => client.dispose()))
+  })
+
+  const deprecationWarnings = () =>
+    warnSpy.mock.calls.filter(
+      (args) => typeof args[0] === 'string' && args[0].includes('"lock" option is deprecated')
+    )
+
+  it('warns once per environment when a lock is supplied, never without one', () => {
+    clients.push(makeClient('lock-warning-none'))
+    expect(deprecationWarnings()).toHaveLength(0)
+
+    clients.push(makeClient('lock-warning-first', passthroughLock))
+    expect(deprecationWarnings()).toHaveLength(1)
+    expect(deprecationWarnings()[0][0]).toContain('migrations/lockless-coordination.md')
+
+    clients.push(makeClient('lock-warning-second', passthroughLock))
+    expect(deprecationWarnings()).toHaveLength(1)
+  })
+})

--- a/packages/core/auth-js/test/GoTrueClient.refreshRejection.test.ts
+++ b/packages/core/auth-js/test/GoTrueClient.refreshRejection.test.ts
@@ -1,0 +1,86 @@
+import GoTrueClient from '../src/GoTrueClient'
+import { memoryLocalStorageAdapter } from '../src/lib/local-storage'
+
+const makeSession = (suffix: string) => ({
+  access_token: `test-access-token-${suffix}`,
+  refresh_token: `test-refresh-token-${suffix}`,
+  token_type: 'bearer',
+  expires_in: 3600,
+  expires_at: Math.floor(Date.now() / 1000) + 3600,
+  user: {
+    id: 'test-user-id',
+    aud: 'authenticated',
+    role: 'authenticated',
+    email: 'user@example.com',
+    app_metadata: {},
+    user_metadata: {},
+    created_at: new Date(0).toISOString(),
+  },
+})
+
+describe('single-caller refresh failure', () => {
+  let consoleErrorSpy: jest.SpyInstance
+
+  beforeEach(() => {
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore()
+  })
+
+  it('rejects the caller without producing an unhandled rejection', async () => {
+    const storageKey = 'test-refresh-rejection'
+    const storage = memoryLocalStorageAdapter({
+      [storageKey]: JSON.stringify(makeSession('stored')),
+    })
+    const mockFetch = jest.fn().mockResolvedValue(
+      new Response(JSON.stringify(makeSession('refreshed')), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    )
+
+    const client = new GoTrueClient({
+      url: 'http://localhost:9999',
+      autoRefreshToken: false,
+      persistSession: true,
+      storage,
+      storageKey,
+      fetch: mockFetch,
+    })
+
+    // A subscriber throwing on TOKEN_REFRESHED escapes `_callRefreshToken` as
+    // a non-AuthError: the caller must receive it, and the refresh dedupe
+    // deferred (which has no concurrent subscriber here) must not leak it as
+    // an unhandled rejection.
+    const {
+      data: { subscription },
+    } = client.onAuthStateChange((event) => {
+      if (event === 'TOKEN_REFRESHED') {
+        throw new Error('subscriber boom')
+      }
+    })
+
+    const unhandled: unknown[] = []
+    const onUnhandled = (reason: unknown) => {
+      unhandled.push(reason)
+    }
+    process.on('unhandledRejection', onUnhandled)
+
+    try {
+      await expect(client.refreshSession()).rejects.toThrow('subscriber boom')
+
+      // Unhandled rejections are reported on later ticks — drain a few so a
+      // leak would have fired the listener before we assert.
+      await new Promise((resolve) => setImmediate(resolve))
+      await new Promise((resolve) => setImmediate(resolve))
+    } finally {
+      process.removeListener('unhandledRejection', onUnhandled)
+      subscription.unsubscribe()
+      await client.dispose()
+    }
+
+    expect(unhandled).toEqual([])
+  })
+})


### PR DESCRIPTION
Adds a one-time `console.warn` when the deprecated `lock` option is passed to the auth client, pointing at the lockless-coordination migration notes. The client has coordinated session refreshes without a lock since 2.107.0, and the option will be removed in v3, but the JSDoc-only deprecation was not reaching users still passing `lock:`.

Also pre-attaches a no-op rejection handler to the refresh dedupe deferred in `_callRefreshToken`: when a refresh fails with no concurrent callers awaiting it, the rejected deferred previously surfaced as an unhandled rejection even though the original caller received the error. Concurrent callers still observe the rejection through `.promise`.

Also fills in the release-time version placeholders in `migrations/lockless-coordination.md` and adds unit tests for both behaviors (warn once per realm, never without `lock`; no unhandled rejection on a single-caller refresh failure).