### PR TITLE
fix(realtime): stop reporting every push failure as a missing subscribe()

### DIFF
--- a/packages/core/realtime-js/src/phoenix/channelAdapter.ts
+++ b/packages/core/realtime-js/src/phoenix/channelAdapter.ts
@@ -77,9 +77,19 @@ export default class ChannelAdapter {
     try {
       push = this.channel.push(event, payload, timeout)
     } catch (error) {
-      throw new Error(
-        `tried to push '${event}' to '${this.channel.topic}' before joining. Use channel.subscribe() before pushing events`
-      )
+      // phoenix throws only when the channel has never been joined, so that is
+      // the one case worth relabelling (`join()` -> `subscribe()`). Any other
+      // failure — most commonly a payload the encoder rejects — reaches here
+      // too, and must keep its own message and stack rather than be reported as
+      // a missing subscribe().
+      if (!this.channel.joinedOnce) {
+        throw new Error(
+          `tried to push '${event}' to '${this.channel.topic}' before joining. Use channel.subscribe() before pushing events`,
+          { cause: error }
+        )
+      }
+
+      throw error
     }
 
     if (this.channel.pushBuffer.length > MAX_PUSH_BUFFER_SIZE) {

--- a/packages/core/realtime-js/test/phoenix/channelAdapter.test.ts
+++ b/packages/core/realtime-js/test/phoenix/channelAdapter.test.ts
@@ -44,6 +44,56 @@ describe('push', () => {
     )
   })
 
+  test('keeps the original error as `cause` when pushed before joining', () => {
+    const original = new Error('Some error')
+    vi.spyOn(channelAdapter.getChannel(), 'push').mockImplementation(() => {
+      throw original
+    })
+
+    expect(() => channelAdapter.push('event', { payload: true })).toThrowError(/before joining/)
+    try {
+      channelAdapter.push('event', { payload: true })
+    } catch (error) {
+      expect((error as Error).cause).toBe(original)
+    }
+  })
+
+  test('rethrows the original error once the channel has joined', async () => {
+    channel.subscribe()
+    await waitForChannelSubscribed(channel)
+    expect(channelAdapter.joinedOnce).toBe(true)
+
+    const original = new TypeError('Converting circular structure to JSON')
+    vi.spyOn(channelAdapter.getChannel(), 'push').mockImplementation(() => {
+      throw original
+    })
+
+    // A push that fails for any reason other than "not joined" must keep its own
+    // message and stack — reporting it as a missing subscribe() sends the
+    // developer after a problem they do not have.
+    expect(() => channelAdapter.push('event', { payload: true })).toThrowError(original)
+    try {
+      channelAdapter.push('event', { payload: true })
+    } catch (error) {
+      expect(error).toBe(original)
+      expect((error as Error).message).not.toMatch(/before joining/)
+    }
+  })
+
+  test('surfaces the encoder error when send() is given an unencodable payload', async () => {
+    channel.subscribe()
+    await waitForChannelSubscribed(channel)
+
+    // A self-referencing payload is an ordinary mistake (a DOM node, a React
+    // ref, an object with a parent pointer) and JSON.stringify rejects it.
+    const circular: Record<string, unknown> = { name: 'node' }
+    circular.self = circular
+
+    await expect(
+      channel.send({ type: 'broadcast', event: 'ping', payload: circular })
+    ).rejects.toThrowError(/circular/i)
+  })
+
   test('should maintain buffer within size limit', async () => {
     channel.subscribe()
     await waitForChannelSubscribed(channel)


### PR DESCRIPTION
## 🔍 Description

`ChannelAdapter.push()` wraps the phoenix `channel.push()` call in a catch-all that always rethrows the same message and drops the original error:

```ts
try {
  push = this.channel.push(event, payload, timeout)
} catch (error) {
  throw new Error(
    `tried to push '${event}' to '${this.channel.topic}' before joining. Use channel.subscribe() before pushing events`
  )
}
```

phoenix throws that error only when the channel has never been joined ([`channel.js`](https://github.com/supabase/phoenix/blob/main/assets/js/phoenix/channel.js), `if (!this.joinedOnce) { throw … }`). Once the channel *has* joined it carries on to `pushEvent.send()`, so anything that fails during send — most commonly the encoder rejecting the payload — comes back through the same `catch` and gets relabelled as a missing `subscribe()`.

A self-referencing payload is an ordinary mistake: a DOM node, a React ref, an object with a parent pointer. On a fully subscribed channel:

```ts
const circular: any = { name: 'node' }
circular.self = circular

await channel.send({ type: 'broadcast', event: 'ping', payload: circular })
```

rejects with:

```
tried to push 'broadcast' to 'realtime:room1' before joining.
Use channel.subscribe() before pushing events
```

while the channel reports `state: 'joined'` and `joinedOnce: true`. `cause` is unset, so the underlying `TypeError: Converting circular structure to JSON` and its stack are gone. The message sends the developer to add a `subscribe()` they have already made, and there is nothing left pointing at the payload.

### What changed?

Only relabel when the channel has genuinely never joined, and attach the original error as `cause` in that branch too. Every other failure is rethrown untouched:

```ts
} catch (error) {
  if (!this.channel.joinedOnce) {
    throw new Error(
      `tried to push '${event}' to '${this.channel.topic}' before joining. Use channel.subscribe() before pushing events`,
      { cause: error }
    )
  }

  throw error
}
```

### Why was this change needed?

The relabelling exists for a good reason — it translates phoenix's `channel.join()` into this SDK's `channel.subscribe()` — but it was applied unconditionally. The result is that the one error message a developer gets for a failed `send()` is, for every cause other than "not joined", both wrong and unactionable.

`{ cause }` is already used elsewhere in this package (`lib/normalizeChannelError.ts`), so no new baseline requirement.

## 🔄 Breaking changes

- [x] This PR contains no breaking changes

The "before joining" message is unchanged for the case it actually describes; the two existing tests covering it pass untouched. Callers that fail for other reasons now receive the real error instead of a misleading one.

## 📋 Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/supabase/supabase-js/blob/master/CONTRIBUTING.md)
- [x] My PR title follows the [conventional commit format](https://www.conventionalcommits.org/): `<type>(<scope>): <description>`
- [x] I have run `prettier` over both changed files (`--check` clean)
- [x] I have added tests for new functionality
- [ ] I have updated documentation — not applicable, no public API or documented behaviour changes

## 📝 Additional notes

### Verification

Three tests added to `test/phoenix/channelAdapter.test.ts`. Reverting only `src/phoenix/channelAdapter.ts` and keeping them gives `3 failed | 5 passed`:

```console
$ npx vitest run test/phoenix/channelAdapter.test.ts
 ✕ keeps the original error as `cause` when pushed before joining
     AssertionError: expected undefined to be Error: Some error
 ✕ rethrows the original error once the channel has joined
     AssertionError: expected a thrown error to be TypeError: Converting circular structure …
 ✕ surfaces the encoder error when send() is given an unencodable payload
     AssertionError: expected [Function] to throw error matching /circular/i
                     but got 'tried to push \'broadcast\' to \'real…'
 Tests  3 failed | 5 passed (8)
```

That last assertion is the user-visible symptom. With the change, `8 passed (8)`.

Package-wide the counts move by exactly the three new tests:

| | Test Files | Tests |
| --- | --- | --- |
| `master` | 1 failed, 25 passed | 2 failed, 473 passed, 1 skipped (476) |
| this branch | 1 failed, 25 passed | 2 failed, **476 passed**, 1 skipped (479) |

The two failures are `RealtimeClient.worker.test.ts` (`starts worker on conenction open`, `terminates worker on disconnect`), which fail identically on an unmodified checkout here — they need a real Web Worker implementation that my environment does not provide. Unrelated to this diff.

`npm run build` is clean and `prettier --check` passes on both files.
