### PR TITLE
fix(auth): stop register() cleanup from unenrolling a verified webauthn factor

### DIFF
--- a/packages/core/auth-js/src/lib/webauthn.ts
+++ b/packages/core/auth-js/src/lib/webauthn.ts
@@ -892,6 +892,9 @@ export class WebAuthnApi {
       })
 
       if (!factor) {
+        // Clean up only an unverified leftover from a previous failed attempt so the
+        // user can retry; a verified factor with this name is an active credential
+        // and must never be deleted here.
         await this.client.mfa
           .listFactors()
           .then((factors) =>
@@ -899,7 +902,7 @@ export class WebAuthnApi {
               (v) =>
                 v.factor_type === 'webauthn' &&
                 v.friendly_name === friendlyName &&
-                v.status !== 'unverified'
+                v.status === 'unverified'
             )
           )
           .then((factor) => (factor ? this.client.mfa.unenroll({ factorId: factor?.id }) : void 0))

--- a/packages/core/auth-js/test/webauthn.register.test.ts
+++ b/packages/core/auth-js/test/webauthn.register.test.ts
@@ -1,0 +1,120 @@
+import 'jest'
+
+import { WebAuthnApi } from '../src/lib/webauthn'
+import { AuthError } from '../src/lib/errors'
+import type GoTrueClient from '../src/GoTrueClient'
+
+/**
+ * register() cleanup after a failed enrollment (#2640).
+ *
+ * When _enroll fails (most commonly a friendly-name conflict), register() looks
+ * up a webauthn factor with the requested friendly name and unenrolls it so the
+ * user can retry. That cleanup must only ever remove an unverified leftover from
+ * a previous failed attempt, never a verified factor: a verified factor with the
+ * same name is the user's active credential, and the conflict proves it exists.
+ */
+describe('WebAuthnApi register cleanup on failed enroll', () => {
+  const originalWindow = (globalThis as any).window
+  const originalNavigator = (globalThis as any).navigator
+  const originalDocument = (globalThis as any).document
+
+  beforeEach(() => {
+    ;(globalThis as any).window = {
+      PublicKeyCredential: function () {},
+      location: { hostname: 'localhost', origin: 'http://localhost' },
+    }
+    ;(globalThis as any).document = {}
+    ;(globalThis as any).navigator = {
+      credentials: { create: () => Promise.resolve(null), get: () => Promise.resolve(null) },
+    }
+  })
+
+  afterEach(() => {
+    ;(globalThis as any).window = originalWindow
+    ;(globalThis as any).navigator = originalNavigator
+    ;(globalThis as any).document = originalDocument
+  })
+
+  const enrollError = new AuthError('A factor with the friendly name already exists', 422)
+
+  function buildClient(
+    factors: Array<{ id: string; factor_type: string; friendly_name: string; status: string }>
+  ) {
+    return {
+      mfa: {
+        enroll: jest.fn().mockResolvedValue({ data: null, error: enrollError }),
+        listFactors: jest.fn().mockResolvedValue({ data: { all: factors }, error: null }),
+        unenroll: jest.fn().mockResolvedValue({ data: null, error: null }),
+      },
+    }
+  }
+
+  test('does not unenroll a verified factor with the same friendly name', async () => {
+    const client = buildClient([
+      {
+        id: 'verified-factor',
+        factor_type: 'webauthn',
+        friendly_name: 'my-key',
+        status: 'verified',
+      },
+    ])
+    const api = new WebAuthnApi(client as unknown as GoTrueClient)
+
+    const { data, error } = await api.register({
+      friendlyName: 'my-key',
+      webauthn: { rpId: 'localhost' },
+    })
+
+    expect(data).toBeNull()
+    expect(error).toBe(enrollError)
+    expect(client.mfa.unenroll).not.toHaveBeenCalled()
+  })
+
+  test('unenrolls only the unverified leftover with the same friendly name', async () => {
+    const client = buildClient([
+      {
+        id: 'verified-factor',
+        factor_type: 'webauthn',
+        friendly_name: 'my-key',
+        status: 'verified',
+      },
+      {
+        id: 'leftover-factor',
+        factor_type: 'webauthn',
+        friendly_name: 'my-key',
+        status: 'unverified',
+      },
+    ])
+    const api = new WebAuthnApi(client as unknown as GoTrueClient)
+
+    const { error } = await api.register({
+      friendlyName: 'my-key',
+      webauthn: { rpId: 'localhost' },
+    })
+
+    expect(error).toBe(enrollError)
+    expect(client.mfa.unenroll).toHaveBeenCalledTimes(1)
+    expect(client.mfa.unenroll).toHaveBeenCalledWith({ factorId: 'leftover-factor' })
+  })
+
+  test('leaves factors of other names and types untouched', async () => {
+    const client = buildClient([
+      {
+        id: 'other-name',
+        factor_type: 'webauthn',
+        friendly_name: 'other-key',
+        status: 'unverified',
+      },
+      { id: 'totp-factor', factor_type: 'totp', friendly_name: 'my-key', status: 'unverified' },
+    ])
+    const api = new WebAuthnApi(client as unknown as GoTrueClient)
+
+    const { error } = await api.register({
+      friendlyName: 'my-key',
+      webauthn: { rpId: 'localhost' },
+    })
+
+    expect(error).toBe(enrollError)
+    expect(client.mfa.unenroll).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## 🔍 Description

### What changed?

The cleanup block that `register()` runs after a failed enrollment selected a webauthn factor with the requested friendly name whose `status !== 'unverified'`, that is, a **verified** factor, and unenrolled it. The condition is now `status === 'unverified'`, so the cleanup removes only an unverified leftover from a previous failed attempt, and a comment states that intent. Three unit tests pin the behaviour down: a verified factor with the same friendly name is never unenrolled, only the unverified leftover is (when both coexist, exactly the leftover is removed), and factors with other names or types are untouched.

### Why was this change needed?

Enrollment most commonly fails on a friendly name conflict, which is precisely the situation where a verified factor with that name already exists. A user retrying `register()` with the same name therefore had their active passkey deleted by the failed attempt's cleanup. See the reproduction and analysis in the linked issue.

Closes #2640

## 📸 Screenshots/Examples

Not applicable.

## 🔄 Breaking changes

- [x] This PR contains no breaking changes

## 📋 Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/supabase/supabase-js/blob/master/CONTRIBUTING.md)
- [x] My PR title follows the [conventional commit format](https://www.conventionalcommits.org/): `<type>(<scope>): <description>`
- [x] I have run `pnpm nx format` to ensure consistent code formatting
- [x] I have added tests for new functionality (if applicable)
- [ ] I have updated documentation (if applicable)

## 📝 Additional notes

Verified locally on the auth-js package: the new tests fail against the previous condition and pass with this one, the full unit suite passes (240 tests), and lint, build and docs targets are green. The docker backed integration suites were not run.
