### PR TITLE
ci: bump supabase/sdk reusable workflows to capability-matrix-v1.6.0

### DIFF
--- a/.github/workflows/sync-compliance.yml
+++ b/.github/workflows/sync-compliance.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: supabase/sdk/.github/workflows/sync-sdk-compliance.yml@75cf587c486f80c2d2afe57ec909ee2520c098b9 # v1.5.0
+    uses: supabase/sdk/.github/workflows/sync-sdk-compliance.yml@a494be6719174adbca0313de1ee187407e2dca95 # capability-matrix-v1.6.0
     with:
       base-branch: master
     secrets:

--- a/.github/workflows/validate-capabilities.yml
+++ b/.github/workflows/validate-capabilities.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   validate:
-    uses: supabase/sdk/.github/workflows/validate-sdk-compliance-javascript.yml@75cf587c486f80c2d2afe57ec909ee2520c098b9 # v1.5.0
+    uses: supabase/sdk/.github/workflows/validate-sdk-compliance-javascript.yml@a494be6719174adbca0313de1ee187407e2dca95 # capability-matrix-v1.6.0
     with:
       build-command: |
         corepack enable


### PR DESCRIPTION
Bumps every supabase/sdk reusable workflow pin to the `capability-matrix-v1.6.0` tag (commit a494be6719174adbca0313de1ee187407e2dca95).

supabase/sdk stopped cutting root `vX.Y.Z` release tags (supabase/sdk#112); the compliance workflows and their tooling are now versioned through `capability-matrix-vX.Y.Z` tags instead. This is the one-time repin onto the new tag family; Dependabot follows the `capability-matrix-v*` prefix from here on.