### PR TITLE
fix(docs): replace dead docs/SECURITY.md links with live security policy URL

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,5 +61,5 @@ Migration notes live close to the code they describe, so they ship via npm along
 
 - [`docs/TESTING.md`](./docs/TESTING.md) — testing guide with Docker requirements per package
 - [`docs/RELEASE.md`](./docs/RELEASE.md) — release workflows and versioning strategy
-- [`docs/SECURITY.md`](./docs/SECURITY.md) — security policies and responsible disclosure
+- [Security Policy](https://github.com/supabase/supabase-js/security/policy) — security policies and responsible disclosure
 - [`docs/JSR_PUBLISHING.md`](./docs/JSR_PUBLISHING.md) — JSR registry publishing

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Testing varies per package. See the top-level [TESTING.md](docs/TESTING.md) for 
 - **[Contributing](./CONTRIBUTING.md)** - Development guidelines
 - **[Release Workflows](./docs/RELEASE.md)** - Release and publishing process
 - **[Migration Guide](./docs/MIGRATION.md)** - Cross-cutting migration notes (per-package migrations live alongside each package under `packages/core/<package>/migrations/`)
-- **[Security Policy](./docs/SECURITY.md)** - Vulnerability reporting and disclosure policy
+- **[Security Policy](https://github.com/supabase/supabase-js/security/policy)** - Vulnerability reporting and disclosure policy
 - **[Securing your npm installs](https://supabase.com/docs/guides/security/npm-security)** - Consumer-side guide to defending your install against npm supply-chain attacks
 
 ## 🔐 Verifying provenance attestations


### PR DESCRIPTION
Fixes #2654

`docs/SECURITY.md` was removed in #2480, replaced by an org-wide policy at the repo's Security tab. Two citations survived the cleanup and now return 404:

1. `AGENTS.md` line 64 — links `./docs/SECURITY.md`
2. `README.md` line 143 — links `./docs/SECURITY.md`

This is especially harmful because the Security Policy link should reach someone attempting **responsible disclosure** — landing on a 404 is the worst outcome.

## Fix
Point both citations at the live security policy URL:
```
https://github.com/supabase/supabase-js/security/policy
```

Two-line change, no code impact.
