### PR TITLE
ci: bump supabase/sdk reusable workflows to v1.3.0

### DIFF
--- a/.github/workflows/sync-compliance.yml
+++ b/.github/workflows/sync-compliance.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: supabase/sdk/.github/workflows/sync-sdk-compliance.yml@63c1ac1d44959bfd02e4fc70a09df287db4a425a # v1.1.1
+    uses: supabase/sdk/.github/workflows/sync-sdk-compliance.yml@4d74492587bde35691e8a85470c0a7ebd7badb3e # v1.3.0
     with:
       base-branch: master
     secrets:

--- a/.github/workflows/validate-capabilities.yml
+++ b/.github/workflows/validate-capabilities.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   validate:
-    uses: supabase/sdk/.github/workflows/validate-sdk-compliance-javascript.yml@63c1ac1d44959bfd02e4fc70a09df287db4a425a # v1.1.1
+    uses: supabase/sdk/.github/workflows/validate-sdk-compliance-javascript.yml@4d74492587bde35691e8a85470c0a7ebd7badb3e # v1.3.0
     with:
       build-command: |
         corepack enable


### PR DESCRIPTION
## What

Bumps the pinned `supabase/sdk` reusable workflow ref from `v1.1.1` to `v1.3.0`, in both `validate-capabilities.yml` and `sync-compliance.yml`.

## Why

`supabase/sdk` was restructured into a `packages/` monorepo layout ([supabase/sdk#93](https://github.com/supabase/sdk/pull/93)), moving `scripts/capability-matrix` to `packages/capability-matrix`.

Pinning there is not fully hermetic: the pinned workflow body comes from the tag, but the composite actions it calls are referenced `@main` and check out `supabase/sdk` at `main`. So on `v1.1.1` we get a post-restructure checkout combined with a workflow body that still hardcodes `_sdk-spec/scripts/capability-matrix`. That only works today because `supabase/sdk` carries transitional `scripts/` → `packages/` symlinks, which are there purely for pinned callers like this one and are meant to be deleted.

Bumping to `v1.3.0` puts the workflow body and the checked-out layout back in agreement, and lets those symlinks be removed upstream.

## Risk

Low. Across `v1.1.1` → `v1.2.0` → `v1.3.0` the reusable workflows changed **only** in these `scripts/` → `packages/` paths. No input was added, removed, renamed, or given a new default, so this is a pure ref bump with no call-site changes needed. In particular the existing `typedoc-packages` input is unchanged.

Worth confirming the compliance check job goes green here before merge, since that is the actual thing being verified.
