### PR TITLE
fix(auth): silence commit-guard-discarded refresh in initial session

### DIFF
--- a/packages/core/auth-js/src/GoTrueClient.ts
+++ b/packages/core/auth-js/src/GoTrueClient.ts
@@ -4357,6 +4357,12 @@ export default class GoTrueClient {
       } catch (err) {
         await this.stateChangeEmitters.get(id)?.callback('INITIAL_SESSION', null)
         this._debug('INITIAL_SESSION', 'callback id', id, 'error', err)
+        if (isAuthRefreshDiscardedError(err)) {
+          // Same successful no-op _recoverAndRefresh treats as debug-only: the
+          // commit guard discarded a refresh because a concurrent signOut
+          // changed session state mid-flight.
+          return
+        }
         if (
           isAuthSessionMissingError(err) ||
           isAuthRetryableFetchError(err) ||

--- a/packages/core/auth-js/test/GoTrueClient.test.ts
+++ b/packages/core/auth-js/test/GoTrueClient.test.ts
@@ -7,7 +7,7 @@ import {
   REFRESH_FAILURE_COOLDOWN_MS,
   STORAGE_KEY,
 } from '../src/lib/constants'
-import { getItemAsync, setItemAsync } from '../src/lib/helpers'
+import { getItemAsync, removeItemAsync, setItemAsync } from '../src/lib/helpers'
 import { memoryLocalStorageAdapter } from '../src/lib/local-storage'
 import {
   deserializeCredentialCreationOptions,
@@ -4486,6 +4486,33 @@ describe('Refresh-token lifecycle (proactive/reactive, cooldown)', () => {
     return spy
   }
 
+  const stubDiscardedRefresh = (
+    client: GoTrueClient,
+    storage: ReturnType<typeof memoryLocalStorageAdapter>
+  ) => {
+    const spy = jest.fn(async () => {
+      // Simulate a concurrent signOut clearing storage while this refresh is in flight.
+      await removeItemAsync(storage, STORAGE_KEY)
+      return {
+        data: {
+          session: {
+            access_token: 'jwt.accesstoken.signature2',
+            refresh_token: 'refresh-token-r2',
+            token_type: 'bearer',
+            expires_in: 60,
+            expires_at: Math.floor(Date.now() / 1000) + 60,
+            user: { id: 'user-1', email: 'u@example.com' } as any,
+          },
+          user: { id: 'user-1', email: 'u@example.com' } as any,
+        },
+        error: null,
+      }
+    })
+    // @ts-expect-error access protected for test
+    client._refreshAccessToken = spy
+    return spy
+  }
+
   describe('storage preservation (Fix A)', () => {
     test('non-retryable refresh failure + access token still valid → storage preserved', async () => {
       const storage = memoryLocalStorageAdapter()
@@ -4905,6 +4932,37 @@ describe('Refresh-token lifecycle (proactive/reactive, cooldown)', () => {
 
       expect(errorSpy).not.toHaveBeenCalled()
       expect(warnSpy).toHaveBeenCalled()
+
+      errorSpy.mockRestore()
+      warnSpy.mockRestore()
+    })
+
+    test('_emitInitialSession does not log a commit-guard-discarded refresh', async () => {
+      // Concurrent signOut clears storage while a refresh is in flight; the
+      // commit guard discards the rotated tokens. This is a successful no-op,
+      // not an application error — it must not hit console.warn or console.error.
+      const storage = memoryLocalStorageAdapter()
+      await plantSession(storage, { secondsUntilExpiry: -60 })
+
+      const client = new GoTrueClient({
+        url: GOTRUE_URL_SIGNUP_ENABLED_AUTO_CONFIRM_ON,
+        storage,
+        autoRefreshToken: false,
+        persistSession: true,
+        skipAutoInitialize: true,
+      })
+      stubDiscardedRefresh(client, storage)
+
+      await client.initialize()
+
+      const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+
+      // @ts-expect-error access private for test
+      await client._emitInitialSession(Symbol('test-discarded-refresh-init'))
+
+      expect(errorSpy).not.toHaveBeenCalled()
+      expect(warnSpy).not.toHaveBeenCalled()
 
       errorSpy.mockRestore()
       warnSpy.mockRestore()


### PR DESCRIPTION
Fixes #2665.

`_emitInitialSession` classified a few expected refresh outcomes (missing session, retryable fetch failure, a few dead-refresh-token codes) as warnings, but missed `AuthRefreshDiscardedError`, so it fell through to `console.error` even when the commit guard was just correctly discarding a refresh due to a concurrent sign-out. This treats that case the same way `_recoverAndRefresh` already does: debug-only, no warn or error.

Adds a test that simulates a concurrent `signOut` clearing storage mid-refresh and asserts neither `console.warn` nor `console.error` fire.