### PR TITLE
fix(auth): preserve generic WebAuthn JSON return types

### DIFF
--- a/packages/core/auth-js/src/lib/webauthn.dom.ts
+++ b/packages/core/auth-js/src/lib/webauthn.dom.ts
@@ -527,6 +527,8 @@ export interface PublicKeyCredentialRequestOptionsFuture
  */
 export type PublicKeyCredentialJSON = RegistrationResponseJSON | AuthenticationResponseJSON
 
+type PublicKeyCredentialBase = Omit<PublicKeyCredential, 'toJSON'>
+
 /**
  * A super class of TypeScript's `PublicKeyCredential` that knows about upcoming WebAuthn features.
  * Includes WebAuthn Level 3 methods for JSON serialization and parsing.
@@ -536,7 +538,7 @@ export type PublicKeyCredentialJSON = RegistrationResponseJSON | AuthenticationR
  */
 export interface PublicKeyCredentialFuture<
   T extends PublicKeyCredentialJSON = PublicKeyCredentialJSON,
-> extends PublicKeyCredential {
+> extends PublicKeyCredentialBase {
   /**
    * The type of the credential (always "public-key").
    * @see {@link https://w3c.github.io/webauthn/#dom-credential-type W3C - type}

--- a/packages/core/auth-js/test/webauthn.dom.test.ts
+++ b/packages/core/auth-js/test/webauthn.dom.test.ts
@@ -1,0 +1,31 @@
+import type {
+  AuthenticationCredential,
+  AuthenticationResponseJSON,
+  RegistrationCredential,
+  RegistrationResponseJSON,
+} from '../src/lib/webauthn.dom'
+
+type Equal<Left, Right> =
+  (<Value>() => Value extends Left ? 1 : 2) extends <Value>() => Value extends Right ? 1 : 2
+    ? true
+    : false
+
+type Expect<Value extends true> = Value
+
+type RegistrationCredentialReturnsRegistrationJSON = Expect<
+  Equal<ReturnType<RegistrationCredential['toJSON']>, RegistrationResponseJSON>
+>
+
+type AuthenticationCredentialReturnsAuthenticationJSON = Expect<
+  Equal<ReturnType<AuthenticationCredential['toJSON']>, AuthenticationResponseJSON>
+>
+
+describe('WebAuthn credential types', () => {
+  test('preserve registration and authentication JSON return types', () => {
+    const registration: RegistrationCredentialReturnsRegistrationJSON = true
+    const authentication: AuthenticationCredentialReturnsAuthenticationJSON = true
+
+    expect(registration).toBe(true)
+    expect(authentication).toBe(true)
+  })
+})


### PR DESCRIPTION
## PR Title

Title: fix(auth): preserve generic WebAuthn JSON return types

## Summary

- **Problem:** TypeScript 6 adds a native `PublicKeyCredential.toJSON()` return contract. `PublicKeyCredentialFuture<T>` currently extends that interface while overriding `toJSON()` with Supabase's distinct generic JSON types, causing `TS2430` whenever consumers run full declaration checking.
- **Objective:** Preserve Supabase's exact registration and authentication JSON return types without claiming that they implement the incompatible native `toJSON()` signature.
- **Scope:** `@supabase/auth-js` WebAuthn declarations and focused type regression coverage only.

## Design

- Defines the inherited credential base as `Omit<PublicKeyCredential, 'toJSON'>` and adds Supabase's generic `toJSON(): T` contract on `PublicKeyCredentialFuture<T>`.
- Retains every other native `PublicKeyCredential` member.
- Adds exact type assertions for registration and authentication credential return values.
- Rejects consumer-side `skipLibCheck`, declaration patches, casts, or widening the generic return type because those approaches either hide the invalid inheritance or discard the existing Supabase JSON contract.

## Key Changes

1. Added `PublicKeyCredentialBase` without the native `toJSON` member.
2. Changed `PublicKeyCredentialFuture<T>` to extend that compatible base.
3. Kept `toJSON(): T` as the authoritative Supabase serialization contract.
4. Added registration and authentication return-type regression assertions.

## Risk / Rollback

- **Primary risk:** Code that relied on assigning the generic Supabase credential type to the complete native `PublicKeyCredential` type may now observe the intentionally different `toJSON` contract.
- **Mitigation:** All native credential members other than the conflicting method remain inherited, and focused passkey tests cover the existing runtime paths.
- **Rollback:** Revert this commit to restore the prior declaration. No runtime code, persistence, network behavior, or release data is changed.

## Validation

- TypeScript `6.0.3`, `skipLibCheck: false`, stable `@supabase/auth-js@2.112.4` consumer: fails at `webauthn.dom.d.ts` with `TS2430`.
- The same TypeScript `6.0.3` consumer against declarations built from this branch: passes.
- Minimal TypeScript `6.0.3` reproduction: fails before the inheritance correction and passes with the corrected base.
- `pnpm nx build @supabase/auth-js`: passed.
- `pnpm exec tsc --build packages/core/auth-js/tsconfig.json --emitDeclarationOnly --force`: passed.
- Focused passkey/WebAuthn suite: 5 suites and 68 tests passed.
- ESLint on both changed files: passed.
- `git diff --check`: passed.
- The infrastructure-backed full auth suite was not claimed locally; the upstream workflow owns signing-key generation and Supabase CLI startup.

## Reviewer Notes

- This is a declaration-only correction; generated package declarations are the load-bearing consumer boundary.
- No issue is linked because repository issue and pull-request searches returned no existing report for `PublicKeyCredentialFuture`.
- A stable package release containing this correction is required for downstream TypeScript 6 consumers that keep full library checking enabled.

## Performance / Observability

- No runtime path changes.
- No effect on latency, bundle execution, requests, storage, logging, metrics, or traces.

## Checklist

- [x] I have read the contributing guidelines.
- [x] The PR title follows the conventional commit format.
- [x] Changed files use the repository's formatting and lint rules.
- [x] Focused regression tests were added and passed.
- [x] No documentation update is required for this declaration correction.
