### PR TITLE
feat(postgrest): add getOpenApiSpec()

### DIFF
--- a/.github/workflows/validate-capabilities.yml
+++ b/.github/workflows/validate-capabilities.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   validate:
-    uses: supabase/sdk/.github/workflows/validate-sdk-compliance-javascript.yml@062ce6ed3dfbaf0b271e3ee26baad2c5fbef9c6c # capability-matrix-v1.7.0
+    uses: supabase/sdk/.github/workflows/validate-sdk-compliance-javascript.yml@1f5fd0a64e982886aeeb6cad2c3b64cbb499d080 # capability-matrix-v1.8.0
     with:
       build-command: |
         corepack enable

--- a/packages/core/postgrest-js/src/PostgrestBuilder.ts
+++ b/packages/core/postgrest-js/src/PostgrestBuilder.ts
@@ -5,65 +5,10 @@ import type {
   MergePartialResult,
   IsValidResultOverride,
 } from './types/types'
-import {
-  ClientServerOptions,
-  Fetch,
-  DEFAULT_MAX_RETRIES,
-  getRetryDelay,
-  RETRYABLE_STATUS_CODES,
-  RETRYABLE_METHODS,
-} from './types/common/common'
+import { ClientServerOptions, Fetch } from './types/common/common'
 import PostgrestError from './PostgrestError'
+import { fetchWithRetry } from './fetchWithRetry'
 import { ContainsNull } from './select-query-parser/types'
-
-/**
- * Sleep for a given number of milliseconds.
- * If an AbortSignal is provided, the sleep resolves early when the signal is aborted.
- */
-function sleep(ms: number, signal?: AbortSignal): Promise<void> {
-  return new Promise((resolve) => {
-    if (signal?.aborted) {
-      resolve()
-      return
-    }
-    const id = setTimeout(() => {
-      signal?.removeEventListener('abort', onAbort)
-      resolve()
-    }, ms)
-    function onAbort() {
-      clearTimeout(id)
-      resolve()
-    }
-    signal?.addEventListener('abort', onAbort)
-  })
-}
-
-/**
- * Check if a request should be retried based on method and status code.
- */
-function shouldRetry(
-  method: string,
-  status: number,
-  attemptCount: number,
-  retryEnabled: boolean
-): boolean {
-  // Don't retry if retries are disabled or we've exhausted attempts
-  if (!retryEnabled || attemptCount >= DEFAULT_MAX_RETRIES) {
-    return false
-  }
-
-  // Only retry idempotent methods (GET, HEAD, OPTIONS)
-  if (!RETRYABLE_METHODS.includes(method as (typeof RETRYABLE_METHODS)[number])) {
-    return false
-  }
-
-  // Only retry on specific status codes (520 - Cloudflare errors)
-  if (!RETRYABLE_STATUS_CODES.includes(status as (typeof RETRYABLE_STATUS_CODES)[number])) {
-    return false
-  }
-
-  return true
-}
 
 export default abstract class PostgrestBuilder<
   ClientOptions extends ClientServerOptions,
@@ -314,75 +259,32 @@ export default abstract class PostgrestBuilder<
       status: number
       statusText: string
     }> => {
-      let attemptCount = 0
+      // Serialize headers as a plain object rather than a Headers instance.
+      // React Native's XHR-based fetch silently drops headers (notably Content-Type)
+      // when given a Headers instance, causing PGRST202 on parameter-less RPC calls.
+      // See supabase/supabase-js#1562 and facebook/react-native#33933.
+      // All sibling packages (auth-js, storage-js, functions-js) already pass plain objects.
+      const headers: Record<string, string> = {}
+      this.headers.forEach((value, key) => {
+        headers[key] = value
+      })
 
-      while (true) {
-        // Serialize headers as a plain object rather than a Headers instance.
-        // React Native's XHR-based fetch silently drops headers (notably Content-Type)
-        // when given a Headers instance, causing PGRST202 on parameter-less RPC calls.
-        // See supabase/supabase-js#1562 and facebook/react-native#33933.
-        // All sibling packages (auth-js, storage-js, functions-js) already pass plain objects.
-        const headers: Record<string, string> = {}
-        this.headers.forEach((value, key) => {
-          headers[key] = value
-        })
-        if (attemptCount > 0) {
-          headers['X-Retry-Count'] = String(attemptCount)
-        }
+      // Only the fetch itself is retried — processResponse errors must never trigger retries
+      const res = await fetchWithRetry(
+        _fetch,
+        this.url.toString(),
+        {
+          method: this.method,
+          headers,
+          body: JSON.stringify(this.body, (_, value) =>
+            typeof value === 'bigint' ? value.toString() : value
+          ),
+          signal: this.signal,
+        },
+        this.retryEnabled
+      )
 
-        // Only wrap the fetch call itself — processResponse errors must never trigger retries
-        let res: Response
-        try {
-          res = await _fetch(this.url.toString(), {
-            method: this.method,
-            headers,
-            body: JSON.stringify(this.body, (_, value) =>
-              typeof value === 'bigint' ? value.toString() : value
-            ),
-            signal: this.signal,
-          })
-          // JS allows throwing any value, and serverless or realm-crossing fetch
-          // implementations can reject with non-Error objects. `instanceof Error`
-          // is too narrow here; narrow at the use site with optional chaining.
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        } catch (fetchError: any) {
-          // Never retry aborted requests
-          if (fetchError?.name === 'AbortError' || fetchError?.code === 'ABORT_ERR') {
-            throw fetchError
-          }
-
-          // Don't retry network errors for non-idempotent methods
-          if (!RETRYABLE_METHODS.includes(this.method as (typeof RETRYABLE_METHODS)[number])) {
-            throw fetchError
-          }
-
-          // Check if we should retry network errors
-          if (this.retryEnabled && attemptCount < DEFAULT_MAX_RETRIES) {
-            const delay = getRetryDelay(attemptCount)
-            attemptCount++
-            await sleep(delay, this.signal)
-            continue
-          }
-
-          // Exhausted retries or retries disabled, throw the last error
-          throw fetchError
-        }
-
-        // Check if we should retry this HTTP response
-        if (shouldRetry(this.method, res.status, attemptCount, this.retryEnabled)) {
-          const retryAfterHeader = res.headers?.get('Retry-After') ?? null
-          const delay =
-            retryAfterHeader !== null
-              ? Math.max(0, parseInt(retryAfterHeader, 10) || 0) * 1000
-              : getRetryDelay(attemptCount)
-          await res.text()
-          attemptCount++
-          await sleep(delay, this.signal)
-          continue
-        }
-
-        return await this.processResponse(res)
-      }
+      return await this.processResponse(res)
     }
 
     let res = executeWithRetry()

