### PR TITLE
fix(realtime): clear disconnect race timeout on successful close

### DIFF
--- a/packages/core/realtime-js/src/phoenix/socketAdapter.ts
+++ b/packages/core/realtime-js/src/phoenix/socketAdapter.ts
@@ -94,9 +94,10 @@ export default class SocketAdapter {
     timeout: number = 10000
   ): Promise<'ok' | 'timeout'> {
     return new Promise((resolve) => {
-      setTimeout(() => resolve('timeout'), timeout)
+      const timer = setTimeout(() => resolve('timeout'), timeout)
       this.socket.disconnect(
         () => {
+          clearTimeout(timer)
           callback()
           resolve('ok')
         },

--- a/packages/core/realtime-js/test/phoenix/socketAdapter.test.ts
+++ b/packages/core/realtime-js/test/phoenix/socketAdapter.test.ts
@@ -62,3 +62,14 @@ describe('connection state', () => {
     expect(socketAdapter.isDisconnecting()).toBe(true)
   })
 })
+
+describe('disconnect timer cleanup', () => {
+  test('does not leave the race timeout pending after a successful disconnect', async () => {
+    testSetup.connect()
+    await testSetup.socketConnected()
+
+    await socketAdapter.disconnect(() => {})
+
+    expect(vi.getTimerCount()).toBe(0)
+  })
+})


### PR DESCRIPTION
## 🔍 Description

### What changed?

`SocketAdapter.disconnect()` starts a race timeout and discards the returned id:

```ts
return new Promise((resolve) => {
  setTimeout(() => resolve('timeout'), timeout)   // id not kept
  this.socket.disconnect(() => { callback(); resolve('ok') }, code, reason)
})
```

The returned value was never wrong on a clean close `resolve('ok')` settles the promise first, and the later `resolve('timeout')` is a no-op. But settling a promise does not cancel a `setTimeout`. The timer stays scheduled for the full `timeout` window, which defaults to 10000ms.

This PR keeps the id and clears it in the disconnect callback. The timeout branch needs no cleanup  if it fires, it has already run.

### Why was this change needed?

In Node a pending timer keeps the event loop alive. A process that awaits `client.disconnect()` and has nothing else to do therefore stays alive until the timer expires, and every `disconnect()` call schedules another one.

The impact is on Node scripts, test suites, CI jobs and serverless handlers, where a process that should exit immediately instead lingers. Browsers are unaffected there is no process to exit and long-running servers hold only one short-lived timer per disconnect. No public API behavior changes.

## 📸 Screenshots/Examples

Added a regression test in `test/phoenix/socketAdapter.test.ts`. On master it fails:

```
FAIL  test/phoenix/socketAdapter.test.ts > disconnect timer cleanup >
      does not leave the race timeout pending after a successful disconnect

AssertionError: expected 1 to be +0 // Object.is equality
- Expected
+ Received
- 0
+ 1

  71|     await socketAdapter.disconnect(() => {})
  72|
  73|     expect(vi.getTimerCount()).toBe(0)
    |                                ^
```

Worth flagging for reviewers: a naive before/after `getTimerCount()` comparison does **not** catch this. A heartbeat timer is cleared in the same tick, so the count goes 1 → 1 and the leak is hidden. Asserting that no timers remain at all is what exposes it.

Reviewers who want to see the event-loop effect directly can run any script that connects to a local WebSocket server, awaits `client.disconnect()`, and logs from `process.on('exit')` on master the exit is delayed by the timeout window; with this change it is immediate.

## 🔄 Breaking changes

- [x] This PR contains no breaking changes

## 📋 Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/supabase/supabase-js/blob/master/CONTRIBUTING.md)
- [x] My PR title follows the [conventional commit format](https://www.conventionalcommits.org/): `<type>(<scope>): <description>`
- [x] I have run `pnpm nx format` to ensure consistent code formatting
- [x] I have added tests for new functionality (if applicable)
- [ ] I have updated documentation (if applicable)

## 📝 Additional notes

Full `realtime-js` suite passes locally: 476 passed, 1 skipped.

Co-authored with Claude; I reproduced the failing test and verified the fix locally.