### PR TITLE
fix(auth): unenroll the unverified factor after a failed registration

### DIFF
--- a/packages/core/auth-js/src/lib/webauthn.ts
+++ b/packages/core/auth-js/src/lib/webauthn.ts
@@ -895,6 +895,10 @@ export class WebAuthnApi {
         await this.client.mfa
           .listFactors()
           .then((factors) =>
+            // Only an unverified factor is leftover from the enrollment that just
+            // failed, and removing it is what lets a retry with the same name
+            // succeed. A verified factor of that name is a passkey the user is
+            // already using, so it must never be selected here.
             factors.data?.all.find(
               (v) =>
                 v.factor_type === 'webauthn' &&

--- a/packages/core/auth-js/src/lib/webauthn.ts
+++ b/packages/core/auth-js/src/lib/webauthn.ts
@@ -899,7 +899,7 @@ export class WebAuthnApi {
               (v) =>
                 v.factor_type === 'webauthn' &&
                 v.friendly_name === friendlyName &&
-                v.status !== 'unverified'
+                v.status === 'unverified'
             )
           )
           .then((factor) => (factor ? this.client.mfa.unenroll({ factorId: factor?.id }) : void 0))

--- a/packages/core/auth-js/test/passkey.methods.test.ts
+++ b/packages/core/auth-js/test/passkey.methods.test.ts
@@ -697,3 +697,61 @@ describe('admin.passkey', () => {
     expect((error as AuthApiError).code).toEqual('passkey_not_found')
   })
 })
+
+describe('mfa.webauthn.register cleanup after a failed enrollment', () => {
+  let browser: ReturnType<typeof setupBrowserEnvironment>
+
+  beforeEach(() => {
+    browser = setupBrowserEnvironment()
+  })
+
+  afterEach(() => {
+    browser.restore()
+    jest.restoreAllMocks()
+  })
+
+  const existingFactor = (status: string, id: string) => ({
+    id,
+    factor_type: 'webauthn',
+    friendly_name: 'My YubiKey',
+    status,
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+  })
+
+  const registerAgainstFailedEnroll = async (existing: ReturnType<typeof existingFactor>) => {
+    const { client, mockFetch } = await createPasskeyClient({ withSession: true })
+    mockFetch.mockResolvedValueOnce(apiErrorResponse('enrollment failed', 422))
+
+    jest.spyOn(client.mfa, 'listFactors').mockResolvedValue({
+      data: { all: [existing], totp: [], phone: [] },
+      error: null,
+    } as any)
+    const unenroll = jest
+      .spyOn(client.mfa, 'unenroll')
+      .mockResolvedValue({ data: null, error: null } as any)
+
+    await client.mfa.webauthn.register({
+      friendlyName: 'My YubiKey',
+      webauthn: { rpId: 'localhost' },
+    })
+
+    return unenroll
+  }
+
+  it('leaves an existing verified factor of the same name alone', async () => {
+    const unenroll = await registerAgainstFailedEnroll(
+      existingFactor('verified', 'verified-factor-id')
+    )
+
+    expect(unenroll).not.toHaveBeenCalled()
+  })
+
+  it('removes the leftover unverified factor', async () => {
+    const unenroll = await registerAgainstFailedEnroll(
+      existingFactor('unverified', 'unverified-factor-id')
+    )
+
+    expect(unenroll).toHaveBeenCalledWith({ factorId: 'unverified-factor-id' })
+  })
+})

--- a/packages/core/auth-js/test/passkey.methods.test.ts
+++ b/packages/core/auth-js/test/passkey.methods.test.ts
@@ -719,12 +719,12 @@ describe('mfa.webauthn.register cleanup after a failed enrollment', () => {
     updated_at: '2026-01-01T00:00:00.000Z',
   })
 
-  const registerAgainstFailedEnroll = async (existing: ReturnType<typeof existingFactor>) => {
+  const registerAgainstFailedEnroll = async (existing: ReturnType<typeof existingFactor>[]) => {
     const { client, mockFetch } = await createPasskeyClient({ withSession: true })
     mockFetch.mockResolvedValueOnce(apiErrorResponse('enrollment failed', 422))
 
     jest.spyOn(client.mfa, 'listFactors').mockResolvedValue({
-      data: { all: [existing], totp: [], phone: [] },
+      data: { all: existing, totp: [], phone: [] },
       error: null,
     } as any)
     const unenroll = jest
@@ -740,18 +740,34 @@ describe('mfa.webauthn.register cleanup after a failed enrollment', () => {
   }
 
   it('leaves an existing verified factor of the same name alone', async () => {
-    const unenroll = await registerAgainstFailedEnroll(
-      existingFactor('verified', 'verified-factor-id')
-    )
+    const unenroll = await registerAgainstFailedEnroll([
+      existingFactor('verified', 'verified-factor-id'),
+    ])
 
     expect(unenroll).not.toHaveBeenCalled()
   })
 
   it('removes the leftover unverified factor', async () => {
-    const unenroll = await registerAgainstFailedEnroll(
-      existingFactor('unverified', 'unverified-factor-id')
-    )
+    const unenroll = await registerAgainstFailedEnroll([
+      existingFactor('unverified', 'unverified-factor-id'),
+    ])
 
     expect(unenroll).toHaveBeenCalledWith({ factorId: 'unverified-factor-id' })
+  })
+
+  it('removes only the unverified one when both share a name', async () => {
+    const unenroll = await registerAgainstFailedEnroll([
+      existingFactor('verified', 'verified-factor-id'),
+      existingFactor('unverified', 'unverified-factor-id'),
+    ])
+
+    expect(unenroll).toHaveBeenCalledTimes(1)
+    expect(unenroll).toHaveBeenCalledWith({ factorId: 'unverified-factor-id' })
+  })
+
+  it('does nothing when no factor of that name exists', async () => {
+    const unenroll = await registerAgainstFailedEnroll([])
+
+    expect(unenroll).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
Closes #2640.

When `_enroll` fails, `register()` tries to clean up after itself by finding a webauthn factor with the same friendly name and unenrolling it. The lookup selects on `v.status !== 'unverified'`, which matches a **verified** factor, so a failed re-registration can delete a passkey the user already had working.

The factor worth cleaning up is the unverified one the failed attempt just left behind, so the condition is inverted. That is the whole change:

```diff
-                v.status !== 'unverified'
+                v.status === 'unverified'
```

Two tests in `passkey.methods.test.ts`, which mocks fetch throughout and needs no server. One drives a failed enrollment with an existing verified factor of the same name and asserts `unenroll` is never called; the other does the same with an unverified factor and asserts it is unenrolled by id. Both fail on `master` and pass with the change, and the other 29 tests in that file are unaffected.

`prettier --check` is clean on both files.
