### PR TITLE
feat(realtime): allow wait for pg changes

### DIFF
--- a/packages/core/realtime-js/src/RealtimeChannel.ts
+++ b/packages/core/realtime-js/src/RealtimeChannel.ts
@@ -1,4 +1,9 @@
-import { CHANNEL_EVENTS, CHANNEL_STATES } from './lib/constants'
+import {
+  CHANNEL_EVENTS,
+  CHANNEL_STATES,
+  DEFAULT_POSTGRES_CHANGES_WAIT_TIMEOUT,
+  POSTGRES_CHANGES_WAIT_ERROR_GRACE,
+} from './lib/constants'
 import type { ChannelState } from './lib/constants'
 import type RealtimeClient from './RealtimeClient'
 import RealtimePresence, { REALTIME_PRESENCE_LISTEN_EVENTS } from './RealtimePresence'
@@ -65,6 +70,34 @@ export type RealtimeChannelOptions = {
      * defines if the channel is private or not and if RLS policies will be used to check data
      */
     private?: boolean
+    /**
+     * By default, `subscribe()` reports `SUBSCRIBED` as soon as the channel itself has joined,
+     * which can happen before the server has actually established the `postgres_changes`
+     * subscription (e.g. before the replication slot is streaming). Set `wait: true` to instead
+     * hold the `SUBSCRIBED` callback until the server confirms the postgres_changes subscription
+     * is active.
+     *
+     * If the subscription cannot be established, the server rejects the join and `subscribe()`
+     * reports `CHANNEL_ERROR` with the server's reason (e.g.
+     * `PostgresChangesSubscribeTimeout: ...` when the wait ran out, or
+     * `RealtimeDisabledForConfiguration: ...` when the table is not enabled for Realtime).
+     *
+     * Has no effect on a channel with no `postgres_changes` bindings.
+     *
+     * Setting `wait: true` automatically extends the channel's join timeout so it outlasts the
+     * server's held reply, so you don't need to pass a larger `timeout` to `subscribe()` yourself.
+     * As a side effect of how Phoenix tracks the join timeout, other pushes on the channel that
+     * do not pass an explicit timeout inherit the extended value too.
+     */
+    postgres_changes_options?: {
+      wait?: boolean
+      /**
+       * Milliseconds the server should wait for postgres_changes subscription confirmation when
+       * `wait` is `true`. Defaults to 15000, and the server clamps it to its own configured
+       * maximum (20s by default), so asking for more waits less.
+       */
+      timeout?: number
+    }
   }
 }
 
