### PR TITLE
fix(postgrest): throw when csv() follows stripNulls()

### DIFF
--- a/packages/core/postgrest-js/src/PostgrestTransformBuilder.ts
+++ b/packages/core/postgrest-js/src/PostgrestTransformBuilder.ts
@@ -783,6 +783,9 @@ export default class PostgrestTransformBuilder<
    * ```
    */
   csv(): PostgrestBuilder<ClientOptions, string, ThrowOnError> {
+    if (this.shouldStripNulls) {
+      throw new Error('stripNulls() cannot be used with csv()')
+    }
     this.headers.set('Accept', 'text/csv')
     return this as unknown as PostgrestBuilder<ClientOptions, string, ThrowOnError>
   }

--- a/packages/core/postgrest-js/test/transforms.test.ts
+++ b/packages/core/postgrest-js/test/transforms.test.ts
@@ -350,6 +350,12 @@ test('stripNulls throws when used with csv', () => {
   )
 })
 
+test('stripNulls throws when csv is called after stripNulls', () => {
+  expect(() => postgrest.from('users').select().stripNulls().csv()).toThrow(
+    'stripNulls() cannot be used with csv()'
+  )
+})
+
 test('geojson', async () => {
   const res = await postgrest.from('shops').select().geojson()
   expect(res).toMatchInlineSnapshot(`


### PR DESCRIPTION
## 🔍 Description

### What changed?

`csv()` now throws when `stripNulls()` has already been called, mirroring the guard `stripNulls()` already has for the opposite order.

### Why was this change needed?

The two are documented as mutually exclusive, but the guard only fires one way round:

```ts
postgrest.from('users').select().csv().stripNulls()  // throws
postgrest.from('users').select().stripNulls().csv()  // accepted silently
```

`stripNulls()` checks `Accept` and throws. `csv()` never checks `shouldStripNulls`, so the second order sends `text/csv` with the flag set but inert: the null-stripping branch in `then()` only rewrites the `application/json` and `vnd.pgrst.object+json` variants. No nulls are stripped and no error is raised.

The existing test covers only the first order. This adds the mirrored case beside it.

## 🔄 Breaking changes

Flagging rather than ticking the box: this turns a silent no-op into a throw. Code calling `.stripNulls().csv()` today gets plain CSV with the flag having no effect; after this it throws. That matches the documented contract and the other call order, but it is still a behaviour change, so it may belong in a minor rather than a patch. Happy to warn instead of throwing if you prefer.

## 🧪 Testing

With the guard reverted the new test fails on `Received function did not throw`; with it, that test and the existing one both pass. `tsc --noEmit` is clean. Integration tests here need Docker and were not run.

## 📋 Checklist

- [x] I have read the Contributing Guidelines
- [x] My PR title follows the conventional commit format
- [x] I have run Prettier on the two changed files
- [x] I have added tests for new functionality
- [ ] Documentation updated: not applicable, the JSDoc already states the constraint
