### PR TITLE
fix(functions): honor pre-aborted signals with timeout

### DIFF
--- a/packages/core/functions-js/src/FunctionsClient.ts
+++ b/packages/core/functions-js/src/FunctionsClient.ts
@@ -272,10 +272,14 @@ export class FunctionsClient {
         // If user provided their own signal, we need to respect both
         if (signal) {
           effectiveSignal = timeoutController.signal
-          // If the user's signal is aborted, abort our timeout controller too.
-          // Store the listener so we can clean it up in finally.
-          onAbort = () => timeoutController!.abort()
-          signal.addEventListener('abort', onAbort)
+          if (signal.aborted) {
+            timeoutController.abort()
+          } else {
+            // If the user's signal is aborted, abort our timeout controller too.
+            // Store the listener so we can clean it up in finally.
+            onAbort = () => timeoutController!.abort()
+            signal.addEventListener('abort', onAbort)
+          }
         } else {
           effectiveSignal = timeoutController.signal
         }

--- a/packages/core/functions-js/test/FunctionsClient.test.ts
+++ b/packages/core/functions-js/test/FunctionsClient.test.ts
@@ -1,7 +1,26 @@
 import { FunctionsClient } from '../src/index'
 
 describe('FunctionsClient', () => {
-  describe('invoke – abort listener cleanup when timeout + signal are both set', () => {
+  describe('invoke – timeout and signal composition', () => {
+    it('passes an aborted signal to fetch when the caller signal was already aborted', async () => {
+      const mockFetch = jest.fn().mockImplementation((_url, init) => {
+        expect(init.signal.aborted).toBe(true)
+        return Promise.reject(init.signal.reason)
+      })
+
+      const client = new FunctionsClient('http://localhost', { customFetch: mockFetch })
+      const controller = new AbortController()
+      controller.abort()
+
+      const { error } = await client.invoke('test-fn', {
+        timeout: 5000,
+        signal: controller.signal,
+      })
+
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+      expect(error).not.toBeNull()
+    })
+
     it('removes the listener from the caller signal after a successful invoke', async () => {
       const mockFetch = jest.fn().mockResolvedValue({
         ok: true,


### PR DESCRIPTION
## 🔍 Description

### What changed?

- Immediately abort the internal timeout controller when `invoke()` receives an already-aborted caller signal.
- Keep the existing listener forwarding and cleanup behavior for signals that abort after invocation starts.
- Add a regression test through `FunctionsClient.invoke()`.

### Why was this change needed?

When both `timeout` and `signal` are supplied, `invoke()` replaces the caller signal with a fresh controller and registers an abort listener. Registering that listener after the caller signal has already aborted does not replay the event, so the request could execute with an active signal.

Closes #2648

## 📸 Screenshots/Examples

Not applicable.

## 🔄 Breaking changes

- [x] This PR contains no breaking changes

## 📋 Checklist

- [x] I have read the Contributing Guidelines
- [x] My PR title follows the conventional commit format
- [x] I have run formatting checks
- [x] I have added regression tests
- [x] Documentation is unchanged because the public API and documented behavior do not change

## 🧪 Validation

- `pnpm --dir packages/core/functions-js exec jest FunctionsClient.test.ts --runInBand` — 3 passed
- `pnpm nx test functions-js` — 43 passed, 1 existing skip
- `pnpm nx build functions-js` — passed
- `pnpm exec prettier --check packages/core/functions-js/src/FunctionsClient.ts packages/core/functions-js/test/FunctionsClient.test.ts` — passed
- `git diff --check` — passed

Package-wide lint currently reports 12 pre-existing errors on the untouched base revision; targeted lint reproduces the same existing errors in `FunctionsClient.ts` and reports no new test-file findings.