### PR TITLE
fix(auth): preserve verified passkey when webauthn register() enrollment fails

### DIFF
--- a/packages/core/auth-js/src/lib/webauthn.ts
+++ b/packages/core/auth-js/src/lib/webauthn.ts
@@ -892,6 +892,10 @@ export class WebAuthnApi {
       })
 
       if (!factor) {
+        // Enrollment failed (commonly a friendly-name conflict). Clean up only a
+        // stale *unverified* factor left by a previous incomplete attempt so a
+        // retry can succeed. Never touch a verified factor: deleting the user's
+        // working passkey because a new enrollment failed would be data loss.
         await this.client.mfa
           .listFactors()
           .then((factors) =>
@@ -899,7 +903,7 @@ export class WebAuthnApi {
               (v) =>
                 v.factor_type === 'webauthn' &&
                 v.friendly_name === friendlyName &&
-                v.status !== 'unverified'
+                v.status === 'unverified'
             )
           )
           .then((factor) => (factor ? this.client.mfa.unenroll({ factorId: factor?.id }) : void 0))

--- a/packages/core/auth-js/test/webauthn.register.test.ts
+++ b/packages/core/auth-js/test/webauthn.register.test.ts
@@ -1,0 +1,127 @@
+import 'jest'
+
+import { WebAuthnApi } from '../src/lib/webauthn'
+import { AuthError } from '../src/lib/errors'
+
+/**
+ * `_register()` is gated by `browserSupportsWebAuthn()`, which needs a browser-like
+ * global. Provide the minimum surface so the enroll/cleanup path runs under the
+ * `node` test environment. Each Jest test file gets its own sandboxed global, so
+ * these assignments don't leak to other suites.
+ */
+const originalWindow = (globalThis as any).window
+const originalDocument = (globalThis as any).document
+const originalNavigator = Object.getOwnPropertyDescriptor(globalThis, 'navigator')
+
+beforeAll(() => {
+  ;(globalThis as any).window = {
+    PublicKeyCredential: function () {},
+    location: { hostname: 'example.com', origin: 'https://example.com' },
+  }
+  ;(globalThis as any).document = {}
+  Object.defineProperty(globalThis, 'navigator', {
+    value: { credentials: { create: () => {}, get: () => {} } },
+    configurable: true,
+    writable: true,
+  })
+})
+
+afterAll(() => {
+  ;(globalThis as any).window = originalWindow
+  ;(globalThis as any).document = originalDocument
+  if (originalNavigator) {
+    Object.defineProperty(globalThis, 'navigator', originalNavigator)
+  } else {
+    delete (globalThis as any).navigator
+  }
+})
+
+type StubFactor = {
+  id: string
+  factor_type: string
+  friendly_name: string
+  status: 'verified' | 'unverified'
+}
+
+function makeClient(factors: StubFactor[]) {
+  const unenroll = jest.fn(async () => ({ data: {}, error: null }))
+  const client = {
+    mfa: {
+      // Enrollment fails, e.g. a friendly-name conflict.
+      enroll: jest.fn(async () => ({
+        data: null,
+        error: new AuthError('A factor with this friendly name already exists'),
+      })),
+      listFactors: jest.fn(async () => ({ data: { all: factors }, error: null })),
+      unenroll,
+    },
+  }
+  return { client, unenroll }
+}
+
+const registerParams = {
+  friendlyName: 'Work Laptop',
+  webauthn: { rpId: 'example.com', rpOrigins: ['https://example.com'] },
+}
+
+describe('WebAuthnApi.register() failed-enrollment cleanup', () => {
+  test('preserves an existing verified factor when enrollment fails', async () => {
+    const { client, unenroll } = makeClient([
+      {
+        id: 'verified-factor-id',
+        factor_type: 'webauthn',
+        friendly_name: 'Work Laptop',
+        status: 'verified',
+      },
+    ])
+    const api = new WebAuthnApi(client as any)
+
+    const { data, error } = await api.register(registerParams)
+
+    // The enroll error is surfaced to the caller...
+    expect(data).toBeNull()
+    expect(error).toBeInstanceOf(AuthError)
+    // ...and the user's working passkey is left untouched.
+    expect(unenroll).not.toHaveBeenCalled()
+  })
+
+  test('removes a stale unverified factor so a retry can succeed', async () => {
+    const { client, unenroll } = makeClient([
+      {
+        id: 'stale-unverified-id',
+        factor_type: 'webauthn',
+        friendly_name: 'Work Laptop',
+        status: 'unverified',
+      },
+    ])
+    const api = new WebAuthnApi(client as any)
+
+    await api.register(registerParams)
+
+    expect(unenroll).toHaveBeenCalledTimes(1)
+    expect(unenroll).toHaveBeenCalledWith({ factorId: 'stale-unverified-id' })
+  })
+
+  test('does not touch a verified factor that shares a name with a stale unverified one', async () => {
+    const { client, unenroll } = makeClient([
+      {
+        id: 'verified-factor-id',
+        factor_type: 'webauthn',
+        friendly_name: 'Work Laptop',
+        status: 'verified',
+      },
+      {
+        id: 'stale-unverified-id',
+        factor_type: 'webauthn',
+        friendly_name: 'Work Laptop',
+        status: 'unverified',
+      },
+    ])
+    const api = new WebAuthnApi(client as any)
+
+    await api.register(registerParams)
+
+    expect(unenroll).toHaveBeenCalledTimes(1)
+    expect(unenroll).toHaveBeenCalledWith({ factorId: 'stale-unverified-id' })
+  })
+})


### PR DESCRIPTION
Fixes #2640

## Description

`mfa.webauthn.register()` runs a cleanup step when its internal enrollment call fails. That cleanup looked up a webauthn factor matching the requested friendly name with `status !== 'unverified'` — i.e. a **verified** factor — and unenrolled it:

```ts
// packages/core/auth-js/src/lib/webauthn.ts
if (!factor) {
  await this.client.mfa
    .listFactors()
    .then((factors) =>
      factors.data?.all.find(
        (v) =>
          v.factor_type === 'webauthn' &&
          v.friendly_name === friendlyName &&
          v.status !== 'unverified' // ← targets a VERIFIED factor
      )
    )
    .then((factor) => (factor ? this.client.mfa.unenroll({ factorId: factor?.id }) : void 0))
  return { data: null, error: enrollError }
}
```

Enrollment commonly fails on a **friendly-name conflict** — precisely the case where a verified factor with that name already exists. So a user who retries registration with an existing name (or whose UI naively retries after a transient error) has their **existing, working passkey silently deleted**, while the call just returns the original enrollment error.

The sensible cleanup semantics here are the opposite: remove a **stale unverified** factor left behind by a previous incomplete attempt so a retry can succeed, and never touch a verified factor. This PR flips the condition to `status === 'unverified'`.

## Type of Change

- [x] Bug fix (fix)
- [ ] New feature (feat)
- [ ] Breaking change
- [ ] Documentation update (docs)
- [ ] Other

## Testing

Adds `packages/core/auth-js/test/webauthn.register.test.ts` covering the failed-enrollment cleanup path:

- a **verified** factor is preserved when enrollment fails (the regression),
- a **stale unverified** factor is cleaned up so a retry can succeed,
- a verified factor sharing a name with a stale unverified one is left intact.

All three tests fail against the previous `!== 'unverified'` behavior and pass with the fix. `nx lint auth-js`, `nx build auth-js`, and `prettier --check` all pass.

## Checklist

- [x] Code formatted (`nx format`)
- [x] Tests added and passing
- [x] Builds passing (`nx build auth-js`)
- [x] Used conventional commits