--- a/packages/core/postgrest-js/src/PostgrestClient.ts
+++ b/packages/core/postgrest-js/src/PostgrestClient.ts
@@ -3,6 +3,7 @@ import PostgrestFilterBuilder from './PostgrestFilterBuilder'
 import { Fetch, GenericSchema, ClientServerOptions } from './types/common/common'
 import { GetRpcFunctionFilterBuilderByArgs } from './types/common/rpc'
 import PostgrestError from './PostgrestError'
+import { fetchWithRetry } from './fetchWithRetry'
 import {
   PostgrestOpenApiSpec,
   PostgrestResponseFailure,
@@ -264,7 +265,8 @@ export default class PostgrestClient<
    * The document lists only the tables, views and functions the caller's role
    * holds privileges on; PostgREST applies that filtering server-side. The
    * schema is the one this client was created with, so call `.schema()` first
-   * to describe a different one.
+   * to describe a different one. Transient failures are retried according to
+   * the client's `retry` option, like any other idempotent request.
    *
    * @example
    * ```ts
@@ -296,7 +298,12 @@ export default class PostgrestClient<
     const fetchImpl = this.fetch ?? globalThis.fetch
     let res: Response
     try {
-      res = await fetchImpl(`${this.url}/`, { method: 'GET', headers: requestHeaders })
+      res = await fetchWithRetry(
+        fetchImpl,
+        `${this.url}/`,
+        { method: 'GET', headers: requestHeaders },
+        this.retry ?? true
+      )
     } catch (fetchError) {
       return toTransportFailure(fetchError, 0, '')
     }

--- a/packages/core/postgrest-js/src/PostgrestClient.ts
+++ b/packages/core/postgrest-js/src/PostgrestClient.ts
@@ -2,6 +2,31 @@ import PostgrestQueryBuilder from './PostgrestQueryBuilder'
 import PostgrestFilterBuilder from './PostgrestFilterBuilder'
 import { Fetch, GenericSchema, ClientServerOptions } from './types/common/common'
 import { GetRpcFunctionFilterBuilderByArgs } from './types/common/rpc'
+import PostgrestError from './PostgrestError'
+import { PostgrestOpenApiSpec, PostgrestSingleResponse } from './types/types'
+
+/**
+ * Build the error for a failed OpenAPI request. PostgREST answers with a JSON
+ * error object when it produced the failure itself; proxies and disabled
+ * OpenAPI output answer with plain text or an empty body, in which case the
+ * body (or, failing that, the status text) becomes the message.
+ */
+function toOpenApiError(body: string, statusText: string): PostgrestError {
+  try {
+    const parsed = JSON.parse(body)
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return new PostgrestError({
+        message: String(parsed.message ?? body),
+        details: parsed.details ?? '',
+        hint: parsed.hint ?? '',
+        code: parsed.code ?? '',
+      })
+    }
+  } catch {
+    // Not JSON; fall through to the plain-text message.
+  }
+  return new PostgrestError({ message: body || statusText, details: '', hint: '', code: '' })
+}
 
 /**
  * PostgREST client.
@@ -201,6 +226,79 @@ export default class PostgrestClient<
       urlLengthLimit: this.urlLengthLimit,
       retry: this.retry,
     })
+  }
+
+  /**
+   * Fetch the OpenAPI description PostgREST publishes for this client's schema.
+   *
+   * The document lists only the tables, views and functions the caller's role
+   * holds privileges on; PostgREST applies that filtering server-side. The
+   * schema is the one this client was created with, so call `.schema()` first
+   * to describe a different one.
+   *
+   * @example
+   * ```ts
+   * const { data, error } = await supabase.getOpenApiSpec()
+   * ```
+   *
+   * @example Describe a schema other than the client default
+   * ```ts
+   * const { data, error } = await supabase.schema('billing').getOpenApiSpec()
+   * ```
+   *
+   * @category Database
+   */
+  async getOpenApiSpec(): Promise<PostgrestSingleResponse<PostgrestOpenApiSpec>> {
+    const headers = new Headers(this.headers)
+    headers.set('Accept', 'application/openapi+json')
+    if (this.schemaName) {
+      headers.set('Accept-Profile', this.schemaName)
+    }
+
+    const fetchImpl = this.fetch ?? globalThis.fetch
+    let res: Response
+    try {
+      res = await fetchImpl(`${this.url}/`, { method: 'GET', headers })
+    } catch (fetchError: any) {
+      return {
+        success: false,
+        error: new PostgrestError({
+          message: `${fetchError?.name ?? 'FetchError'}: ${fetchError?.message}`,
+          details: '',
+          hint: '',
+          code: '',
+        }),
+        data: null,
+        count: null,
+        status: 0,
+        statusText: '',
+      }
+    }
+
+    const body = await res.text()
+    if (res.ok) {
+      try {
+        return {
+          success: true,
+          error: null,
+          data: JSON.parse(body) as PostgrestOpenApiSpec,
+          count: null,
+          status: res.status,
+          statusText: res.statusText,
+        }
+      } catch {
+        // A 2xx status does not guarantee a JSON body; report it like a failure.
+      }
+    }
+
+    return {
+      success: false,
+      error: toOpenApiError(body, res.statusText),
+      data: null,
+      count: null,
+      status: res.status,
+      statusText: res.statusText,
+    }
   }
 
   /**

--- a/packages/core/postgrest-js/src/PostgrestClient.ts
+++ b/packages/core/postgrest-js/src/PostgrestClient.ts
@@ -285,10 +285,18 @@ export default class PostgrestClient<
       headers.set('Accept-Profile', this.schemaName)
     }
 
+    // Headers reach the fetch implementation as a plain object, as in
+    // PostgrestBuilder: React Native's XHR-based fetch drops headers that are
+    // supplied as a Headers instance.
+    const requestHeaders: Record<string, string> = {}
+    headers.forEach((value, key) => {
+      requestHeaders[key] = value
+    })
+
     const fetchImpl = this.fetch ?? globalThis.fetch
     let res: Response
     try {
-      res = await fetchImpl(`${this.url}/`, { method: 'GET', headers })
+      res = await fetchImpl(`${this.url}/`, { method: 'GET', headers: requestHeaders })
     } catch (fetchError) {
       return toTransportFailure(fetchError, 0, '')
     }

--- a/packages/core/postgrest-js/src/PostgrestClient.ts
+++ b/packages/core/postgrest-js/src/PostgrestClient.ts
@@ -3,7 +3,11 @@ import PostgrestFilterBuilder from './PostgrestFilterBuilder'
 import { Fetch, GenericSchema, ClientServerOptions } from './types/common/common'
 import { GetRpcFunctionFilterBuilderByArgs } from './types/common/rpc'
 import PostgrestError from './PostgrestError'
-import { PostgrestOpenApiSpec, PostgrestSingleResponse } from './types/types'
+import {
+  PostgrestOpenApiSpec,
+  PostgrestResponseFailure,
+  PostgrestSingleResponse,
+} from './types/types'
 
 /**
  * Build the error for a failed OpenAPI request. PostgREST answers with a JSON
@@ -26,6 +30,32 @@ function toOpenApiError(body: string, statusText: string): PostgrestError {
     // Not JSON; fall through to the plain-text message.
   }
   return new PostgrestError({ message: body || statusText, details: '', hint: '', code: '' })
+}
+
+/**
+ * Build the response for a request that yielded no readable body: the fetch
+ * itself rejected (no status is known, so it is 0), or the body stream failed
+ * while being read (the response status is preserved).
+ */
+function toTransportFailure(
+  cause: unknown,
+  status: number,
+  statusText: string
+): PostgrestResponseFailure {
+  const err = cause as { name?: string; message?: string } | null | undefined
+  return {
+    success: false,
+    error: new PostgrestError({
+      message: `${err?.name ?? 'FetchError'}: ${err?.message}`,
+      details: '',
+      hint: '',
+      code: '',
+    }),
+    data: null,
+    count: null,
+    status,
+    statusText,
+  }
 }
 
 /**
@@ -259,23 +289,17 @@ export default class PostgrestClient<
     let res: Response
     try {
       res = await fetchImpl(`${this.url}/`, { method: 'GET', headers })
-    } catch (fetchError: any) {
-      return {
-        success: false,
-        error: new PostgrestError({
-          message: `${fetchError?.name ?? 'FetchError'}: ${fetchError?.message}`,
-          details: '',
-          hint: '',
-          code: '',
-        }),
-        data: null,
-        count: null,
-        status: 0,
-        statusText: '',
-      }
+    } catch (fetchError) {
+      return toTransportFailure(fetchError, 0, '')
     }
 
-    const body = await res.text()
+    let body: string
+    try {
+      body = await res.text()
+    } catch (readError) {
+      return toTransportFailure(readError, res.status, res.statusText)
+    }
+
     if (res.ok) {
       try {
         return {

--- a/packages/core/postgrest-js/src/fetchWithRetry.ts
+++ b/packages/core/postgrest-js/src/fetchWithRetry.ts
@@ -1,0 +1,141 @@
+import {
+  DEFAULT_MAX_RETRIES,
+  Fetch,
+  getRetryDelay,
+  RETRYABLE_METHODS,
+  RETRYABLE_STATUS_CODES,
+} from './types/common/common'
+
+/**
+ * Sleep for a given number of milliseconds.
+ * If an AbortSignal is provided, the sleep resolves early when the signal is aborted.
+ */
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    if (signal?.aborted) {
+      resolve()
+      return
+    }
+    const id = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort)
+      resolve()
+    }, ms)
+    function onAbort() {
+      clearTimeout(id)
+      resolve()
+    }
+    signal?.addEventListener('abort', onAbort)
+  })
+}
+
+/**
+ * Check if a request should be retried based on method and status code.
+ */
+function shouldRetry(
+  method: string,
+  status: number,
+  attemptCount: number,
+  retryEnabled: boolean
+): boolean {
+  // Don't retry if retries are disabled or we've exhausted attempts
+  if (!retryEnabled || attemptCount >= DEFAULT_MAX_RETRIES) {
+    return false
+  }
+
+  // Only retry idempotent methods (GET, HEAD, OPTIONS)
+  if (!RETRYABLE_METHODS.includes(method as (typeof RETRYABLE_METHODS)[number])) {
+    return false
+  }
+
+  // Only retry on specific status codes (520 - Cloudflare errors)
+  if (!RETRYABLE_STATUS_CODES.includes(status as (typeof RETRYABLE_STATUS_CODES)[number])) {
+    return false
+  }
+
+  return true
+}
+
+export interface RetryableRequest {
+  method: string
+  /** Plain object, never a Headers instance: React Native's XHR-based fetch drops the latter. */
+  headers: Record<string, string>
+  body?: string
+  signal?: AbortSignal
+}
+
+/**
+ * Perform a request with the retry policy shared by every PostgREST call.
+ *
+ * Idempotent methods (GET, HEAD, OPTIONS) are retried up to
+ * `DEFAULT_MAX_RETRIES` times when the fetch rejects or the server answers
+ * with a retryable status (503, 520). The wait honours the `Retry-After`
+ * header when present and backs off exponentially otherwise. Retried
+ * attempts carry an `X-Retry-Count` header. Aborted requests and
+ * non-idempotent methods are never retried: their rejection propagates
+ * unchanged. A response body is drained before its request is retried.
+ */
+export async function fetchWithRetry(
+  fetchImpl: Fetch,
+  url: string,
+  request: RetryableRequest,
+  retryEnabled: boolean
+): Promise<Response> {
+  let attemptCount = 0
+
+  while (true) {
+    const headers: Record<string, string> = { ...request.headers }
+    if (attemptCount > 0) {
+      headers['X-Retry-Count'] = String(attemptCount)
+    }
+
+    let res: Response
+    try {
+      res = await fetchImpl(url, {
+        method: request.method,
+        headers,
+        body: request.body,
+        signal: request.signal,
+      })
+      // JS allows throwing any value, and serverless or realm-crossing fetch
+      // implementations can reject with non-Error objects. `instanceof Error`
+      // is too narrow here; narrow at the use site with optional chaining.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } catch (fetchError: any) {
+      // Never retry aborted requests
+      if (fetchError?.name === 'AbortError' || fetchError?.code === 'ABORT_ERR') {
+        throw fetchError
+      }
+
+      // Don't retry network errors for non-idempotent methods
+      if (!RETRYABLE_METHODS.includes(request.method as (typeof RETRYABLE_METHODS)[number])) {
+        throw fetchError
+      }
+
+      // Check if we should retry network errors
+      if (retryEnabled && attemptCount < DEFAULT_MAX_RETRIES) {
+        const delay = getRetryDelay(attemptCount)
+        attemptCount++
+        await sleep(delay, request.signal)
+        continue
+      }
+
+      // Exhausted retries or retries disabled, throw the last error
+      throw fetchError
+    }
+
+    // Check if we should retry this HTTP response
+    if (shouldRetry(request.method, res.status, attemptCount, retryEnabled)) {
+      const retryAfterHeader = res.headers?.get('Retry-After') ?? null
+      const delay =
+        retryAfterHeader !== null
+          ? Math.max(0, parseInt(retryAfterHeader, 10) || 0) * 1000
+          : getRetryDelay(attemptCount)
+      await res.text()
+      attemptCount++
+      await sleep(delay, request.signal)
+      continue
+    }
+
+    return res
+  }
+}

--- a/packages/core/postgrest-js/src/index.ts
+++ b/packages/core/postgrest-js/src/index.ts
@@ -27,6 +27,7 @@ export type {
   PostgrestResponseSuccess,
   PostgrestSingleResponse,
   PostgrestMaybeSingleResponse,
+  PostgrestOpenApiSpec,
 } from './types/types'
 export type { ClientServerOptions as PostgrestClientOptions } from './types/common/common'
 // https://github.com/supabase/postgrest-js/issues/551

--- a/packages/core/postgrest-js/src/types/types.ts
+++ b/packages/core/postgrest-js/src/types/types.ts
@@ -40,6 +40,27 @@ export type PostgrestSingleResponse<T> = PostgrestResponseSuccess<T> | Postgrest
 export type PostgrestMaybeSingleResponse<T> = PostgrestSingleResponse<T | null>
 export type PostgrestResponse<T> = PostgrestSingleResponse<T[]>
 
+/**
+ * OpenAPI description served by PostgREST at the REST root (`GET /`).
+ *
+ * PostgREST emits OpenAPI 2.0 (Swagger), so the version lives in `swagger`.
+ * Only the top level is typed here; the contents of `paths`, `definitions`
+ * and `parameters` follow the OpenAPI 2.0 specification and vary with the
+ * PostgREST version.
+ *
+ * {@link https://docs.postgrest.org/en/stable/references/api/openapi.html}
+ */
+export interface PostgrestOpenApiSpec {
+  swagger: string
+  info: Record<string, unknown>
+  host?: string
+  basePath?: string
+  paths: Record<string, Record<string, unknown>>
+  definitions: Record<string, Record<string, unknown>>
+  parameters?: Record<string, Record<string, unknown>>
+  [key: string]: unknown
+}
+
 export type DatabaseWithOptions<Database, Options extends ClientServerOptions> = {
   db: Database
   options: Options

--- a/packages/core/postgrest-js/src/types/types.ts
+++ b/packages/core/postgrest-js/src/types/types.ts
@@ -44,9 +44,10 @@ export type PostgrestResponse<T> = PostgrestSingleResponse<T[]>
  * OpenAPI description served by PostgREST at the REST root (`GET /`).
  *
  * PostgREST emits OpenAPI 2.0 (Swagger), so the version lives in `swagger`.
- * Only the top level is typed here; the contents of `paths`, `definitions`
- * and `parameters` follow the OpenAPI 2.0 specification and vary with the
- * PostgREST version.
+ * OpenAPI 2.0 requires only `swagger`, `info` and `paths`; a PostgREST
+ * `db-root-spec` override may leave out any other field. Only the top level
+ * is typed here; the contents of `paths`, `definitions` and `parameters`
+ * follow the OpenAPI 2.0 specification and vary with the PostgREST version.
  *
  * {@link https://docs.postgrest.org/en/stable/references/api/openapi.html}
  */
@@ -56,7 +57,7 @@ export interface PostgrestOpenApiSpec {
   host?: string
   basePath?: string
   paths: Record<string, Record<string, unknown>>
-  definitions: Record<string, Record<string, unknown>>
+  definitions?: Record<string, Record<string, unknown>>
   parameters?: Record<string, Record<string, unknown>>
   [key: string]: unknown
 }

--- a/packages/core/postgrest-js/test/openapi-spec.test.ts
+++ b/packages/core/postgrest-js/test/openapi-spec.test.ts
@@ -189,4 +189,94 @@ describe('getOpenApiSpec', () => {
     expect(res.error).toBeInstanceOf(PostgrestError)
     expect(res.error).toMatchObject({ message: 'TypeError: terminated', code: '' })
   })
+
+  describe('retries', () => {
+    beforeEach(() => {
+      jest.useFakeTimers()
+    })
+
+    afterEach(() => {
+      jest.useRealTimers()
+    })
+
+    /** Minimal response stand-in; the client reads only these members. */
+    const replyWith = (
+      status: number,
+      statusText: string,
+      body: string,
+      headers: Record<string, string> = {}
+    ) =>
+      ({
+        ok: status >= 200 && status < 300,
+        status,
+        statusText,
+        headers: new Headers(headers),
+        text: () => Promise.resolve(body),
+      }) as unknown as Response
+
+    /** Advance the fake clock until the request settles. */
+    async function settle<T>(pending: Promise<T>): Promise<T> {
+      let settled = false
+      const tracked = pending.finally(() => {
+        settled = true
+      })
+      while (!settled) {
+        await jest.advanceTimersByTimeAsync(1000)
+      }
+      return tracked
+    }
+
+    test('retries a 503 after the Retry-After delay and marks the retry attempt', async () => {
+      const replies: Array<() => Response> = [
+        () =>
+          replyWith(503, 'Service Unavailable', '{"code":"PGRST002","message":"schema cache"}', {
+            'Retry-After': '1',
+          }),
+        () => replyWith(200, 'OK', JSON.stringify(SPEC)),
+      ]
+      const { calls, fetchImpl } = fetchReplying(() => replies.shift()!())
+      const postgrest = new PostgrestClient(REST_URL, { fetch: fetchImpl })
+
+      const res = await settle(postgrest.getOpenApiSpec())
+
+      expect(calls).toHaveLength(2)
+      expect((calls[1].init?.headers as Record<string, string>)['X-Retry-Count']).toBe('1')
+      expect(res).toMatchObject({ success: true, data: SPEC, status: 200 })
+    })
+
+    test('retries a rejected fetch and succeeds on the next attempt', async () => {
+      const replies: Array<() => Response | Promise<never>> = [
+        () => Promise.reject(new TypeError('fetch failed')),
+        () => replyWith(200, 'OK', JSON.stringify(SPEC)),
+      ]
+      const { calls, fetchImpl } = fetchReplying(() => replies.shift()!())
+      const postgrest = new PostgrestClient(REST_URL, { fetch: fetchImpl })
+
+      const res = await settle(postgrest.getOpenApiSpec())
+
+      expect(calls).toHaveLength(2)
+      expect(res).toMatchObject({ success: true, data: SPEC })
+    })
+
+    test('does not retry when the client disables retries', async () => {
+      const { calls, fetchImpl } = fetchReplying(() => replyWith(520, '', 'origin error'))
+      const postgrest = new PostgrestClient(REST_URL, { fetch: fetchImpl, retry: false })
+
+      const res = await settle(postgrest.getOpenApiSpec())
+
+      expect(calls).toHaveLength(1)
+      expect(res).toMatchObject({ success: false, status: 520 })
+      expect(res.error).toMatchObject({ message: 'origin error' })
+    })
+
+    test('gives up after the maximum number of retries', async () => {
+      const { calls, fetchImpl } = fetchReplying(() => replyWith(520, '', 'origin error'))
+      const postgrest = new PostgrestClient(REST_URL, { fetch: fetchImpl })
+
+      const res = await settle(postgrest.getOpenApiSpec())
+
+      expect(calls).toHaveLength(4)
+      expect(res).toMatchObject({ success: false, status: 520 })
+    })
+  })
 })

--- a/packages/core/postgrest-js/test/openapi-spec.test.ts
+++ b/packages/core/postgrest-js/test/openapi-spec.test.ts
@@ -158,4 +158,23 @@ describe('getOpenApiSpec', () => {
     expect(res.error).toBeInstanceOf(PostgrestError)
     expect(res.error).toMatchObject({ message: 'TypeError: fetch failed', code: '' })
   })
+
+  test('reports a body that cannot be read as an error without throwing', async () => {
+    const body = new ReadableStream({
+      start(controller) {
+        controller.error(new TypeError('terminated'))
+      },
+    })
+    const { fetchImpl } = fetchReplying(() => new Response(body, { status: 200, statusText: 'OK' }))
+    const postgrest = new PostgrestClient(REST_URL, { fetch: fetchImpl })
+
+    const res = await postgrest.getOpenApiSpec()
+
+    expect(res.success).toBe(false)
+    expect(res.data).toBeNull()
+    expect(res.status).toBe(200)
+    expect(res.statusText).toBe('OK')
+    expect(res.error).toBeInstanceOf(PostgrestError)
+    expect(res.error).toMatchObject({ message: 'TypeError: terminated', code: '' })
+  })
 })

--- a/packages/core/postgrest-js/test/openapi-spec.test.ts
+++ b/packages/core/postgrest-js/test/openapi-spec.test.ts
@@ -75,6 +75,18 @@ describe('getOpenApiSpec', () => {
     expect(headers.get('Accept-Profile')).toBe('billing')
   })
 
+  test('hands headers to fetch as a plain object', async () => {
+    const { calls, fetchImpl } = fetchReplying(() => jsonResponse(SPEC))
+    const postgrest = new PostgrestClient(REST_URL, { schema: 'public', fetch: fetchImpl })
+
+    await postgrest.getOpenApiSpec()
+
+    const headers = calls[0].init?.headers as Record<string, string>
+    expect(headers).not.toBeInstanceOf(Headers)
+    expect(headers['accept']).toBe('application/openapi+json')
+    expect(headers['accept-profile']).toBe('public')
+  })
+
   test('returns a PostgrestError built from the PostgREST error body', async () => {
     const pgrstError = {
       code: 'PGRST301',

--- a/packages/core/postgrest-js/test/openapi-spec.test.ts
+++ b/packages/core/postgrest-js/test/openapi-spec.test.ts
@@ -1,0 +1,161 @@
+import { PostgrestClient, PostgrestError } from '../src/index'
+
+const REST_URL = 'http://localhost:3000'
+
+const SPEC = {
+  swagger: '2.0',
+  info: { title: 'PostgREST API', version: '12.0.0' },
+  host: '0.0.0.0:3000',
+  basePath: '/',
+  paths: { '/todos': { get: {} } },
+  definitions: { todos: { properties: { id: { type: 'integer' } } } },
+  parameters: {},
+}
+
+type Call = { input: Parameters<typeof fetch>[0]; init?: Parameters<typeof fetch>[1] }
+
+/** A fetch stub that records each call and replies with the given response. */
+function fetchReplying(response: () => Response | Promise<never>) {
+  const calls: Call[] = []
+  const fetchImpl: typeof fetch = (input, init) => {
+    calls.push({ input, init })
+    return Promise.resolve().then(response)
+  }
+  return { calls, fetchImpl }
+}
+
+const jsonResponse = (body: unknown, status = 200, statusText = 'OK') =>
+  new Response(JSON.stringify(body), {
+    status,
+    statusText,
+    headers: { 'Content-Type': 'application/openapi+json' },
+  })
+
+describe('getOpenApiSpec', () => {
+  test('requests the REST root with a trailing slash and returns the parsed document', async () => {
+    const { calls, fetchImpl } = fetchReplying(() => jsonResponse(SPEC))
+    const postgrest = new PostgrestClient(REST_URL, { schema: 'public', fetch: fetchImpl })
+
+    const res = await postgrest.getOpenApiSpec()
+
+    expect(calls).toHaveLength(1)
+    expect(String(calls[0].input)).toBe(`${REST_URL}/`)
+    expect(calls[0].init?.method).toBe('GET')
+    const headers = new Headers(calls[0].init?.headers)
+    expect(headers.get('Accept')).toBe('application/openapi+json')
+    expect(headers.get('Accept-Profile')).toBe('public')
+
+    expect(res).toEqual({
+      success: true,
+      error: null,
+      data: SPEC,
+      count: null,
+      status: 200,
+      statusText: 'OK',
+    })
+  })
+
+  test('omits Accept-Profile when the client has no schema', async () => {
+    const { calls, fetchImpl } = fetchReplying(() => jsonResponse(SPEC))
+    const postgrest = new PostgrestClient(REST_URL, { fetch: fetchImpl })
+
+    await postgrest.getOpenApiSpec()
+
+    const headers = new Headers(calls[0].init?.headers)
+    expect(headers.has('Accept-Profile')).toBe(false)
+  })
+
+  test('describes the schema selected with .schema()', async () => {
+    const { calls, fetchImpl } = fetchReplying(() => jsonResponse(SPEC))
+    const postgrest = new PostgrestClient(REST_URL, { schema: 'public', fetch: fetchImpl })
+
+    await postgrest.schema('billing').getOpenApiSpec()
+
+    const headers = new Headers(calls[0].init?.headers)
+    expect(headers.get('Accept-Profile')).toBe('billing')
+  })
+
+  test('returns a PostgrestError built from the PostgREST error body', async () => {
+    const pgrstError = {
+      code: 'PGRST301',
+      details: null,
+      hint: null,
+      message: 'JWT expired',
+    }
+    const { fetchImpl } = fetchReplying(() => jsonResponse(pgrstError, 401, 'Unauthorized'))
+    const postgrest = new PostgrestClient(REST_URL, { fetch: fetchImpl })
+
+    const res = await postgrest.getOpenApiSpec()
+
+    expect(res.success).toBe(false)
+    expect(res.data).toBeNull()
+    expect(res.status).toBe(401)
+    expect(res.statusText).toBe('Unauthorized')
+    expect(res.error).toBeInstanceOf(PostgrestError)
+    expect(res.error).toMatchObject({
+      name: 'PostgrestError',
+      message: 'JWT expired',
+      code: 'PGRST301',
+      details: '',
+      hint: '',
+    })
+  })
+
+  test('falls back to the status text when a failed response has no body', async () => {
+    const { fetchImpl } = fetchReplying(
+      () => new Response(null, { status: 404, statusText: 'Not Found' })
+    )
+    const postgrest = new PostgrestClient(REST_URL, { fetch: fetchImpl })
+
+    const res = await postgrest.getOpenApiSpec()
+
+    expect(res.success).toBe(false)
+    expect(res.status).toBe(404)
+    expect(res.error).toBeInstanceOf(PostgrestError)
+    expect(res.error).toMatchObject({ message: 'Not Found', code: '', details: '', hint: '' })
+  })
+
+  test('uses a non-JSON failure body as the error message', async () => {
+    const { fetchImpl } = fetchReplying(
+      () =>
+        new Response('OpenAPI output is disabled', { status: 406, statusText: 'Not Acceptable' })
+    )
+    const postgrest = new PostgrestClient(REST_URL, { fetch: fetchImpl })
+
+    const res = await postgrest.getOpenApiSpec()
+
+    expect(res.success).toBe(false)
+    expect(res.status).toBe(406)
+    expect(res.error).toMatchObject({ message: 'OpenAPI output is disabled', code: '' })
+  })
+
+  test('reports a successful response whose body is not JSON as an error', async () => {
+    const { fetchImpl } = fetchReplying(
+      () => new Response('<html>not a spec</html>', { status: 200, statusText: 'OK' })
+    )
+    const postgrest = new PostgrestClient(REST_URL, { fetch: fetchImpl })
+
+    const res = await postgrest.getOpenApiSpec()
+
+    expect(res.success).toBe(false)
+    expect(res.data).toBeNull()
+    expect(res.status).toBe(200)
+    expect(res.error).toBeInstanceOf(PostgrestError)
+    expect(res.error).toMatchObject({ message: '<html>not a spec</html>', code: '' })
+  })
+
+  test('maps a rejected fetch to status 0 without throwing', async () => {
+    const failure = new TypeError('fetch failed')
+    const { fetchImpl } = fetchReplying(() => Promise.reject(failure))
+    const postgrest = new PostgrestClient(REST_URL, { fetch: fetchImpl })
+
+    const res = await postgrest.getOpenApiSpec()
+
+    expect(res.success).toBe(false)
+    expect(res.data).toBeNull()
+    expect(res.status).toBe(0)
+    expect(res.statusText).toBe('')
+    expect(res.error).toBeInstanceOf(PostgrestError)
+    expect(res.error).toMatchObject({ message: 'TypeError: fetch failed', code: '' })
+  })
+})

--- a/packages/core/supabase-js/src/SupabaseClient.ts
+++ b/packages/core/supabase-js/src/SupabaseClient.ts
@@ -3,7 +3,9 @@ import { FunctionsClient } from '@supabase/functions-js'
 import {
   PostgrestClient,
   type PostgrestFilterBuilder,
+  type PostgrestOpenApiSpec,
   type PostgrestQueryBuilder,
+  type PostgrestSingleResponse,
 } from '@supabase/postgrest-js'
 import {
   type RealtimeChannel,
@@ -459,6 +461,25 @@ export default class SupabaseClient<
     Database[DynamicSchema] extends GenericSchema ? Database[DynamicSchema] : any
   > {
     return this.rest.schema<DynamicSchema>(schema)
+  }
+
+  // NOTE: signatures must be kept in sync with PostgrestClient.getOpenApiSpec
+  /**
+   * Fetch the OpenAPI description PostgREST publishes for this client's schema.
+   *
+   * The document lists only the tables, views and functions the caller's role
+   * holds privileges on. The request carries the same `apikey` and
+   * `Authorization` headers as every other query, so the description is scoped
+   * to the signed-in user. Call `.schema()` first to describe a schema other
+   * than the client default.
+   *
+   * @example
+   * ```ts
+   * const { data, error } = await supabase.getOpenApiSpec()
+   * ```
+   */
+  getOpenApiSpec(): Promise<PostgrestSingleResponse<PostgrestOpenApiSpec>> {
+    return this.rest.getOpenApiSpec()
   }
 
   // NOTE: signatures must be kept in sync with PostgrestClient.rpc

--- a/packages/core/supabase-js/src/index.ts
+++ b/packages/core/supabase-js/src/index.ts
@@ -7,6 +7,7 @@ export type {
   PostgrestResponse,
   PostgrestSingleResponse,
   PostgrestMaybeSingleResponse,
+  PostgrestOpenApiSpec,
   PostgrestBuilder,
   PostgrestFilterBuilder,
   PostgrestTransformBuilder,

--- a/packages/core/supabase-js/test/unit/SupabaseClient.test.ts
+++ b/packages/core/supabase-js/test/unit/SupabaseClient.test.ts
@@ -583,4 +583,35 @@ describe('SupabaseClient', () => {
       })
     })
   })
+
+  describe('getOpenApiSpec', () => {
+    test('fetches the REST root for the client schema with the caller credentials', async () => {
+      const spec = { swagger: '2.0', info: {}, paths: {}, definitions: {} }
+      const mockFetch = jest
+        .fn()
+        .mockResolvedValue(new Response(JSON.stringify(spec), { status: 200, statusText: 'OK' }))
+
+      const client = createClient(URL, KEY, {
+        db: { schema: 'billing' },
+        global: { fetch: mockFetch },
+      })
+      client.auth.getSession = jest.fn().mockResolvedValue({
+        data: { session: { access_token: 'user-token' } },
+      })
+
+      const { data, error } = await client.getOpenApiSpec()
+
+      expect(error).toBeNull()
+      expect(data).toEqual(spec)
+
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+      const [input, options] = mockFetch.mock.calls[0]
+      expect(String(input)).toBe(`${URL}/rest/v1/`)
+      expect(options.method).toBe('GET')
+      expect(options.headers.get('Accept')).toBe('application/openapi+json')
+      expect(options.headers.get('Accept-Profile')).toBe('billing')
+      expect(options.headers.get('apikey')).toBe(KEY)
+      expect(options.headers.get('Authorization')).toBe('Bearer user-token')
+    })
+  })
 })

--- a/scripts/canonical-mapping.yaml
+++ b/scripts/canonical-mapping.yaml
@@ -85,6 +85,7 @@ mappings:
 
   # query renames
   database.query.from: database.query.from_table
+  database.query.get_open_api_spec: database.query.openapi_spec
   database.query.schema: database.query.schema_selection
 
   # ─── functions ───────────────────────────────────────────────────────────

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -342,6 +342,20 @@ features:
     status: implemented
     symbols:
       - PostgrestClient.from
+  database.query.openapi_spec:
+    status: implemented
+    symbols:
+      - PostgrestClient.getOpenApiSpec
+      - SupabaseClient.getOpenApiSpec
+    supporting_symbols:
+      - PostgrestOpenApiSpec
+      - PostgrestOpenApiSpec.swagger
+      - PostgrestOpenApiSpec.info
+      - PostgrestOpenApiSpec.host
+      - PostgrestOpenApiSpec.basePath
+      - PostgrestOpenApiSpec.paths
+      - PostgrestOpenApiSpec.definitions
+      - PostgrestOpenApiSpec.parameters
   database.query.rpc:
     status: implemented
     symbols:


### PR DESCRIPTION
Fetches PostgREST's OpenAPI description for the client's schema through the client's own credentials. Groundwork for tool generation in @supabase/server.