### PR TITLE
fix(storage): percent-encode the object key in every URL, not just purgeCache

### DIFF
--- a/packages/core/storage-js/src/packages/StorageFileApi.ts
+++ b/packages/core/storage-js/src/packages/StorageFileApi.ts
@@ -139,7 +139,7 @@ export default class StorageFileApi extends BaseApiClient<StorageError> {
       }
 
       const cleanPath = this._removeEmptyFolders(path)
-      const _path = this._getFinalPath(cleanPath)
+      const _path = encodeStoragePath(this._getFinalPath(cleanPath))
       const data = await (method == 'PUT' ? put : post)(
         this.fetch,
         `${this.url}/object/${_path}`,
@@ -280,7 +280,7 @@ export default class StorageFileApi extends BaseApiClient<StorageError> {
     fileOptions?: FileOptions
   ) {
     const cleanPath = this._removeEmptyFolders(path)
-    const _path = this._getFinalPath(cleanPath)
+    const _path = encodeStoragePath(this._getFinalPath(cleanPath))
 
     const url = new URL(this.url + `/object/upload/sign/${_path}`)
     url.searchParams.set('token', token)
@@ -393,7 +393,7 @@ export default class StorageFileApi extends BaseApiClient<StorageError> {
       }
   > {
     return this.handleOperation(async () => {
-      let _path = this._getFinalPath(path)
+      let _path = encodeStoragePath(this._getFinalPath(path))
 
       const headers = { ...this.headers }
 
@@ -711,7 +711,7 @@ export default class StorageFileApi extends BaseApiClient<StorageError> {
       }
   > {
     return this.handleOperation(async () => {
-      let _path = this._getFinalPath(path)
+      let _path = encodeStoragePath(this._getFinalPath(path))
 
       const hasTransform =
         typeof options?.transform === 'object' &&
@@ -913,7 +913,7 @@ export default class StorageFileApi extends BaseApiClient<StorageError> {
     if (options?.versionId != null) query.set('versionId', String(options.versionId))
     const queryString = query.toString()
 
-    const _path = this._getFinalPath(path)
+    const _path = encodeStoragePath(this._getFinalPath(path))
     const downloadFn = () =>
       get(
         this.fetch,
@@ -965,7 +965,7 @@ export default class StorageFileApi extends BaseApiClient<StorageError> {
         error: StorageError
       }
   > {
-    const _path = this._getFinalPath(path)
+    const _path = encodeStoragePath(this._getFinalPath(path))
     const query = new URLSearchParams()
     if (options?.versionId != null) query.set('versionId', String(options.versionId))
     const queryString = query.toString()
@@ -1009,7 +1009,7 @@ export default class StorageFileApi extends BaseApiClient<StorageError> {
         error: StorageError
       }
   > {
-    const _path = this._getFinalPath(path)
+    const _path = encodeStoragePath(this._getFinalPath(path))
 
     try {
       await head(this.fetch, `${this.url}/object/${_path}`, {
@@ -1106,7 +1106,7 @@ export default class StorageFileApi extends BaseApiClient<StorageError> {
       cacheNonce?: string
     }
   ): { data: { publicUrl: string } } {
-    const _path = this._getFinalPath(path)
+    const _path = encodeStoragePath(this._getFinalPath(path))
 
     const query = new URLSearchParams()
     if (options?.download) query.set('download', options.download === true ? '' : options.download)
@@ -1123,8 +1123,7 @@ export default class StorageFileApi extends BaseApiClient<StorageError> {
     return {
       data: {
         publicUrl:
-          encodeURI(`${this.url}/${renderPath}/public/${_path}`) +
-          (queryString ? `?${queryString}` : ''),
+          `${this.url}/${renderPath}/public/${_path}` + (queryString ? `?${queryString}` : ''),
       },
     }
   }

--- a/packages/core/storage-js/test/object-key-encoding.test.ts
+++ b/packages/core/storage-js/test/object-key-encoding.test.ts
@@ -1,0 +1,71 @@
+import StorageFileApi from '../src/packages/StorageFileApi'
+
+const URL_BASE = 'https://proj.supabase.co/storage/v1'
+
+const makeApi = (fetchImpl?: any) => new StorageFileApi(URL_BASE, {}, 'bucket', fetchImpl)
+
+/**
+ * A `#` in an object key ends the URL path and starts a fragment, and a `?`
+ * starts the query string, so an unencoded key silently addresses a different
+ * object than the one the caller asked for.
+ */
+describe('object keys that carry URL-significant characters', () => {
+  describe('getPublicUrl', () => {
+    test('percent-encodes a hash', () => {
+      const { data } = makeApi().getPublicUrl('folder/report#1.png')
+
+      expect(data.publicUrl).toBe(`${URL_BASE}/object/public/bucket/folder/report%231.png`)
+    })
+
+    test('percent-encodes a question mark', () => {
+      const { data } = makeApi().getPublicUrl('folder/what?.png')
+
+      expect(data.publicUrl).toBe(`${URL_BASE}/object/public/bucket/folder/what%3F.png`)
+    })
+
+    test('keeps path separators literal', () => {
+      const { data } = makeApi().getPublicUrl('a/b/c.png')
+
+      expect(data.publicUrl).toBe(`${URL_BASE}/object/public/bucket/a/b/c.png`)
+    })
+
+    test('leaves the query string it builds itself untouched', () => {
+      const { data } = makeApi().getPublicUrl('folder/report#1.png', { download: 'report#1.png' })
+
+      const [path, query] = data.publicUrl.split('?')
+      expect(path).toBe(`${URL_BASE}/object/public/bucket/folder/report%231.png`)
+      expect(query).toBe('download=report%231.png')
+    })
+  })
+
+  describe('requests built from an object key', () => {
+    const capture = () => {
+      const calls: string[] = []
+      const fetchImpl = jest.fn(async (url: string) => {
+        calls.push(url)
+        return new Response('{}', {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+      })
+
+      return { calls, fetchImpl }
+    }
+
+    test('info() encodes the key', async () => {
+      const { calls, fetchImpl } = capture()
+
+      await makeApi(fetchImpl).info('folder/report#1.png')
+
+      expect(calls[0]).toContain('/object/info/bucket/folder/report%231.png')
+    })
+
+    test('createSignedUrl() encodes the key', async () => {
+      const { calls, fetchImpl } = capture()
+
+      await makeApi(fetchImpl).createSignedUrl('folder/report#1.png', 60)
+
+      expect(calls[0]).toContain('/object/sign/bucket/folder/report%231.png')
+    })
+  })
+})


### PR DESCRIPTION
## The bug

`encodeStoragePath` already exists in this repo, and its doc comment states the reason:

> ...key (e.g. `?`, `#`) can't be interpreted as a querystring/fragment start.
> Splits on `/` so real path separators stay literal — the storage server routes on them and decodes each segment back to the original key.

It is wired into exactly **one** call site (`purgeCache`). Every other method builds its URL straight from `_getFinalPath`, which only strips leading slashes:

```ts
private _getFinalPath(path: string) {
  return `${this.bucketId}/${path.replace(/^\/+/, '')}`
}
```

So an object key containing `#` or `?` silently addresses a different object:

```ts
storage.from('bucket').getPublicUrl('folder/report#1.png')
// → https://<project>/storage/v1/object/public/bucket/folder/report#1.png
```

`#1.png` is a fragment. The server only ever sees `.../folder/report`, and the caller gets a 404 for a file that exists. Keys like `report #1.pdf` or `Q&A?.png` are ordinary user uploads, so this is reachable with no unusual input.

The same key breaks the URL in `upload`, `uploadToSignedUrl`, `createSignedUploadUrl`, `createSignedUrl`, the authenticated download path, `info` and `exists` — eight call sites in total.

`getPublicUrl` additionally wrapped the whole URL in `encodeURI`. That escapes a space, so the output *looks* encoded, while leaving `#` and `?` untouched — the two characters that actually break routing.

## The fix

Apply the existing helper at every call site, exactly as `purgeCache` already does, and drop the now-redundant `encodeURI` so there is a single mechanism.

Path separators keep working: `encodeStoragePath` splits on `/` before encoding each segment.

## Verification

New test file `test/object-key-encoding.test.ts`, 6 assertions covering `getPublicUrl` (hash, question mark, separators kept literal, self-built query string untouched) plus `info()` and `createSignedUrl()` through an injected fetch.

- on `master`: **5 of the 6 fail**, e.g. `Expected .../report%231.png`, `Received .../report#1.png`
- with the fix: all pass

Full `storage-js` suite goes from 409 to **415 passing**. The 6 failures and 1 snapshot that remain are identical to master on my machine (integration specs that need a local storage server), confirmed with `git stash`. `tsc --noEmit` clean, `prettier --check` clean.

I could not exercise the integration specs against a real storage server, so the round trip that matters — server decoding each segment back to the original key — rests on the helper's own doc comment and on `purgeCache` already shipping this behaviour. Happy to adjust if any endpoint expects the raw key.
