### PR TITLE
fix(supabase): add missing SDK request headers to the CORS allow-list

### DIFF
--- a/packages/core/supabase-js/src/cors.ts
+++ b/packages/core/supabase-js/src/cors.ts
@@ -34,6 +34,14 @@
  * - x-client-info: Library version information
  * - apikey: Project API key
  * - content-type: Standard HTTP content type
+ * - accept-profile: Schema selected by postgrest-js on GET/HEAD requests
+ * - content-profile: Schema selected by postgrest-js on writes
+ * - cache-control: Cache directive sent by storage-js on uploads. Only safelisted
+ *   as a response header, so as a request header it still triggers a preflight
+ * - x-supabase-api-version: API version pinned by auth-js on every request
+ * - x-region: Function region sent by functions-js when a region is configured
+ * - x-upsert: Upsert flag sent by storage-js on uploads and signed upload URLs
+ * - x-metadata: Base64-encoded object metadata sent by storage-js on uploads
  * - x-retry-count: Retry attempt number sent by postgrest-js on retried requests
  * - traceparent: W3C trace context sent when `tracePropagation` is enabled
  * - tracestate: Vendor-specific trace data sent alongside traceparent
@@ -44,6 +52,13 @@ const SUPABASE_HEADERS = [
   'x-client-info',
   'apikey',
   'content-type',
+  'accept-profile',
+  'content-profile',
+  'cache-control',
+  'x-supabase-api-version',
+  'x-region',
+  'x-upsert',
+  'x-metadata',
   'x-retry-count',
   'traceparent',
   'tracestate',

--- a/packages/core/supabase-js/test/unit/cors.test.ts
+++ b/packages/core/supabase-js/test/unit/cors.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from '@jest/globals'
 import { corsHeaders, type CorsHeaders } from '../../src/cors'
+import { createClient, FunctionRegion, type SupabaseClient } from '../../src/index'
 
 describe('CORS Module', () => {
   describe('corsHeaders', () => {
@@ -16,15 +17,22 @@ describe('CORS Module', () => {
     it('should include all Supabase custom headers', () => {
       const allowedHeaders = corsHeaders['Access-Control-Allow-Headers']
 
-      // Pin the exact list: when the SDK starts sending a new header, this
-      // test must fail until the header is added to SUPABASE_HEADERS —
-      // otherwise browser preflights break for Edge Functions using corsHeaders.
+      // Pin the exact list. This catches an accidental edit to SUPABASE_HEADERS;
+      // the "headers the SDK actually sends" describe block below is what catches
+      // a new header being sent without being added here.
       expect(allowedHeaders.split(', ').sort()).toEqual(
         [
           'authorization',
           'x-client-info',
           'apikey',
           'content-type',
+          'accept-profile',
+          'content-profile',
+          'cache-control',
+          'x-supabase-api-version',
+          'x-region',
+          'x-upsert',
+          'x-metadata',
           'x-retry-count',
           'traceparent',
           'tracestate',
@@ -54,6 +62,90 @@ describe('CORS Module', () => {
 
     it('should not include Access-Control-Allow-Credentials by default', () => {
       expect(corsHeaders).not.toHaveProperty('Access-Control-Allow-Credentials')
+    })
+  })
+
+  describe('headers the SDK actually sends', () => {
+    // The pinned list above only compares SUPABASE_HEADERS against a copy of
+    // itself, so it cannot notice a sub-client starting to send a new header.
+    // These cases drive the sub-clients through a recording fetch and assert
+    // every request header they emit is covered by the allow-list — which is
+    // the property Edge Functions using `corsHeaders` actually depend on.
+    const allowed = new Set(
+      corsHeaders['Access-Control-Allow-Headers'].split(',').map((h) => h.trim().toLowerCase())
+    )
+
+    const headerNamesFrom = (init: RequestInit | undefined): string[] => {
+      const headers = init?.headers
+      if (!headers) return []
+      if (headers instanceof Headers) return [...headers.keys()].map((k) => k.toLowerCase())
+      if (Array.isArray(headers)) return headers.map(([name]) => name.toLowerCase())
+      return Object.keys(headers).map((name) => name.toLowerCase())
+    }
+
+    /** Runs `exercise` against a client whose fetch records request header names. */
+    const observeHeaders = async (
+      exercise: (client: SupabaseClient) => PromiseLike<unknown>
+    ): Promise<string[]> => {
+      const seen: string[] = []
+      const recordingFetch = async (_input: RequestInfo | URL, init?: RequestInit) => {
+        seen.push(...headerNamesFrom(init))
+        return new Response('{}', {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      }
+      const client = createClient('http://localhost:3000', 'some.fake.key', {
+        global: { fetch: recordingFetch as typeof fetch },
+      })
+      await exercise(client)
+      return [...new Set(seen)]
+    }
+
+    const expectAllAllowed = (observed: string[]) => {
+      expect(observed.length).toBeGreaterThan(0)
+      expect(observed.filter((name) => !allowed.has(name))).toEqual([])
+    }
+
+    it('covers the headers functions.invoke sends for a region', async () => {
+      const observed = await observeHeaders((client) =>
+        client.functions.invoke('hello', {
+          region: FunctionRegion.UsEast1,
+          body: { hello: 'world' },
+        })
+      )
+      expect(observed).toContain('x-region')
+      expectAllAllowed(observed)
+    })
+
+    it('covers the headers a storage upload sends', async () => {
+      const observed = await observeHeaders((client) =>
+        client.storage.from('bucket').upload('note.txt', 'hello', {
+          upsert: true,
+          contentType: 'text/plain',
+          metadata: { owner: 'tests' },
+        })
+      )
+      expect(observed).toEqual(expect.arrayContaining(['x-upsert', 'x-metadata', 'cache-control']))
+      expectAllAllowed(observed)
+    })
+
+    it('covers the headers an auth request sends', async () => {
+      const observed = await observeHeaders((client) => client.auth.getUser('some.jwt.token'))
+      expect(observed).toContain('x-supabase-api-version')
+      expectAllAllowed(observed)
+    })
+
+    it('covers the headers a postgrest read sends', async () => {
+      const observed = await observeHeaders((client) => client.from('users').select('id'))
+      expect(observed).toContain('accept-profile')
+      expectAllAllowed(observed)
+    })
+
+    it('covers the headers a postgrest write sends', async () => {
+      const observed = await observeHeaders((client) => client.from('users').insert({ id: 1 }))
+      expect(observed).toContain('content-profile')
+      expectAllAllowed(observed)
     })
   })
 


### PR DESCRIPTION
## 🔍 Description

`corsHeaders` (`@supabase/supabase-js/cors`) describes itself as "all custom headers sent by the Supabase SDK", and the module comment tells you to "update SUPABASE_HEADERS whenever the SDK starts sending one". Seven headers the SDK does send were missing from `Access-Control-Allow-Headers`:

| header | sent by | where |
| --- | --- | --- |
| `accept-profile` | postgrest-js | `PostgrestBuilder.ts:287` — reads, whenever a schema is set |
| `content-profile` | postgrest-js | `PostgrestBuilder.ts:289` — writes, whenever a schema is set |
| `cache-control` | storage-js | `StorageFileApi.ts:116` — uploads |
| `x-supabase-api-version` | auth-js | `lib/fetch.ts:186` — every request |
| `x-region` | functions-js | `FunctionsClient.ts:222` — `invoke()` with a region configured |
| `x-upsert` | storage-js | `StorageFileApi.ts:93,292,400` — uploads and signed upload URLs |
| `x-metadata` | storage-js | `StorageFileApi.ts:120,317` — uploads |

None of them are [CORS-safelisted request headers](https://fetch.spec.whatwg.org/#cors-safelisted-request-header) — that list is only `accept`, `accept-language`, `content-language`, `content-type` and `range`; `Cache-Control` is safelisted for *responses*, not requests — so each one triggers a preflight. When an Edge Function answers that preflight with `corsHeaders`, the browser rejects the call and the real request is never sent.

Two of these are not edge cases. `createClient` defaults the PostgREST schema to `public`, so `accept-profile` and `content-profile` go out on virtually every database call, and `x-supabase-api-version` goes out on every auth call.

### What changed?

- Added the seven headers to `SUPABASE_HEADERS` in `packages/core/supabase-js/src/cors.ts`, each documented with the client that sends it and when.
- Replaced the completeness claim in `test/unit/cors.test.ts` with a check that can actually detect drift.

### Why was this change needed?

The test meant to prevent exactly this said:

```ts
// Pin the exact list: when the SDK starts sending a new header, this
// test must fail until the header is added to SUPABASE_HEADERS —
// otherwise browser preflights break for Edge Functions using corsHeaders.
```

but it compared `SUPABASE_HEADERS` against a hardcoded copy of itself. It can only catch someone editing the constant, never a sub-client starting to send a new header — which is how the list drifted.

The new `headers the SDK actually sends` block drives auth, postgrest (read and write), storage and functions through a recording `fetch` and asserts every request header they emit is covered by the allow-list. That guard is what turned up `accept-profile` and `content-profile`; I had missed both when grepping for header assignments.

`test/deno/cors-validation.test.ts` already refers to "the v2.93.0 incident when hardcoded CORS didn't include" a new header, so this failure mode has bitten before.

I also checked realtime: its `send()` REST fallback only sets `apikey`, `Content-Type` and `Authorization`, all already allowed, so there is no gap there.

## 🔄 Breaking changes

- [x] This PR contains no breaking changes

The change only widens what an Edge Function using `corsHeaders` accepts.

## 📋 Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/supabase/supabase-js/blob/master/CONTRIBUTING.md)
- [x] My PR title follows the [conventional commit format](https://www.conventionalcommits.org/): `<type>(<scope>): <description>`
- [x] I have run `prettier` over both changed files (`--check` clean)
- [x] I have added tests for new functionality
- [x] I have updated documentation — the `SUPABASE_HEADERS` doc comment now lists each header and its source

## 📝 Additional notes

### Verification

Reverting only `src/cors.ts` and keeping the tests leaves `6 failed, 7 passed`, and each failure names the exact header that is missing:

```console
$ npx jest --runInBand test/unit/cors.test.ts
  ✕ covers the headers functions.invoke sends for a region     + "x-region"
  ✕ covers the headers a storage upload sends                  + "cache-control", "x-metadata", "x-upsert"
  ✕ covers the headers an auth request sends                   + "x-supabase-api-version"
  ✕ covers the headers a postgrest read sends                  + "accept-profile"
  ✕ covers the headers a postgrest write sends                 + "content-profile"
  ✕ should include all Supabase custom headers
Tests: 6 failed, 7 passed, 13 total
```

With the change:

```console
$ npx jest --runInBand test/unit/cors.test.ts
Tests: 13 passed, 13 total

$ npx jest --runInBand test/unit
Test Suites: 11 passed, 11 total
Tests:       149 passed, 149 total

$ npm run test:types      # tsd incl. dist/cors.d.cts, plus jsr publish --dry-run
$ npx tsdown              # build
```

Both exit 0.

`test/types/cors.test-d.ts` asserts types only, and the Deno CORS suite only requires a four-header subset, so neither needed updating. `src/cors.ts` and `test/unit/cors.test.ts` are the only two places that spell out the list.
