### PR TITLE
fix(realtime): forward an explicit send() timeout of 0

### DIFF
--- a/packages/core/realtime-js/src/RealtimeChannel.ts
+++ b/packages/core/realtime-js/src/RealtimeChannel.ts
@@ -1114,7 +1114,7 @@ export default class RealtimeChannel {
       }
     } else {
       return new Promise((resolve) => {
-        const push = this.channelAdapter.push(args.type, args, opts.timeout || this.timeout)
+        const push = this.channelAdapter.push(args.type, args, opts.timeout ?? this.timeout)
 
         if (args.type === 'broadcast' && !this.params?.config?.broadcast?.ack) {
           resolve('ok')

--- a/packages/core/realtime-js/test/RealtimeChannel.push.test.ts
+++ b/packages/core/realtime-js/test/RealtimeChannel.push.test.ts
@@ -116,6 +116,19 @@ describe('push', () => {
     expect(timeoutSpy).toHaveBeenCalled()
   })
 
+  test('send() forwards an explicit opts.timeout of 0 to the underlying push', async () => {
+    channel.subscribe()
+    testSetup.mockServer.emit('message', phxJoinReply(channel, {}))
+    await waitForChannelSubscribed(channel)
+
+    const pushSpy = vi.spyOn(channel.channelAdapter, 'push')
+
+    channel.send({ type: 'broadcast', event: 'test-event', payload: {} }, { timeout: 0 })
+
+    // 0 is a caller-supplied value, not an absent option.
+    expect(pushSpy).toHaveBeenCalledWith('broadcast', expect.anything(), 0)
+  })
+
   test("does not time out after receiving 'ok'", async () => {
     channel.subscribe()
     testSetup.mockServer.emit('message', phxJoinReply(channel, {}))


### PR DESCRIPTION
## 🔍 Description

### What changed?

`send()` resolves an explicit `opts.timeout` with `??` instead of `||`, matching the other two paths in the same method.

### Why was this change needed?

`send()` resolves the timeout in three places. Two use `??`:

```ts
httpSend()                 opts.timeout ?? this.timeout   // :979
send(), REST fallback      opts.timeout ?? this.timeout   // :1103
send(), websocket branch   opts.timeout || this.timeout   // :1117
```

`0` is falsy, so the websocket branch replaced a caller's `timeout: 0` with the channel default while the other two passed it through. The same call therefore behaved differently depending on which branch it took.

`git blame` shows the `||` predates the Phoenix adapter refactor and no commit or discussion treats `timeout: 0` as deliberately ignored, so this reads as a miss rather than a decision.

## 🧪 Testing

`npx vitest run` in `packages/core/realtime-js`: 474 passed, 2 failed, 1 skipped. Both failures are in `RealtimeClient.worker.test.ts` and fail identically with `opts.timeout || this.timeout` restored from master, so they are pre-existing. `tsc --noEmit` is clean. Reverting the change makes the added test fail on the pushed timeout argument.

## 📋 Checklist

- [x] I have read the Contributing Guidelines
- [x] My PR title follows the conventional commit format
- [x] I have run Prettier on the changed files
- [x] I have added tests for new functionality
- [ ] Documentation updated: not applicable
