### PR TITLE
fix(supabase): warn when schema is passed outside db options

### DIFF
--- a/packages/core/supabase-js/src/SupabaseClient.ts
+++ b/packages/core/supabase-js/src/SupabaseClient.ts
@@ -25,6 +25,7 @@ import {
 import { checkApiKeyFormat, fetchWithAuth } from './lib/fetch'
 import {
   applySettingDefaults,
+  checkTopLevelSchemaOption,
   validateSupabaseUrl,
   type ResolvedSupabaseClientOptions,
 } from './lib/helpers'
@@ -320,6 +321,7 @@ export default class SupabaseClient<
     const baseUrl = validateSupabaseUrl(supabaseUrl)
     if (!supabaseKey) throw new Error('supabaseKey is required.')
     checkApiKeyFormat(supabaseKey)
+    checkTopLevelSchemaOption(options)
 
     this.realtimeUrl = new URL('realtime/v1', baseUrl)
     this.realtimeUrl.protocol = this.realtimeUrl.protocol.replace('http', 'ws')

--- a/packages/core/supabase-js/src/lib/helpers.ts
+++ b/packages/core/supabase-js/src/lib/helpers.ts
@@ -21,6 +21,42 @@ export function ensureTrailingSlash(url: string): string {
 
 export const isBrowser = () => typeof window !== 'undefined'
 
+let warnedTopLevelSchema = false
+
+/**
+ * Warn (once per process) when `schema` is passed at the top level of the client options
+ * instead of under `db`. A top-level `schema` is not part of the options shape and is
+ * ignored, so queries silently go to the default schema. Never throws.
+ */
+export function checkTopLevelSchemaOption(options: unknown): void {
+  if (warnedTopLevelSchema) {
+    return
+  }
+  if (
+    typeof options !== 'object' ||
+    options === null ||
+    !('schema' in options) ||
+    (options as { schema?: unknown }).schema === undefined
+  ) {
+    return
+  }
+  warnedTopLevelSchema = true
+  console.warn(
+    '@supabase/supabase-js: The "schema" option must be nested under "db", ' +
+      "e.g. createClient(url, key, { db: { schema: 'myschema' } }). " +
+      'A top-level "schema" is ignored and queries go to the default schema.'
+  )
+}
+
+/**
+ * For tests only. Resets the one-time top-level `schema` warning.
+ *
+ * @internal
+ */
+export function _resetTopLevelSchemaWarning(): void {
+  warnedTopLevelSchema = false
+}
+
 export type ResolvedSupabaseClientOptions<SchemaName> = Omit<
   Required<SupabaseClientOptions<SchemaName>>,
   'tracePropagation'

--- a/packages/core/supabase-js/src/lib/helpers.ts
+++ b/packages/core/supabase-js/src/lib/helpers.ts
@@ -27,6 +27,9 @@ let warnedTopLevelSchema = false
  * Warn (once per process) when `schema` is passed at the top level of the client options
  * instead of under `db`. A top-level `schema` is not part of the options shape and is
  * ignored, so queries silently go to the default schema. Never throws.
+ *
+ * Only `undefined` counts as unset, matching `db.schema`, where any other value is sent
+ * as the profile header.
  */
 export function checkTopLevelSchemaOption(options: unknown): void {
   if (warnedTopLevelSchema) {

--- a/packages/core/supabase-js/test/unit/SupabaseClient.test.ts
+++ b/packages/core/supabase-js/test/unit/SupabaseClient.test.ts
@@ -1,5 +1,6 @@
 import { PostgrestClient } from '@supabase/postgrest-js'
 import { createClient, SupabaseClient } from '../../src/index'
+import { _resetTopLevelSchemaWarning } from '../../src/lib/helpers'
 import { Database } from '../types'
 
 const URL = 'http://localhost:3000'
@@ -230,6 +231,29 @@ describe('SupabaseClient', () => {
       const schemaClient = client.schema('personal')
       expect(schemaClient).toBeDefined()
       expect(schemaClient).toBeInstanceOf(PostgrestClient)
+    })
+
+    test('warns, but does not throw, when schema is passed outside db', () => {
+      _resetTopLevelSchemaWarning()
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined)
+      try {
+        expect(() => createClient(URL, KEY, { schema: 'personal' } as any)).not.toThrow()
+        expect(warnSpy).toHaveBeenCalledTimes(1)
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringMatching(/must be nested under "db"/))
+      } finally {
+        warnSpy.mockRestore()
+      }
+    })
+
+    test('does not warn when schema is nested under db', () => {
+      _resetTopLevelSchemaWarning()
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined)
+      try {
+        createClient<Database, 'personal'>(URL, KEY, { db: { schema: 'personal' } })
+        expect(warnSpy).not.toHaveBeenCalled()
+      } finally {
+        warnSpy.mockRestore()
+      }
     })
   })
 

