### PR TITLE
fix(auth): treat expires_in of 0 as a session

### DIFF
--- a/packages/core/auth-js/src/lib/fetch.ts
+++ b/packages/core/auth-js/src/lib/fetch.ts
@@ -325,5 +325,5 @@ export function _noResolveJsonResponse(data: Response): Response {
  * @returns true if a session is in the response
  */
 function hasSession(data: GoTrueSessionData): boolean {
-  return !!data.access_token && !!data.refresh_token && !!data.expires_in
+  return !!data.access_token && !!data.refresh_token && typeof data.expires_in === 'number'
 }

--- a/packages/core/auth-js/test/fetch.test.ts
+++ b/packages/core/auth-js/test/fetch.test.ts
@@ -392,4 +392,24 @@ describe('_sessionResponse', () => {
     expect(result.data.session).toBeNull()
     expect(result.data.user).toEqual(user)
   })
+
+  test('returns a session when expires_in is 0', () => {
+    // A response carrying a usable token pair is a session even when the
+    // token has no remaining lifetime.
+    const user = { id: 'user-id', email: 'user@example.com' } as any
+    const data = {
+      access_token: 'access-token',
+      refresh_token: 'refresh-token',
+      expires_in: 0,
+      token_type: 'bearer',
+      user,
+    } as any
+
+    const result = _sessionResponse(data)
+
+    expect(result.error).toBeNull()
+    expect(result.data.session).not.toBeNull()
+    expect(result.data.session?.access_token).toEqual('access-token')
+    expect(typeof result.data.session?.expires_at).toEqual('number')
+  })
 })


### PR DESCRIPTION
## 🔍 Description

### What changed?

`hasSession()` checks the type of `expires_in` rather than its truthiness.

### Why was this change needed?

`hasSession()` decides whether `_sessionResponse` builds a session at all:

```ts
return !!data.access_token && !!data.refresh_token && !!data.expires_in
```

`0` is falsy, so a response carrying a valid `access_token` and `refresh_token` is reported as having no session. `_sessionResponse` then returns `{ session: null, user }` with `error: null`, so the tokens are dropped and the caller has no signal that it happened. That contradicts the function's own doc comment, "checks if the response object contains a valid session".

The `!!` arrived in #2314, which retyped the parameter away from `any` and wrapped the existing truthy chain. The zero case does not appear to have been considered either then or when the chain was first written.

I have not found a gotrue response that sets `expires_in: 0`, so this is hardening a guard rather than fixing a reported failure. Happy to close it if you consider the value unreachable.

## 🧪 Testing

Reverting the one-line change makes the added test fail on `expect(received).not.toBeNull()`. With it, all 21 tests in `packages/core/auth-js/test/fetch.test.ts` pass. Test files needing Docker were not run.

## 📋 Checklist

- [x] I have read the Contributing Guidelines
- [x] My PR title follows the conventional commit format
- [x] I have run Prettier on the changed files
- [x] I have added tests for new functionality
- [ ] Documentation updated: not applicable
