### PR TITLE
feat(storage): object versioning updates

### DIFF
--- a/.github/workflows/validate-capabilities.yml
+++ b/.github/workflows/validate-capabilities.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   validate:
-    uses: supabase/sdk/.github/workflows/validate-sdk-compliance-javascript.yml@a494be6719174adbca0313de1ee187407e2dca95 # capability-matrix-v1.6.0
+    uses: supabase/sdk/.github/workflows/validate-sdk-compliance-javascript.yml@062ce6ed3dfbaf0b271e3ee26baad2c5fbef9c6c # capability-matrix-v1.7.0
     with:
       build-command: |
         corepack enable

--- a/packages/core/storage-js/src/lib/types.ts
+++ b/packages/core/storage-js/src/lib/types.ts
@@ -7,6 +7,29 @@ import { StorageError } from './common/errors'
  */
 export type BucketType = 'STANDARD' | 'ANALYTICS' | (string & {})
 
+/**
+ * Bucket-level object versioning status, as reported by the API.
+ * - DISABLED: versioning has never been enabled for the bucket (the implicit starting state)
+ * - ENABLED: new object writes create new versions
+ * - SUSPENDED: versioning was enabled, then suspended
+ */
+export type VersioningStatus = 'DISABLED' | 'ENABLED' | 'SUSPENDED'
+
+/**
+ * Bucket-level object versioning status that can be set via `createBucket`.
+ * `SUSPENDED` is excluded: it only makes sense for a bucket that has already
+ * had versioning enabled at some point - a brand-new bucket with no history
+ * should just start `DISABLED` instead.
+ */
+export type CreateSettableVersioningStatus = Exclude<VersioningStatus, 'SUSPENDED'>
+
+/**
+ * Bucket-level object versioning status that can be set via `updateBucket`.
+ * `DISABLED` is excluded: it's never a legal destination, since there's no
+ * transition back to it once versioning has been touched.
+ */
+export type UpdateSettableVersioningStatus = Exclude<VersioningStatus, 'DISABLED'>
+
 export interface Bucket {
   id: string
   type?: BucketType
@@ -17,6 +40,7 @@ export interface Bucket {
   created_at: string
   updated_at: string
   public: boolean
+  versioning_status?: VersioningStatus
 }
 
 export interface ListBucketOptions {
@@ -110,6 +134,14 @@ export interface FileObject {
    * This field should not be relied upon.
    */
   buckets?: Bucket
+  /** Version identifier for this object (null for folders, omitted on older schemas) */
+  version?: string | null
+  /** Timestamp at which this version was archived */
+  archived_at?: string | null
+  /** Whether this entry is a delete marker rather than a real object version (null for folders, omitted on older schemas) */
+  is_delete_marker?: boolean | null
+  /** Whether this object was created while the bucket had versioning enabled (null for folders, omitted on older schemas) */
+  is_versioned?: boolean | null
 }
 
 /**
@@ -144,6 +176,12 @@ export interface FileObjectV2 {
    * This field may not be present in responses.
    */
   updated_at?: string
+  /** Timestamp at which this version was archived */
+  archived_at?: string | null
+  /** Whether this entry is a delete marker rather than a real object version */
+  is_delete_marker?: boolean
+  /** Whether this object was created while the bucket had versioning enabled */
+  is_versioned?: boolean
 }
 
 export interface SortBy {
@@ -180,8 +218,18 @@ export interface FileOptions {
   headers?: Record<string, string>
 }
 
+/**
+ * An entry for `remove()`. Either a plain path (deletes whichever row is currently
+ * at that path), or an object targeting an exact `(path, versionId)`
+ */
+export type DeleteObjectEntry = string | { path: string; versionId: string }
+
 export interface DestinationOptions {
   destinationBucket?: string
+  /**
+   * The version id of the source object to move/restore.
+   */
+  sourceVersionId?: string
 }
 
 export interface SearchOptions {
@@ -205,6 +253,23 @@ export interface SearchOptions {
    * The search string to filter files by.
    */
   search?: string
+
+  /**
+   * Controls whether noncurrent object versions are included in the results.
+   * @default 'exclude'
+   */
+  noncurrentVersions?: 'exclude' | 'include' | 'only'
+
+  /**
+   * Controls whether delete markers are included in the results.
+   * @default 'exclude'
+   */
+  deleteMarkers?: 'exclude' | 'include' | 'only'
+
+  /**
+   * When true, only returns objects whose key exactly matches the given prefix.
+   */
+  exactMatch?: boolean
 }
 
 export interface SortByV2 {
@@ -245,6 +310,23 @@ export interface SearchV2Options {
    * @default 'name asc'
    */
   sortBy?: SortByV2
+
+  /**
+   * Controls whether noncurrent object versions are included in the results.
+   * @default 'exclude'
+   */
+  noncurrentVersions?: 'exclude' | 'include' | 'only'
+
+  /**
+   * Controls whether delete markers are included in the results.
+   * @default 'exclude'
+   */
+  deleteMarkers?: 'exclude' | 'include' | 'only'
+
+  /**
+   * When true, only returns objects whose key exactly matches the given prefix.
+   */
+  exactMatch?: boolean
 }
 
 /**
@@ -267,6 +349,14 @@ export interface SearchV2Object {
   metadata: FileMetadata | null
   /** @deprecated Last access timestamp */
   last_accessed_at: string
+  /** Version identifier for this object */
+  version?: string
+  /** Timestamp at which this version was archived */
+  archived_at?: string | null
+  /** Whether this entry is a delete marker rather than a real object version */
+  is_delete_marker?: boolean
+  /** Whether this object was created while the bucket had versioning enabled */
+  is_versioned?: boolean
 }
 
 /**

--- a/packages/core/storage-js/src/packages/StorageBucketApi.ts
+++ b/packages/core/storage-js/src/packages/StorageBucketApi.ts
@@ -6,9 +6,11 @@ import BaseApiClient from '../lib/common/BaseApiClient'
 import {
   Bucket,
   BucketType,
+  CreateSettableVersioningStatus,
   FetchParameters,
   ListBucketOptions,
   PurgeCacheOptions,
+  UpdateSettableVersioningStatus,
 } from '../lib/types'
 import { StorageClientOptions } from '../StorageClient'
 
@@ -163,6 +165,8 @@ export default class StorageBucketApi extends BaseApiClient<StorageError> {
    * Each mime type specified can be a wildcard, e.g. image/*, or a specific mime type, e.g. image/png.
    * @param options.type (private-beta) specifies the bucket type. see `BucketType` for more details.
    *   - default bucket type is `STANDARD`
+   * @param options.versioningStatus the bucket's initial object versioning status.
+   * The default value is `DISABLED`
    * @returns Promise with response containing newly created bucket name or error
    *
    * @example Create bucket
@@ -199,6 +203,7 @@ export default class StorageBucketApi extends BaseApiClient<StorageError> {
       fileSizeLimit?: number | string | null
       allowedMimeTypes?: string[] | null
       type?: BucketType
+      versioningStatus?: CreateSettableVersioningStatus
     } = {
       public: false,
     }
@@ -223,6 +228,7 @@ export default class StorageBucketApi extends BaseApiClient<StorageError> {
           public: options.public,
           file_size_limit: options.fileSizeLimit,
           allowed_mime_types: options.allowedMimeTypes,
+          versioning_status: options.versioningStatus,
         },
         { headers: this.headers }
       )
@@ -242,6 +248,8 @@ export default class StorageBucketApi extends BaseApiClient<StorageError> {
    * @param options.allowedMimeTypes specifies the allowed mime types that this bucket can accept during upload.
    * The default value is null, which allows files with all mime types to be uploaded.
    * Each mime type specified can be a wildcard, e.g. image/*, or a specific mime type, e.g. image/png.
+   * @param options.versioningStatus the bucket's new object versioning status. `DISABLED` is not
+   * valid here, there's no transition back to it once versioning has been touched.
    * @returns Promise with response containing success message or error
    *
    * @example Update bucket
@@ -277,6 +285,7 @@ export default class StorageBucketApi extends BaseApiClient<StorageError> {
       public: boolean
       fileSizeLimit?: number | string | null
       allowedMimeTypes?: string[] | null
+      versioningStatus?: UpdateSettableVersioningStatus
     }
   ): Promise<
     | {
@@ -298,6 +307,7 @@ export default class StorageBucketApi extends BaseApiClient<StorageError> {
           public: options.public,
           file_size_limit: options.fileSizeLimit,
           allowed_mime_types: options.allowedMimeTypes,
+          versioning_status: options.versioningStatus,
         },
         { headers: this.headers }
       )

--- a/packages/core/storage-js/src/packages/StorageFileApi.ts
+++ b/packages/core/storage-js/src/packages/StorageFileApi.ts
@@ -20,6 +20,7 @@ import {
   SearchV2Options,
   SearchV2Result,
   PurgeCacheOptions,
+  DeleteObjectEntry,
 } from '../lib/types'
 import BlobDownloadBuilder from './BlobDownloadBuilder'
 
@@ -509,6 +510,7 @@ export default class StorageFileApi extends BaseApiClient<StorageError> {
    * @param fromPath The original file path, including the current file name. For example `folder/image.png`.
    * @param toPath The new file path, including the new file name. For example `folder/image-new.png`.
    * @param options The destination options.
+   * @param options.sourceVersionId The version id of the source object to move.
    * @returns Promise with response containing success message or error
    *
    * @example Move file
@@ -558,6 +560,7 @@ export default class StorageFileApi extends BaseApiClient<StorageError> {
           sourceKey: fromPath,
           destinationKey: toPath,
           destinationBucket: options?.destinationBucket,
+          sourceVersionId: options?.sourceVersionId,
         },
         { headers: this.headers }
       )
@@ -572,6 +575,7 @@ export default class StorageFileApi extends BaseApiClient<StorageError> {
    * @param fromPath The original file path, including the current file name. For example `folder/image.png`.
    * @param toPath The new file path, including the new file name. For example `folder/image-copy.png`.
    * @param options The destination options.
+   * @param options.sourceVersionId The version id of the source object to copy.
    * @returns Promise with response containing copied file path or error
    *
    * @example Copy file
@@ -621,6 +625,7 @@ export default class StorageFileApi extends BaseApiClient<StorageError> {
           sourceKey: fromPath,
           destinationKey: toPath,
           destinationBucket: options?.destinationBucket,
+          sourceVersionId: options?.sourceVersionId,
         },
         { headers: this.headers }
       )
@@ -834,7 +839,7 @@ export default class StorageFileApi extends BaseApiClient<StorageError> {
    * @category Storage
    * @subcategory File Buckets
    * @param path The full path and file name of the file to be downloaded. For example `folder/image.png`.
-   * @param options Optional settings: `transform` to transform the asset before serving it to the client, and `cacheNonce` to append a cache nonce parameter to the URL to invalidate the cache.
+   * @param options Optional settings: `transform` to transform the asset before serving it to the client, `cacheNonce` to append a cache nonce parameter to the URL to invalidate the cache, and `versionId` to download a specific object version.
    * @param parameters Additional fetch parameters like signal for cancellation. Supports standard fetch options including cache control.
    * @returns BlobDownloadBuilder instance for downloading the file
    *
@@ -893,11 +898,9 @@ export default class StorageFileApi extends BaseApiClient<StorageError> {
    *   - `objects` table permissions: `select`
    * - Refer to the [Storage guide](/docs/guides/storage/security/access-control) on how access control works
    */
-  download<Options extends { transform?: TransformOptions; cacheNonce?: string }>(
-    path: string,
-    options?: Options,
-    parameters?: FetchParameters
-  ): BlobDownloadBuilder {
+  download<
+    Options extends { transform?: TransformOptions; cacheNonce?: string; versionId?: string },
+  >(path: string, options?: Options, parameters?: FetchParameters): BlobDownloadBuilder {
     const wantsTransformation =
       typeof options?.transform === 'object' &&
       options.transform !== null &&
@@ -907,6 +910,7 @@ export default class StorageFileApi extends BaseApiClient<StorageError> {
     const query = new URLSearchParams()
     if (options?.transform) this.applyTransformOptsToQuery(query, options.transform)
     if (options?.cacheNonce != null) query.set('cacheNonce', String(options.cacheNonce))
+    if (options?.versionId != null) query.set('versionId', String(options.versionId))
     const queryString = query.toString()
 
     const _path = this._getFinalPath(path)
@@ -932,6 +936,7 @@ export default class StorageFileApi extends BaseApiClient<StorageError> {
    * @category Storage
    * @subcategory File Buckets
    * @param path The file path, including the file name. For example `folder/image.png`.
+   * @param options Optional settings, including `versionId` to retrieve a specific object version.
    * @returns Promise with response containing file metadata or error
    *
    * @example Get file info
@@ -947,7 +952,10 @@ export default class StorageFileApi extends BaseApiClient<StorageError> {
    * }
    * ```
    */
-  async info(path: string): Promise<
+  async info(
+    path: string,
+    options?: { versionId?: string }
+  ): Promise<
     | {
         data: Camelize<FileObjectV2>
         error: null
@@ -958,11 +966,18 @@ export default class StorageFileApi extends BaseApiClient<StorageError> {
       }
   > {
     const _path = this._getFinalPath(path)
+    const query = new URLSearchParams()
+    if (options?.versionId != null) query.set('versionId', String(options.versionId))
+    const queryString = query.toString()
 
     return this.handleOperation(async () => {
-      const data = await get(this.fetch, `${this.url}/object/info/${_path}`, {
-        headers: this.headers,
-      })
+      const data = await get(
+        this.fetch,
+        `${this.url}/object/info/${_path}${queryString ? `?${queryString}` : ''}`,
+        {
+          headers: this.headers,
+        }
+      )
 
       return recursiveToCamel(data) as Camelize<FileObjectV2>
     })
@@ -1122,7 +1137,9 @@ export default class StorageFileApi extends BaseApiClient<StorageError> {
    *
    * @category Storage
    * @subcategory File Buckets
-   * @param paths An array of files to delete, including the path and file name. For example [`'folder/image.png'`].
+   * @param paths An array of files to delete. Each entry is either a path (deletes whichever
+   * version is currently at that path, e.g. `'folder/image.png'`), or `{ path, versionId }` to
+   * delete an exact version current or archived (e.g. `{ path: 'folder/image.png', versionId: '...' }`).
    * @returns Promise with response containing array of deleted file objects or error
    *
    * @example Delete file
@@ -1141,13 +1158,21 @@ export default class StorageFileApi extends BaseApiClient<StorageError> {
    * }
    * ```
    *
+   * @example Delete a specific object version
+   * ```js
+   * const { data, error } = await supabase
+   *   .storage
+   *   .from('avatars')
+   *   .remove([{ path: 'folder/avatar1.png', versionId: 'noncurrent-version-id' }])
+   * ```
+   *
    * @remarks
    * - RLS policy permissions required:
    *   - `buckets` table permissions: none
    *   - `objects` table permissions: `delete` and `select`
    * - Refer to the [Storage guide](/docs/guides/storage/security/access-control) on how access control works
    */
-  async remove(paths: string[]): Promise<
+  async remove(paths: DeleteObjectEntry[]): Promise<
     | {
         data: FileObject[]
         error: null

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -603,6 +603,18 @@ features:
     symbols:
       - StorageApiError.code
       - StorageVectorsApiError.code
+  storage.file_buckets.bucket_versioning_status:
+    status: implemented
+    symbols:
+      - default.createBucket
+      - default.updateBucket
+      - default.getBucket
+      - default.listBuckets
+    supporting_symbols:
+      - Bucket.versioning_status
+      - CreateSettableVersioningStatus
+      - UpdateSettableVersioningStatus
+      - VersioningStatus
   storage.file_buckets.access_bucket:
     status: implemented
     symbols:
@@ -612,6 +624,12 @@ features:
     status: implemented
     symbols:
       - default.copy
+  storage.file_buckets.copy_specific_version:
+    status: implemented
+    symbols:
+      - default.copy
+    supporting_symbols:
+      - DestinationOptions.sourceVersionId
   storage.file_buckets.copy_cross_bucket:
     status: implemented
     symbols:
@@ -643,6 +661,10 @@ features:
     status: implemented
     symbols:
       - default.download
+  storage.file_buckets.download_specific_version:
+    status: implemented
+    symbols:
+      - default.download
   storage.file_buckets.download_as_stream:
     status: implemented
     symbols:
@@ -664,6 +686,14 @@ features:
     status: implemented
     symbols:
       - default.info
+  storage.file_buckets.file_info_specific_version:
+    status: implemented
+    symbols:
+      - default.info
+    supporting_symbols:
+      - FileObjectV2.archived_at
+      - FileObjectV2.is_delete_marker
+      - FileObjectV2.is_versioned
   storage.file_buckets.get_bucket:
     status: implemented
     symbols:
@@ -683,10 +713,36 @@ features:
     symbols:
       - default.list
       - default.listV2
+  storage.file_buckets.list_file_versions:
+    status: implemented
+    symbols:
+      - default.list
+      - default.listV2
+    supporting_symbols:
+      - FileObject.version
+      - FileObject.archived_at
+      - FileObject.is_delete_marker
+      - FileObject.is_versioned
+      - SearchOptions.noncurrentVersions
+      - SearchOptions.deleteMarkers
+      - SearchOptions.exactMatch
+      - SearchV2Object.version
+      - SearchV2Object.archived_at
+      - SearchV2Object.is_delete_marker
+      - SearchV2Object.is_versioned
+      - SearchV2Options.noncurrentVersions
+      - SearchV2Options.deleteMarkers
+      - SearchV2Options.exactMatch
   storage.file_buckets.move:
     status: implemented
     symbols:
       - default.move
+  storage.file_buckets.move_specific_version:
+    status: implemented
+    symbols:
+      - default.move
+    supporting_symbols:
+      - DestinationOptions.sourceVersionId
   storage.file_buckets.move_cross_bucket:
     status: implemented
     symbols:
@@ -704,6 +760,12 @@ features:
     status: implemented
     symbols:
       - default.remove
+  storage.file_buckets.remove_specific_version:
+    status: implemented
+    symbols:
+      - default.remove
+    supporting_symbols:
+      - DeleteObjectEntry
   storage.file_buckets.update_bucket:
     status: implemented
     symbols:


### PR DESCRIPTION
<!-- Your PR title should follow the conventional commit format:
<type>(<scope>): <description> -->

## 🔍 Description

<!-- Provide a clear and concise description of what this PR does -->
Updates to support the new object versioning feature in storage.

### What changed?

Several new parameters were added. All changes are additive/optional:
- `Bucket` gains `versioning_status`
- `ListBucketOptions` response gains `version`, `archived_at`, `is_delete_marker`, `is_versioned` on `FileObject` (`list()`/`remove()`) and `SearchV2Object` (`listV2()`)
- `FileObjectV2` gains `archived_at`, `is_delete_marker`, `is_versioned`
- `SearchOptions`/`SearchV2Options` gain `noncurrentVersions`, `deleteMarkers`, `exactMatch` for `list()`/`listV2()`
- `DestinationOptions` (shared by `move()`/`copy()`) gains `sourceVersionId`
- New `DeleteObjectEntry` type. `remove()`'s `paths` param now accepts `(string | { path: string; versionId: string })[]` instead of `string[]`, to target an exact version for deletion
- New `VersioningStatus`, `CreateSettableVersioningStatus`, `UpdateSettableVersioningStatus` types: `createBucket()`/`updateBucket()` gain a `versioningStatus` option (`DISABLED`/`ENABLED` on create, `ENABLED`/`SUSPENDED` on update)
- `download()` and `info()` gain a `versionId` option to target a specific object version