### PR TITLE
fix(postgrest): key limit and range off referencedTable truthiness

### DIFF
--- a/packages/core/postgrest-js/src/PostgrestTransformBuilder.ts
+++ b/packages/core/postgrest-js/src/PostgrestTransformBuilder.ts
@@ -496,7 +496,7 @@ export default class PostgrestTransformBuilder<
       referencedTable = foreignTable,
     }: { foreignTable?: string; referencedTable?: string } = {}
   ): this {
-    const key = typeof referencedTable === 'undefined' ? 'limit' : `${referencedTable}.limit`
+    const key = referencedTable ? `${referencedTable}.limit` : 'limit'
     this.url.searchParams.set(key, `${rows}`)
     return this
   }
@@ -564,9 +564,8 @@ export default class PostgrestTransformBuilder<
       referencedTable = foreignTable,
     }: { foreignTable?: string; referencedTable?: string } = {}
   ): this {
-    const keyOffset =
-      typeof referencedTable === 'undefined' ? 'offset' : `${referencedTable}.offset`
-    const keyLimit = typeof referencedTable === 'undefined' ? 'limit' : `${referencedTable}.limit`
+    const keyOffset = referencedTable ? `${referencedTable}.offset` : 'offset'
+    const keyLimit = referencedTable ? `${referencedTable}.limit` : 'limit'
     this.url.searchParams.set(keyOffset, `${from}`)
     // Range is inclusive, so add 1
     this.url.searchParams.set(keyLimit, `${to - from + 1}`)

--- a/packages/core/postgrest-js/test/transforms.test.ts
+++ b/packages/core/postgrest-js/test/transforms.test.ts
@@ -172,6 +172,18 @@ test('range', async () => {
   `)
 })
 
+test('limit, range and order agree on an empty referencedTable', () => {
+  const order = postgrest.from('users').select().order('username', { referencedTable: '' })
+  expect((order as any).url.searchParams.get('order')).toBe('username.asc')
+
+  const limit = postgrest.from('users').select().limit(1, { referencedTable: '' })
+  expect((limit as any).url.searchParams.get('limit')).toBe('1')
+
+  const range = postgrest.from('users').select().range(0, 1, { referencedTable: '' })
+  expect((range as any).url.searchParams.get('offset')).toBe('0')
+  expect((range as any).url.searchParams.get('limit')).toBe('2')
+})
+
 test('single', async () => {
   const res = await postgrest.from('users').select().limit(1).single()
   expect(res).toMatchInlineSnapshot(`


### PR DESCRIPTION
## 🔍 Description

### What changed?

`limit()` and `range()` decide whether the param is scoped to a referenced table the same way `order()` already does.

### Why was this change needed?

The three methods answer the same question two different ways:

```ts
// order()
const key = referencedTable ? `${referencedTable}.order` : 'order'
// limit(), range()
const key = typeof referencedTable === 'undefined' ? 'limit' : `${referencedTable}.limit`
```

With `referencedTable: ''`, `order()` falls back to the top-level param while `limit()` and `range()` build `.limit` and `.offset`. Those are not params PostgREST recognises, so the intended `limit` and `offset` are never set and the request goes out unbounded rather than erroring.

All three used the `typeof` form when they were added in 650170d1. The types-only change dd4dc91c rewrote `order()`'s to the truthy form and left the other two, and the `foreignTable` to `referencedTable` rename in 2c52724d carried both shapes across unchanged.

An empty table name is a caller mistake rather than something PostgREST can return, so this aligns three sibling methods rather than fixing a reachable failure. Close it if that is not worth a patch.

## 🧪 Testing

Reverting the change makes the added test fail on the `limit` param, which reads `null`. With it, that test passes and `tsc --noEmit` is clean. The `csv` and `range` tests in the same file need Docker and were not run.

## 📋 Checklist

- [x] I have read the Contributing Guidelines
- [x] My PR title follows the conventional commit format
- [x] I have run Prettier on the changed files
- [x] I have added tests for new functionality
- [ ] Documentation updated: not applicable