@@ -395,7 +428,7 @@ export default class RealtimeChannel {
     }
     if (this.channelAdapter.isClosed()) {
       const {
-        config: { broadcast, presence, private: isPrivate },
+        config: { broadcast, presence, private: isPrivate, postgres_changes_options },
       } = this.params
 
       const postgres_changes = this.bindings.postgres_changes?.map((r) => r.filter) ?? []
@@ -410,6 +443,7 @@ export default class RealtimeChannel {
         presence: { ...presence, enabled: presence_enabled },
         postgres_changes,
         private: isPrivate,
+        ...(postgres_changes_options ? { postgres_changes_options } : {}),
       }
 
       if (this.socket.accessTokenValue) {
@@ -426,8 +460,17 @@ export default class RealtimeChannel {
 
       this._updateFilterMessage()
 
+      const joinTimeout =
+        postgres_changes_options?.wait && postgres_changes.length > 0
+          ? Math.max(
+              timeout,
+              (postgres_changes_options.timeout ?? DEFAULT_POSTGRES_CHANGES_WAIT_TIMEOUT) +
+                POSTGRES_CHANGES_WAIT_ERROR_GRACE
+            )
+          : timeout
+
       this.channelAdapter
-        .subscribe(timeout)
+        .subscribe(joinTimeout)
         .receive('ok', async ({ postgres_changes }: PostgresChangesFilters) => {
           // Only refresh auth if using callback-based tokens
           if (!this.socket._isManualToken()) {

--- a/packages/core/realtime-js/src/lib/constants.ts
+++ b/packages/core/realtime-js/src/lib/constants.ts
@@ -19,6 +19,15 @@ export const VERSION = version
 
 export const DEFAULT_TIMEOUT = 10000
 
+/** Mirrors the Realtime server's own default for `postgres_changes_options.timeout`. */
+export const DEFAULT_POSTGRES_CHANGES_WAIT_TIMEOUT = 15000
+
+/**
+ * Headroom added to the join timeout when waiting on postgres_changes, covering the
+ * CHANNEL_ERROR_BACKOFF_MS sleep (5s by default) the server takes before rejecting a join.
+ */
+export const POSTGRES_CHANGES_WAIT_ERROR_GRACE = 10000
+
 export const WS_CLOSE_NORMAL = 1000
 export const MAX_PUSH_BUFFER_SIZE = 100
 

--- a/packages/core/realtime-js/test/RealtimeChannel.postgres.test.ts
+++ b/packages/core/realtime-js/test/RealtimeChannel.postgres.test.ts
@@ -2,7 +2,7 @@ import assert from 'assert'
 import { describe, beforeEach, afterEach, test, vi, expect } from 'vitest'
 import RealtimeChannel from '../src/RealtimeChannel'
 import { postgresChangesFilter } from '../src/RealtimePostgresFilterBuilder'
-import { CHANNEL_STATES } from '../src/lib/constants'
+import { CHANNEL_STATES, POSTGRES_CHANGES_WAIT_ERROR_GRACE } from '../src/lib/constants'
 import {
   phxJoinReply,
   setupRealtimeTest,
@@ -983,5 +983,185 @@ describe('Duplicate postgres_changes bindings', () => {
 
     expect(channel.bindings.broadcast.length).toBe(2)
     expect(channel.bindings.presence.length).toBe(2)
+  })
+})
+
+describe('postgres_changes_options (wait for subscription confirmation)', () => {
+  test('is omitted from the join payload when not configured', () => {
+    channel.on('postgres_changes', { event: '*', schema: 'public', table: 'users' }, vi.fn())
+
+    channel.subscribe()
+
+    expect(channel.joinPush.payload().config).not.toHaveProperty('postgres_changes_options')
+  })
+
+  test('is forwarded to the join payload when configured', () => {
+    const waitingChannel = testSetup.client.channel('test-postgres-wait', {
+      config: { postgres_changes_options: { wait: true, timeout: 20000 } },
+    })
+    waitingChannel.on('postgres_changes', { event: '*', schema: 'public', table: 'users' }, vi.fn())
+
+    waitingChannel.subscribe()
+
+    expect(waitingChannel.joinPush.payload().config.postgres_changes_options).toEqual({
+      wait: true,
+      timeout: 20000,
+    })
+
+    waitingChannel.unsubscribe()
+  })
+
+  test('extends the join push timeout past the configured wait timeout', () => {
+    const waitingChannel = testSetup.client.channel('test-postgres-wait-timeout', {
+      config: { postgres_changes_options: { wait: true, timeout: 20000 } },
+    })
+    waitingChannel.on('postgres_changes', { event: '*', schema: 'public', table: 'users' }, vi.fn())
+
+    waitingChannel.subscribe()
+
+    expect(waitingChannel.joinPush.timeout).toBe(20000 + POSTGRES_CHANGES_WAIT_ERROR_GRACE)
+
+    waitingChannel.unsubscribe()
+  })
+
+  test('defaults the wait timeout to 15000ms when wait is true but no timeout is given', () => {
+    const waitingChannel = testSetup.client.channel('test-postgres-wait-default-timeout', {
+      config: { postgres_changes_options: { wait: true } },
+    })
+    waitingChannel.on('postgres_changes', { event: '*', schema: 'public', table: 'users' }, vi.fn())
+
+    waitingChannel.subscribe()
+
+    expect(waitingChannel.joinPush.timeout).toBe(15000 + POSTGRES_CHANGES_WAIT_ERROR_GRACE)
+
+    waitingChannel.unsubscribe()
+  })
+
+  test('does not extend the join push timeout when there are no postgres_changes bindings', () => {
+    const waitingChannel = testSetup.client.channel('test-postgres-wait-no-bindings', {
+      config: { postgres_changes_options: { wait: true, timeout: 20000 } },
+    })
+
+    waitingChannel.subscribe()
+
+    expect(waitingChannel.joinPush.timeout).toBe(defaultTimeout)
+
+    waitingChannel.unsubscribe()
+  })
+
+  test('does not extend the join push timeout when wait is false', () => {
+    const waitingChannel = testSetup.client.channel('test-postgres-wait-disabled', {
+      config: { postgres_changes_options: { wait: false, timeout: 20000 } },
+    })
+    waitingChannel.on('postgres_changes', { event: '*', schema: 'public', table: 'users' }, vi.fn())
+
+    waitingChannel.subscribe()
+
+    expect(waitingChannel.joinPush.timeout).toBe(defaultTimeout)
+
+    waitingChannel.unsubscribe()
+  })
+
+  test('does not shrink an explicitly larger subscribe() timeout', () => {
+    const waitingChannel = testSetup.client.channel('test-postgres-wait-larger-timeout', {
+      config: { postgres_changes_options: { wait: true, timeout: 5000 } },
+    })
+    waitingChannel.on('postgres_changes', { event: '*', schema: 'public', table: 'users' }, vi.fn())
+
+    waitingChannel.subscribe(undefined, 30000)
+
+    expect(waitingChannel.joinPush.timeout).toBe(30000)
+
+    waitingChannel.unsubscribe()
+  })
+
+  describe('subscribe() callback behavior', () => {
+    test('reports SUBSCRIBED only once the server replies ok', async () => {
+      const waitingChannel = testSetup.client.channel('test-wait-subscribed', {
+        config: { postgres_changes_options: { wait: true, timeout: 5000 } },
+      })
+      waitingChannel.on(
+        'postgres_changes',
+        { event: '*', schema: 'public', table: 'users' },
+        vi.fn()
+      )
+
+      const statuses: string[] = []
+      waitingChannel.subscribe((status) => statuses.push(status))
+
+      await vi.advanceTimersByTimeAsync(4000)
+      expect(statuses).toEqual([])
+
+      testSetup.mockServer.emit(
+        'message',
+        phxJoinReply(waitingChannel, {
+          postgres_changes: [{ event: '*', schema: 'public', table: 'users', id: 'srv-1' }],
+        })
+      )
+
+      await waitForChannelSubscribed(waitingChannel)
+      expect(statuses).toEqual(['SUBSCRIBED'])
+
+      waitingChannel.unsubscribe()
+    })
+
+    test("surfaces the server's timeout rejection as CHANNEL_ERROR before the client gives up", async () => {
+      const waitTimeout = 5000
+      const waitingChannel = testSetup.client.channel('test-wait-server-timeout', {
+        config: { postgres_changes_options: { wait: true, timeout: waitTimeout } },
+      })
+      waitingChannel.on(
+        'postgres_changes',
+        { event: '*', schema: 'public', table: 'users' },
+        vi.fn()
+      )
+
+      const seen: { status: string; message?: string }[] = []
+      waitingChannel.subscribe((status, err) => seen.push({ status, message: err?.message }))
+
+      await vi.advanceTimersByTimeAsync(waitTimeout + 5000)
+
+      expect(seen).toEqual([])
+
+      testSetup.mockServer.emit(
+        'message',
+        phxJoinReply(
+          waitingChannel,
+          {
+            reason: `PostgresChangesSubscribeTimeout: Timed out after ${waitTimeout}ms waiting for the postgres_changes subscription`,
+          },
+          'error'
+        )
+      )
+
+      await vi.waitFor(() => expect(seen.length).toBeGreaterThan(0))
+
+      expect(seen[0].status).toBe('CHANNEL_ERROR')
+      expect(seen[0].message).toContain('PostgresChangesSubscribeTimeout')
+
+      waitingChannel.unsubscribe()
+    })
+
+    test('reports TIMED_OUT only when the server never replies at all', async () => {
+      const waitingChannel = testSetup.client.channel('test-wait-no-reply', {
+        config: { postgres_changes_options: { wait: true, timeout: 5000 } },
+      })
+      waitingChannel.on(
+        'postgres_changes',
+        { event: '*', schema: 'public', table: 'users' },
+        vi.fn()
+      )
+
+      const statuses: string[] = []
+      waitingChannel.subscribe((status) => statuses.push(status))
+
+      await vi.advanceTimersByTimeAsync(5000 + POSTGRES_CHANGES_WAIT_ERROR_GRACE - 1)
+      expect(statuses).toEqual([])
+
+      await vi.advanceTimersByTimeAsync(10)
+      expect(statuses).toContain('TIMED_OUT')
+
+      waitingChannel.unsubscribe()
+    })
   })
 })


### PR DESCRIPTION
## 🔍 Description

Adds a `wait: true` option so subscribe() doesn't report SUBSCRIBED until the server confirms the postgres_changes subscription is actually active ‚fixing a race where changes could be missed if the channel joined before replication was streaming.

```
config: {
  postgres_changes_options: {
    wait?: boolean     // wait for server confirmation before SUBSCRIBED
    timeout?: number   // ms to wait, default 15000
  }
}
```

If confirmation fails, you get CHANNEL_ERROR with the server's reason instead of a false SUBSCRIBED.