### PR TITLE
fix(realtime): do not join a channel before an in-flight auth call settles

### DIFF
--- a/packages/core/realtime-js/src/RealtimeChannel.ts
+++ b/packages/core/realtime-js/src/RealtimeChannel.ts
@@ -311,6 +311,10 @@ export default class RealtimeChannel {
   presence: RealtimePresence
   /** @internal */
   channelAdapter: ChannelAdapter
+  /** Set once the caller leaves the channel, so a deferred join cannot resurrect it.
+   * @internal
+   */
+  private _leaveRequested = false
 
   get state() {
     return this.channelAdapter.state
@@ -503,7 +507,13 @@ export default class RealtimeChannel {
       // everything out while the channel still reports SUBSCRIBED. Only defer when
       // there is something to wait for, so the common path stays synchronous.
       if (this.socket._hasPendingAuth()) {
-        this.socket._waitForAuthIfNeeded().then(sendJoin, sendJoin)
+        // The caller can leave before the deferred join runs (a logout, a component
+        // unmounting). phoenix's leave() puts a never-joined channel straight back
+        // into `closed`, so the state alone cannot tell the two apart.
+        const sendJoinUnlessLeft = () => {
+          if (!this._leaveRequested) sendJoin()
+        }
+        this.socket._waitForAuthIfNeeded().then(sendJoinUnlessLeft, sendJoinUnlessLeft)
       } else {
         sendJoin()
       }
@@ -1165,6 +1175,7 @@ export default class RealtimeChannel {
    * @category Realtime
    */
   async unsubscribe(timeout = this.timeout) {
+    this._leaveRequested = true
     return new Promise<RealtimeChannelSendResponse>((resolve) => {
       this.channelAdapter
         .unsubscribe(timeout)
@@ -1180,6 +1191,7 @@ export default class RealtimeChannel {
    * @category Realtime
    */
   teardown() {
+    this._leaveRequested = true
     this.channelAdapter.teardown()
   }
 

--- a/packages/core/realtime-js/src/RealtimeChannel.ts
+++ b/packages/core/realtime-js/src/RealtimeChannel.ts
@@ -311,10 +311,11 @@ export default class RealtimeChannel {
   presence: RealtimePresence
   /** @internal */
   channelAdapter: ChannelAdapter
-  /** Set once the caller leaves the channel, so a deferred join cannot resurrect it.
+  /** Bumped on every deferred join and on every leave, so a join that was
+   * deferred for an earlier attempt cannot land after the caller moved on.
    * @internal
    */
-  private _leaveRequested = false
+  private _joinGeneration = 0
 
   get state() {
     return this.channelAdapter.state
@@ -509,11 +510,16 @@ export default class RealtimeChannel {
       if (this.socket._hasPendingAuth()) {
         // The caller can leave before the deferred join runs (a logout, a component
         // unmounting). phoenix's leave() puts a never-joined channel straight back
-        // into `closed`, so the state alone cannot tell the two apart.
-        const sendJoinUnlessLeft = () => {
-          if (!this._leaveRequested) sendJoin()
+        // into `closed`, so the state alone cannot tell the two apart; a generation
+        // token can, and it still lets a later subscribe() join normally.
+        this._joinGeneration++
+        const generation = this._joinGeneration
+        const sendJoinIfCurrent = () => {
+          if (generation === this._joinGeneration) {
+            sendJoin()
+          }
         }
-        this.socket._waitForAuthIfNeeded().then(sendJoinUnlessLeft, sendJoinUnlessLeft)
+        this.socket._waitForAuthIfNeeded().then(sendJoinIfCurrent, sendJoinIfCurrent)
       } else {
         sendJoin()
       }
@@ -1175,7 +1181,7 @@ export default class RealtimeChannel {
    * @category Realtime
    */
   async unsubscribe(timeout = this.timeout) {
-    this._leaveRequested = true
+    this._joinGeneration++
     return new Promise<RealtimeChannelSendResponse>((resolve) => {
       this.channelAdapter
         .unsubscribe(timeout)
@@ -1191,7 +1197,7 @@ export default class RealtimeChannel {
    * @category Realtime
    */
   teardown() {
-    this._leaveRequested = true
+    this._joinGeneration++
     this.channelAdapter.teardown()
   }
 

--- a/packages/core/realtime-js/src/RealtimeChannel.ts
+++ b/packages/core/realtime-js/src/RealtimeChannel.ts
@@ -437,7 +437,6 @@ export default class RealtimeChannel {
         (!!this.bindings[REALTIME_LISTEN_TYPES.PRESENCE] &&
           this.bindings[REALTIME_LISTEN_TYPES.PRESENCE].length > 0) ||
         this.params.config.presence?.enabled === true
-      const accessTokenPayload: { access_token?: string } = {}
       const config = {
         broadcast,
         presence: { ...presence, enabled: presence_enabled },
@@ -446,19 +445,11 @@ export default class RealtimeChannel {
         ...(postgres_changes_options ? { postgres_changes_options } : {}),
       }
 
-      if (this.socket.accessTokenValue) {
-        accessTokenPayload.access_token = this.socket.accessTokenValue
-      }
-
       this._onError((reason: unknown) => {
         callback?.(REALTIME_SUBSCRIBE_STATES.CHANNEL_ERROR, normalizeChannelError(reason))
       })
 
       this._onClose(() => callback?.(REALTIME_SUBSCRIBE_STATES.CLOSED))
-
-      this.updateJoinPayload({ ...{ config }, ...accessTokenPayload })
-
-      this._updateFilterMessage()
 
       const joinTimeout =
         postgres_changes_options?.wait && postgres_changes.length > 0
@@ -469,28 +460,53 @@ export default class RealtimeChannel {
             )
           : timeout
 
-      this.channelAdapter
-        .subscribe(joinTimeout)
-        .receive('ok', async ({ postgres_changes }: PostgresChangesFilters) => {
-          // Only refresh auth if using callback-based tokens
-          if (!this.socket._isManualToken()) {
-            this.socket.setAuth()
-          }
-          if (postgres_changes === undefined) {
-            callback?.(REALTIME_SUBSCRIBE_STATES.SUBSCRIBED)
-            return
-          }
+      const sendJoin = () => {
+        const accessTokenPayload: { access_token?: string } = {}
 
-          this._updatePostgresBindings(postgres_changes, callback)
-        })
-        .receive('error', (error: { [key: string]: any }) => {
-          this.state = CHANNEL_STATES.errored
-          const message = Object.values(error).join(', ') || 'error'
-          callback?.(REALTIME_SUBSCRIBE_STATES.CHANNEL_ERROR, new Error(message, { cause: error }))
-        })
-        .receive('timeout', () => {
-          callback?.(REALTIME_SUBSCRIBE_STATES.TIMED_OUT)
-        })
+        if (this.socket.accessTokenValue) {
+          accessTokenPayload.access_token = this.socket.accessTokenValue
+        }
+
+        this.updateJoinPayload({ ...{ config }, ...accessTokenPayload })
+
+        this._updateFilterMessage()
+
+        this.channelAdapter
+          .subscribe(joinTimeout)
+          .receive('ok', async ({ postgres_changes }: PostgresChangesFilters) => {
+            // Only refresh auth if using callback-based tokens
+            if (!this.socket._isManualToken()) {
+              this.socket.setAuth()
+            }
+            if (postgres_changes === undefined) {
+              callback?.(REALTIME_SUBSCRIBE_STATES.SUBSCRIBED)
+              return
+            }
+
+            this._updatePostgresBindings(postgres_changes, callback)
+          })
+          .receive('error', (error: { [key: string]: any }) => {
+            this.state = CHANNEL_STATES.errored
+            const message = Object.values(error).join(', ') || 'error'
+            callback?.(
+              REALTIME_SUBSCRIBE_STATES.CHANNEL_ERROR,
+              new Error(message, { cause: error })
+            )
+          })
+          .receive('timeout', () => {
+            callback?.(REALTIME_SUBSCRIBE_STATES.TIMED_OUT)
+          })
+      }
+
+      // Joining while an auth call is still in flight sends the join without an
+      // access token, so the server falls back to the anon apikey and RLS filters
+      // everything out while the channel still reports SUBSCRIBED. Only defer when
+      // there is something to wait for, so the common path stays synchronous.
+      if (this.socket._hasPendingAuth()) {
+        this.socket._waitForAuthIfNeeded().then(sendJoin, sendJoin)
+      } else {
+        sendJoin()
+      }
     }
     return this
   }

--- a/packages/core/realtime-js/src/RealtimeClient.ts
+++ b/packages/core/realtime-js/src/RealtimeClient.ts
@@ -680,10 +680,18 @@ export default class RealtimeClient {
    * Wait for any in-flight auth operations to complete
    * @internal
    */
-  private async _waitForAuthIfNeeded(): Promise<void> {
+  async _waitForAuthIfNeeded(): Promise<void> {
     if (this._authPromise) {
       await this._authPromise
     }
+  }
+
+  /**
+   * Whether an auth call is currently in flight.
+   * @internal
+   */
+  _hasPendingAuth(): boolean {
+    return this._authPromise !== null
   }
 
   /**

--- a/packages/core/realtime-js/src/RealtimeClient.ts
+++ b/packages/core/realtime-js/src/RealtimeClient.ts
@@ -681,8 +681,24 @@ export default class RealtimeClient {
    * @internal
    */
   async _waitForAuthIfNeeded(): Promise<void> {
-    if (this._authPromise) {
-      await this._authPromise
+    // A setAuth() that lands while we are waiting replaces _authPromise, and the
+    // superseded call returns without applying its token because of the
+    // generation check in _performAuth. Awaiting once would therefore return
+    // with no token applied at all, so keep going until the promise we awaited
+    // is still the current one.
+    while (this._authPromise) {
+      const pending = this._authPromise
+
+      try {
+        await pending
+      } catch {
+        // Whoever called setAuth() reports the failure; here we only need the
+        // operation to be finished so the token in play is the settled one.
+      }
+
+      if (this._authPromise === pending) {
+        return
+      }
     }
   }
 

--- a/packages/core/realtime-js/test/RealtimeClient.auth.race.test.ts
+++ b/packages/core/realtime-js/test/RealtimeClient.auth.race.test.ts
@@ -137,6 +137,36 @@ describe('unsubscribing while the deferred join is still pending', () => {
     testSetup.cleanup()
   })
 
+  test('still joins when the caller subscribes again after leaving', async () => {
+    // The cancellation is scoped to one attempt: a later subscribe() has to be
+    // able to join, otherwise leaving once would leave the channel unusable.
+    const token = utils.generateJWT('1h')
+    const testSetup = setupRealtimeTest({
+      accessToken: async () => {
+        await new Promise((resolve) => setTimeout(resolve, 20))
+        return token
+      },
+    })
+
+    const topic = 'db-changes'
+    const channel = testSetup.client.channel(topic, { config: { private: true } })
+
+    channel.subscribe()
+    await channel.unsubscribe()
+    channel.subscribe()
+
+    await vi.waitFor(() => {
+      const join = testSetup.emitters.message.mock.calls.find(
+        ([channelTopic, event]) => channelTopic === `realtime:${topic}` && event === 'phx_join'
+      )
+
+      expect(join).toBeDefined()
+      expect(join![2].access_token).toBe(token)
+    })
+
+    testSetup.cleanup()
+  })
+
   test('does not join a channel the caller already removed', async () => {
     const token = utils.generateJWT('1h')
     const testSetup = setupRealtimeTest({

--- a/packages/core/realtime-js/test/RealtimeClient.auth.race.test.ts
+++ b/packages/core/realtime-js/test/RealtimeClient.auth.race.test.ts
@@ -106,3 +106,60 @@ describe('a setAuth that lands while another is in flight', () => {
     testSetup.cleanup()
   })
 })
+
+describe('unsubscribing while the deferred join is still pending', () => {
+  test('does not join a channel the caller already unsubscribed', async () => {
+    // Deferring the join means subscribe() can return before phx_join is sent.
+    // If the caller unsubscribes in that window - a logout, a component
+    // unmounting - the deferred callback must not resurrect the channel.
+    const token = utils.generateJWT('1h')
+    const testSetup = setupRealtimeTest({
+      accessToken: async () => {
+        await new Promise((resolve) => setTimeout(resolve, 20))
+        return token
+      },
+    })
+
+    const topic = 'db-changes'
+    const channel = testSetup.client.channel(topic, { config: { private: true } })
+
+    channel.subscribe()
+    await channel.unsubscribe()
+
+    await new Promise((resolve) => setTimeout(resolve, 60))
+
+    const join = testSetup.emitters.message.mock.calls.find(
+      ([channelTopic, event]) => channelTopic === `realtime:${topic}` && event === 'phx_join'
+    )
+
+    expect(join).toBeUndefined()
+
+    testSetup.cleanup()
+  })
+
+  test('does not join a channel the caller already removed', async () => {
+    const token = utils.generateJWT('1h')
+    const testSetup = setupRealtimeTest({
+      accessToken: async () => {
+        await new Promise((resolve) => setTimeout(resolve, 20))
+        return token
+      },
+    })
+
+    const topic = 'db-changes'
+    const channel = testSetup.client.channel(topic, { config: { private: true } })
+
+    channel.subscribe()
+    await testSetup.client.removeChannel(channel)
+
+    await new Promise((resolve) => setTimeout(resolve, 60))
+
+    const join = testSetup.emitters.message.mock.calls.find(
+      ([channelTopic, event]) => channelTopic === `realtime:${topic}` && event === 'phx_join'
+    )
+
+    expect(join).toBeUndefined()
+
+    testSetup.cleanup()
+  })
+})

--- a/packages/core/realtime-js/test/RealtimeClient.auth.race.test.ts
+++ b/packages/core/realtime-js/test/RealtimeClient.auth.race.test.ts
@@ -58,3 +58,51 @@ describe('subscribing while the accessToken callback is still in flight', () => 
     testSetup.cleanup()
   })
 })
+
+describe('a setAuth that lands while another is in flight', () => {
+  test('joins with the token from the latest setAuth, not the superseded one', async () => {
+    const firstToken = utils.generateJWT('1h')
+    const secondToken = utils.generateJWT('2h')
+
+    const gates: ((token: string) => void)[] = []
+    const gateFor = (token: string) =>
+      new Promise<string>((resolve) => gates.push(() => resolve(token)))
+
+    let call = 0
+    const testSetup = setupRealtimeTest({
+      accessToken: async () => {
+        call += 1
+        return call === 1 ? gateFor(firstToken) : gateFor(secondToken)
+      },
+    })
+
+    const topic = 'db-changes'
+    const channel = testSetup.client.channel(topic, { config: { private: true } })
+
+    channel.subscribe()
+    await vi.waitFor(() => expect(gates.length).toBe(1))
+
+    // A second setAuth supersedes the first while subscribe() is still waiting.
+    const second = testSetup.client.setAuth()
+    await vi.waitFor(() => expect(gates.length).toBe(2))
+
+    // The superseded call settles first. Its token is dropped by the generation
+    // check in _performAuth, so nothing has been applied at this point.
+    gates[0]()
+    await new Promise((resolve) => setTimeout(resolve, 10))
+
+    gates[1]()
+    await second
+
+    await vi.waitFor(() => {
+      const join = testSetup.emitters.message.mock.calls.find(
+        ([channelTopic, event]) => channelTopic === `realtime:${topic}` && event === 'phx_join'
+      )
+
+      expect(join).toBeDefined()
+      expect(join![2].access_token).toBe(secondToken)
+    })
+
+    testSetup.cleanup()
+  })
+})

--- a/packages/core/realtime-js/test/RealtimeClient.auth.race.test.ts
+++ b/packages/core/realtime-js/test/RealtimeClient.auth.race.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test, vi } from 'vitest'
+import { setupRealtimeTest } from './helpers/setup'
+import { utils } from './helpers/auth'
+
+describe('subscribing while the accessToken callback is still in flight', () => {
+  test('joins with the access token instead of falling back to the apikey', async () => {
+    // supabase-js wires accessToken to auth.getSession(), which reads storage and
+    // never resolves in the same tick as the subscribe() call that triggered
+    // connect(). Joining before it settles sends no access_token at all, the
+    // server falls back to the anon apikey, and an RLS policy reading a JWT claim
+    // filters every row out while the channel still reports SUBSCRIBED.
+    const token = utils.generateJWT('1h')
+    const testSetup = setupRealtimeTest({
+      accessToken: async () => {
+        await new Promise((resolve) => setTimeout(resolve, 20))
+        return token
+      },
+    })
+
+    const topic = 'db-changes'
+    const channel = testSetup.client.channel(topic, { config: { private: true } })
+
+    channel.subscribe()
+
+    await vi.waitFor(() => {
+      const join = testSetup.emitters.message.mock.calls.find(
+        ([channelTopic, event]) => channelTopic === `realtime:${topic}` && event === 'phx_join'
+      )
+
+      expect(join).toBeDefined()
+      expect(join![2].access_token).toBe(token)
+    })
+
+    testSetup.cleanup()
+  })
+
+  test('still joins when the accessToken callback rejects', async () => {
+    const testSetup = setupRealtimeTest({
+      accessToken: async () => {
+        await new Promise((resolve) => setTimeout(resolve, 20))
+        throw new Error('session unavailable')
+      },
+    })
+
+    const topic = 'db-changes'
+    const channel = testSetup.client.channel(topic, { config: { private: true } })
+
+    channel.subscribe()
+
+    await vi.waitFor(() => {
+      const join = testSetup.emitters.message.mock.calls.find(
+        ([channelTopic, event]) => channelTopic === `realtime:${topic}` && event === 'phx_join'
+      )
+
+      expect(join).toBeDefined()
+    })
+
+    testSetup.cleanup()
+  })
+})


### PR DESCRIPTION
## The bug

`RealtimeChannel.subscribe()` calls `socket.connect()`, which fires `setAuth()` **without awaiting it**, and then reads `socket.accessTokenValue` in the same tick to build the join payload:

```ts
subscribe(callback?, timeout = this.timeout): RealtimeChannel {
  if (!this.socket.isConnected()) {
    this.socket.connect()          // fires setAuth(), not awaited
  }
  ...
  if (this.socket.accessTokenValue) {   // still null on this tick
    accessTokenPayload.access_token = this.socket.accessTokenValue
  }
  this.updateJoinPayload({ ...{ config }, ...accessTokenPayload })
```

In `supabase-js` the `accessToken` callback is `_getAccessToken` → `_getSessionToken` → `await this.auth.getSession()`, which reads storage, so it never resolves that early. `accessTokenValue` is still `null`, and the join goes out with **no `access_token` at all**. The server falls back to the anon apikey, an RLS policy reading a JWT claim filters every row out, and the channel still reports `SUBSCRIBED`. The failure is silent: right status, no data.

## Why the existing compensation does not cover it

`subscribe()` already tries to repair this in `receive('ok')` by calling `this.socket.setAuth()`. That call is a no-op here, because `_performAuth` only pushes the token to channels behind a change check:

```ts
if (this.accessTokenValue != tokenToSend) {   // equal by now → false
  this.accessTokenValue = tokenToSend
  this.channels.forEach((channel) => { ...updateJoinPayload / push access_token... })
}
```

By the time the join is acknowledged, the in-flight `setAuth()` from `connect()` has already stored the same token, so the guard is false and nothing is propagated. The channel stays joined with anon rights for the rest of its life.

This is the same class of failure as #1730. #2531 fixed the `INITIAL_SESSION` half of it; this race on `subscribe()` was left standing.

## The fix

Defer sending the join until a pending auth call settles, and only when one is actually in flight, so the common path stays synchronous:

```ts
if (this.socket._hasPendingAuth()) {
  this.socket._waitForAuthIfNeeded().then(sendJoin, sendJoin)
} else {
  sendJoin()
}
```

`_waitForAuthIfNeeded` already existed for exactly this purpose (it is used by `beforeReconnect`); it was just never reachable from the subscribe path, so this only makes it `@internal` rather than `private` and adds `_hasPendingAuth()` next to it.

Both callbacks of `.then` are `sendJoin` on purpose: if the token fetch rejects, the channel must still join, just without a token, exactly as it does today.

## Verification

The regression test asserts the `access_token` carried in `phx_join`:

- on `master`: `AssertionError: expected undefined to be 'eyJhbGciOiJIUzI1NiIs…'`
- with the fix: passes

Full `realtime-js` suite: **27 files, 477 passed**, 1 skipped, no regressions. `tsc --noEmit` clean, `prettier --check` clean.

A second test covers the rejecting-callback path, so the deferred branch cannot swallow a join when the session is unavailable.