--- a/packages/core/supabase-js/test/unit/helpers.test.ts
+++ b/packages/core/supabase-js/test/unit/helpers.test.ts
@@ -41,6 +41,49 @@ test('override setting defaults', async () => {
   expect(settings.db.schema).toBe(defaults.db.schema)
 })
 
+describe('checkTopLevelSchemaOption', () => {
+  let warnSpy: jest.SpyInstance
+
+  beforeEach(() => {
+    helpers._resetTopLevelSchemaWarning()
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    warnSpy.mockRestore()
+  })
+
+  test('is silent when schema is nested under db', () => {
+    helpers.checkTopLevelSchemaOption({ db: { schema: 'myschema' } })
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+
+  test('is silent for undefined, empty, and non-object options', () => {
+    helpers.checkTopLevelSchemaOption(undefined)
+    helpers.checkTopLevelSchemaOption({})
+    helpers.checkTopLevelSchemaOption(null)
+    helpers.checkTopLevelSchemaOption('nope')
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+
+  test('is silent when a top-level schema is explicitly undefined', () => {
+    helpers.checkTopLevelSchemaOption({ schema: undefined })
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+
+  test('warns, but does not throw, for a top-level schema', () => {
+    expect(() => helpers.checkTopLevelSchemaOption({ schema: 'myschema' })).not.toThrow()
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringMatching(/must be nested under "db"/))
+  })
+
+  test('warns only once per process', () => {
+    helpers.checkTopLevelSchemaOption({ schema: 'one' })
+    helpers.checkTopLevelSchemaOption({ schema: 'two' })
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+  })
+})
+
 test('applySettingDefaults with accessToken', () => {
   const defaults = {
     db: { schema: 'public' },

--- a/packages/core/supabase-js/test/unit/helpers.test.ts
+++ b/packages/core/supabase-js/test/unit/helpers.test.ts
@@ -46,7 +46,7 @@ describe('checkTopLevelSchemaOption', () => {
 
   beforeEach(() => {
     helpers._resetTopLevelSchemaWarning()
-    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined)
   })
 
   afterEach(() => {


### PR DESCRIPTION
Warns once per process when `schema` is passed at the top level of the client options instead of under `db`. That shape (the v1 API) is not part of `SupabaseClientOptions` and is silently ignored today, so queries go to the default schema and the only signal is a confusing PostgREST "relation does not exist" error downstream.

The check mirrors `checkApiKeyFormat`: `console.warn`, never throws, no type changes, so nothing that compiles or runs today changes behavior. Throwing would crash any app that currently runs with a stray top-level `schema` (including configs spread from a shared object), which is a breaking change on 2.x; the warning lands next to the PostgREST error that already surfaces the problem, so the failure is explained rather than silenced. A `schema?: never` compile-time guard is worth its own PR, since it turns compiling code into non-compiling code.

Closes #969 — this covers the original report (wrong option shape). The other half of that thread, the `createClient<Database>` second-generic requirement, is documented in #2662 and supabase/supabase#49967.