### PR TITLE
fix(postgrest): honour HTTP-date Retry-After and bound the retry delay

### DIFF
--- a/packages/core/postgrest-js/src/PostgrestBuilder.ts
+++ b/packages/core/postgrest-js/src/PostgrestBuilder.ts
@@ -10,6 +10,8 @@ import {
   Fetch,
   DEFAULT_MAX_RETRIES,
   getRetryDelay,
+  MAX_RETRY_AFTER_DELAY,
+  parseRetryAfter,
   RETRYABLE_STATUS_CODES,
   RETRYABLE_METHODS,
 } from './types/common/common'
@@ -370,10 +372,12 @@ export default abstract class PostgrestBuilder<
 
         // Check if we should retry this HTTP response
         if (shouldRetry(this.method, res.status, attemptCount, this.retryEnabled)) {
-          const retryAfterHeader = res.headers?.get('Retry-After') ?? null
+          // `Retry-After` may be delay-seconds or an HTTP-date; anything else
+          // falls back to exponential backoff rather than retrying immediately.
+          const retryAfter = parseRetryAfter(res.headers?.get('Retry-After') ?? null)
           const delay =
-            retryAfterHeader !== null
-              ? Math.max(0, parseInt(retryAfterHeader, 10) || 0) * 1000
+            retryAfter !== null
+              ? Math.min(retryAfter, MAX_RETRY_AFTER_DELAY)
               : getRetryDelay(attemptCount)
           await res.text()
           attemptCount++

--- a/packages/core/postgrest-js/src/types/common/common.ts
+++ b/packages/core/postgrest-js/src/types/common/common.ts
@@ -18,6 +18,60 @@ export const getRetryDelay = (attemptIndex: number): number =>
   Math.min(1000 * 2 ** attemptIndex, 30000)
 
 /**
+ * Upper bound on a delay taken from a `Retry-After` header, in milliseconds.
+ *
+ * Matches the ceiling of {@link getRetryDelay} so a server — or an intermediary
+ * such as a CDN — cannot stall a request for an arbitrary length of time.
+ */
+export const MAX_RETRY_AFTER_DELAY = 30000
+
+/**
+ * Parse a `Retry-After` header value into a delay in milliseconds.
+ *
+ * `Retry-After` is either `delay-seconds` or an `HTTP-date`:
+ *
+ * ```
+ * Retry-After = HTTP-date / delay-seconds
+ * delay-seconds = 1*DIGIT
+ * ```
+ *
+ * Returns `null` when the value is absent, empty, or matches neither form, so
+ * callers can fall back to their own backoff instead of retrying immediately.
+ * `Date.parse` handles the preferred IMF-fixdate form (and, in V8, the obsolete
+ * RFC 850 form), but its behaviour on non-ISO input is implementation-defined,
+ * so engines that reject a given format simply take the `null` fallback.
+ *
+ * @param value - Raw header value, or null when the header is absent
+ * @param now - Reference time used to turn an HTTP-date into a delay
+ * @returns Delay in milliseconds, or null if the value cannot be interpreted
+ *
+ * @see https://www.rfc-editor.org/rfc/rfc9110.html#name-retry-after
+ */
+export const parseRetryAfter = (value: string | null, now: number = Date.now()): number | null => {
+  if (value === null) {
+    return null
+  }
+
+  const trimmed = value.trim()
+  if (trimmed === '') {
+    return null
+  }
+
+  // delay-seconds: digits only, so a malformed value like "30s" is not read as 30
+  if (/^\d+$/.test(trimmed)) {
+    return Number(trimmed) * 1000
+  }
+
+  // HTTP-date: a timestamp already in the past means "retry now"
+  const retryAt = Date.parse(trimmed)
+  if (!Number.isNaN(retryAt)) {
+    return Math.max(0, retryAt - now)
+  }
+
+  return null
+}
+
+/**
  * Status codes that are safe to retry.
  * 520 = Cloudflare timeout/connection errors (transient)
  * 503 = PostgREST schema cache not yet loaded (transient, signals retry via Retry-After header)

--- a/packages/core/postgrest-js/test/retry.test.ts
+++ b/packages/core/postgrest-js/test/retry.test.ts
@@ -413,6 +413,90 @@ describe('Automatic Retries', () => {
     })
   })
 
+  describe('Retry-After header', () => {
+    // `Retry-After` is either delay-seconds or an HTTP-date (RFC 9110 §10.2.3).
+    // Capture the delay actually slept so each form can be asserted directly.
+    let delaysSeen: number[]
+
+    beforeEach(() => {
+      delaysSeen = []
+      const realSetTimeout = globalThis.setTimeout
+      jest.spyOn(globalThis, 'setTimeout').mockImplementation(((fn: any, delay?: number) => {
+        delaysSeen.push(delay as number)
+        return realSetTimeout(fn, 0)
+      }) as any)
+    })
+
+    const unavailable = (retryAfter: string) => ({
+      ok: false,
+      status: 503,
+      statusText: 'Service Unavailable',
+      headers: new Headers({ 'Retry-After': retryAfter, 'Content-Type': 'application/json' }),
+      text: () => Promise.resolve(JSON.stringify({ code: 'PGRST002', message: 'retrying' })),
+    })
+
+    const success = () => ({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      headers: new Headers(),
+      text: () => Promise.resolve('[]'),
+    })
+
+    /** Delay slept before the single retry triggered by a 503 carrying `retryAfter`. */
+    async function delayFor(retryAfter: string): Promise<number> {
+      fetchMock.mockResolvedValueOnce(unavailable(retryAfter)).mockResolvedValueOnce(success())
+      const client = new PostgrestClient('http://localhost:3000', { fetch: fetchMock })
+      const result = await runWithTimers(client.from('users').select())
+      expect(result.error).toBeNull()
+      expect(fetchMock).toHaveBeenCalledTimes(2)
+      return delaysSeen[0]
+    }
+
+    it('should honour delay-seconds', async () => {
+      expect(await delayFor('2')).toBe(2000)
+    })
+
+    it('should treat delay-seconds of 0 as an immediate retry', async () => {
+      expect(await delayFor('0')).toBe(0)
+    })
+
+    it('should honour an HTTP-date instead of retrying immediately', async () => {
+      const retryAt = new Date(Date.now() + 5000).toUTCString()
+      const delay = await delayFor(retryAt)
+      // Whole-second header resolution means the delay lands just under 5s.
+      expect(delay).toBeGreaterThan(3000)
+      expect(delay).toBeLessThanOrEqual(5000)
+    })
+
+    it('should retry immediately for an HTTP-date already in the past', async () => {
+      expect(await delayFor(new Date(Date.now() - 60_000).toUTCString())).toBe(0)
+    })
+
+    it('should fall back to exponential backoff for an unparseable value', async () => {
+      // Previously parsed as 0 via `parseInt`, producing an immediate hot retry.
+      expect(await delayFor('soon')).toBe(1000)
+    })
+
+    it('should fall back to exponential backoff for an empty value', async () => {
+      expect(await delayFor('')).toBe(1000)
+    })
+
+    it('should not read a trailing-unit value as a bare number of seconds', async () => {
+      expect(await delayFor('30s')).toBe(1000)
+    })
+
+    it('should cap a very large delay-seconds value', async () => {
+      // A day-long Retry-After previously stalled the request for 24 hours.
+      expect(await delayFor('86400')).toBe(30000)
+    })
+
+    it('should cap a far-future HTTP-date', async () => {
+      const farFuture = new Date(Date.now() + 86_400_000).toUTCString()
+      expect(await delayFor(farFuture)).toBe(30000)
+    })
+  })
+
   describe('AbortError handling', () => {
     it('should rethrow AbortError immediately without retrying', async () => {
       const abortError = new Error('The operation was aborted')

--- a/packages/core/supabase-js/src/lib/rest/types/common/common.ts
+++ b/packages/core/supabase-js/src/lib/rest/types/common/common.ts
@@ -28,6 +28,60 @@ export const getRetryDelay = (attemptIndex: number): number =>
   Math.min(1000 * 2 ** attemptIndex, 30000)
 
 /**
+ * Upper bound on a delay taken from a `Retry-After` header, in milliseconds.
+ *
+ * Matches the ceiling of {@link getRetryDelay} so a server — or an intermediary
+ * such as a CDN — cannot stall a request for an arbitrary length of time.
+ */
+export const MAX_RETRY_AFTER_DELAY = 30000
+
+/**
+ * Parse a `Retry-After` header value into a delay in milliseconds.
+ *
+ * `Retry-After` is either `delay-seconds` or an `HTTP-date`:
+ *
+ * ```
+ * Retry-After = HTTP-date / delay-seconds
+ * delay-seconds = 1*DIGIT
+ * ```
+ *
+ * Returns `null` when the value is absent, empty, or matches neither form, so
+ * callers can fall back to their own backoff instead of retrying immediately.
+ * `Date.parse` handles the preferred IMF-fixdate form (and, in V8, the obsolete
+ * RFC 850 form), but its behaviour on non-ISO input is implementation-defined,
+ * so engines that reject a given format simply take the `null` fallback.
+ *
+ * @param value - Raw header value, or null when the header is absent
+ * @param now - Reference time used to turn an HTTP-date into a delay
+ * @returns Delay in milliseconds, or null if the value cannot be interpreted
+ *
+ * @see https://www.rfc-editor.org/rfc/rfc9110.html#name-retry-after
+ */
+export const parseRetryAfter = (value: string | null, now: number = Date.now()): number | null => {
+  if (value === null) {
+    return null
+  }
+
+  const trimmed = value.trim()
+  if (trimmed === '') {
+    return null
+  }
+
+  // delay-seconds: digits only, so a malformed value like "30s" is not read as 30
+  if (/^\d+$/.test(trimmed)) {
+    return Number(trimmed) * 1000
+  }
+
+  // HTTP-date: a timestamp already in the past means "retry now"
+  const retryAt = Date.parse(trimmed)
+  if (!Number.isNaN(retryAt)) {
+    return Math.max(0, retryAt - now)
+  }
+
+  return null
+}
+
+/**
  * Status codes that are safe to retry.
  * 520 = Cloudflare timeout/connection errors (transient)
  * 503 = PostgREST schema cache not yet loaded (transient, signals retry via Retry-After header)


### PR DESCRIPTION
## 🔍 Description

`Retry-After` can be either `delay-seconds` or an `HTTP-date` ([RFC 9110 §10.2.3](https://www.rfc-editor.org/rfc/rfc9110.html#name-retry-after)):

```
Retry-After   = HTTP-date / delay-seconds
delay-seconds = 1*DIGIT
```

The retry path in `PostgrestBuilder` read it with `parseInt(retryAfterHeader, 10) || 0`, which only handles the second form. Delays measured against a 503 carrying the header:

| `Retry-After` | before | after |
| --- | --- | --- |
| `2` | 2000 ms | 2000 ms |
| `Thu, 27 Aug 2026 11:12:53 GMT` (~120 s out) | **0 ms** | ~120000 ms |
| `86400` | **86400000 ms** | 30000 ms |
| `soon` | **0 ms** | 1000 ms |

Three separate problems, all in that one expression:

1. **An HTTP-date retries immediately.** `parseInt('Thu, 27 Aug …')` is `NaN` and `NaN || 0` is `0`, so the client hot-retries a server that has just asked it to wait — the opposite of what the header means. That lands squarely on the path this code exists for: 503 is retryable for `PGRST002`, and the comment on `RETRYABLE_STATUS_CODES` says 503 "signals retry via Retry-After header".
2. **The exponential backoff fallback is skipped.** The fallback to `getRetryDelay()` is keyed on the header being *absent*, so any present-but-unparseable value yields 0 ms instead of backing off.
3. **The delay is unbounded.** `getRetryDelay()` caps its own backoff at 30 s, but a `Retry-After` of `86400` slept for 24 hours, leaving the caller's promise pending for a day.

### What changed?

- Added `parseRetryAfter()` beside `getRetryDelay()` in `postgrest-js/src/types/common/common.ts`. It handles `delay-seconds` and `HTTP-date`, treats a timestamp already in the past as "retry now", and returns `null` when the value matches neither form so the caller falls back to its own backoff.
- Added `MAX_RETRY_AFTER_DELAY` — 30 s, the ceiling `getRetryDelay` already applies — and clamped the honoured delay to it.
- Regenerated `packages/core/supabase-js/src/lib/rest/types/common/common.ts`, which is synced from that file (`pnpm codegen`; `pnpm codegen:check` is clean).

### Why was this change needed?

A 503 with a date-form `Retry-After` currently produces the worst possible behaviour: the client retries with no delay at all, three times in a row, against a service that explicitly asked for a pause. Falling back to `getRetryDelay()` on an unparseable value is also strictly safer than 0 ms, which matters because `Date.parse` is implementation-defined for non-ISO input — an engine that rejects a format now backs off instead of hot-looping.

## 🔄 Breaking changes

- [x] This PR contains no breaking changes

Two behaviour changes I want to flag rather than bury, both easy to drop if you disagree:

- `delay-seconds` is now matched strictly as `1*DIGIT`, so a non-conforming `Retry-After: 30s` takes the backoff fallback instead of being read as 30 seconds. I went strict because guessing at units is unsafe in the general case: `parseInt` reads `30m` as 30 seconds when the server meant 30 minutes. Happy to restore the lenient leading-integer behaviour if you would rather keep it.
- The clamp means a `Retry-After` above 30 s now retries at 30 s rather than waiting the full period. The alternative is to stop retrying altogether when the server asks for longer than the ceiling, surfacing the error immediately instead of burning the retry budget. I picked the clamp because it matches the existing `getRetryDelay` ceiling, but I have no strong preference.

## 📋 Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/supabase/supabase-js/blob/master/CONTRIBUTING.md)
- [x] My PR title follows the [conventional commit format](https://www.conventionalcommits.org/): `<type>(<scope>): <description>`
- [x] I have run `prettier` over every changed file (`--check` clean)
- [x] I have added tests for new functionality
- [x] I have updated documentation — `parseRetryAfter` and `MAX_RETRY_AFTER_DELAY` carry JSDoc citing the RFC

## 📝 Additional notes

### Verification

Reverting only the two `src` files and keeping the tests leaves `5 failed, 26 passed`, each failure naming the exact delay:

```console
$ npx jest --runInBand test/retry.test.ts
  ✕ should honour an HTTP-date instead of retrying immediately   expected > 3000, received 0
  ✕ should fall back to exponential backoff for an unparseable value  expected 1000, received 0
  ✕ should not read a trailing-unit value as a bare number of seconds expected 1000, received 30000
  ✕ should cap a very large delay-seconds value                  expected 30000, received 86400000
  ✕ should cap a far-future HTTP-date                            expected 30000, received 0
Tests: 5 failed, 26 passed, 31 total
```

With the change, `32 passed` (9 new cases), stable over three consecutive runs.

Package-wide, the counts are unchanged apart from the new tests. On an unmodified checkout the suite is `14 failed suites / 274 failed tests / 80 passed`; with this branch it is `14 failed / 274 failed / 88 passed`. The failures are the Docker-backed integration suites failing with `ECONNREFUSED` because I have no local PostgREST — identical before and after, and the passing count moves by exactly the 8 tests I added at that point.

`npx tsdown` builds clean for both `postgrest-js` and `supabase-js`, and `supabase-js`'s unit suite still passes 149/149 after the codegen sync.

### One caveat on HTTP-date parsing

RFC 9110 requires recipients to accept all three date formats. `Date.parse` handles IMF-fixdate (`Sun, 06 Nov 1994 08:49:37 GMT`) and, in V8, the obsolete RFC 850 form. The obsolete asctime form (`Sun Nov  6 08:49:37 1994`) parses but is interpreted as local time rather than UTC, so on a non-UTC host it is off by the local offset. In practice the clamp absorbs this — any date more than 30 s out yields the 30 s ceiling either way — and asctime `Retry-After` values are vanishingly rare, so I left it rather than hand-rolling a date parser. Glad to add one if you want strict conformance.
