### PR TITLE
docs(supabase): clarify db.schema needs the second generic

### DIFF
--- a/packages/core/supabase-js/src/lib/types.ts
+++ b/packages/core/supabase-js/src/lib/types.ts
@@ -108,6 +108,8 @@ export interface TracePropagationOptions {
 export type SupabaseClientOptions<SchemaName> = {
   /**
    * The Postgres schema which your tables belong to. Must be on the list of exposed schemas in Supabase. Defaults to `public`.
+   *
+   * With generated `Database` types, this type-checks against schemas other than `public` only when the schema name is also passed as the second generic to `createClient`, e.g. `createClient<Database, 'myschema'>(url, key, { db: { schema: 'myschema' } })`. `supabase.schema('myschema').from(...)` infers its schema per call and needs no second generic.
    */
   db?: {
     schema?: SchemaName


### PR DESCRIPTION
Clarifies the `db.schema` JSDoc in `SupabaseClientOptions`: with generated `Database` types, `createClient<Database>(...)` only type-checks `db.schema` against `public` unless the schema is also passed as the second generic — `createClient<Database, 'myschema'>(...)`. `supabase.schema('myschema').from(...)` needs no second generic and infers its schema per call.

Related to #969 — TypeScript users kept hitting this because nothing documented the second-generic requirement.

Docs companion: supabase/supabase#49967