### PR TITLE
fix(postgrest-js): escape double quotes and backslashes in in()/notIn() filter values

### DIFF
--- a/packages/core/postgrest-js/src/PostgrestFilterBuilder.ts
+++ b/packages/core/postgrest-js/src/PostgrestFilterBuilder.ts
@@ -33,7 +33,10 @@ export type IsStringOperator<Path extends string> = Path extends `${string}->>${
   ? true
   : false
 
-const PostgrestReservedCharsRegexp = new RegExp('[,()]')
+// Values containing any of these must be double-quoted in `in`/`notIn` lists, and any
+// embedded `"`/`\` escaped, per PostgREST's grammar:
+// https://docs.postgrest.org/en/stable/references/api/url_grammar.html
+const PostgrestReservedCharsRegexp = new RegExp('[,()"\\\\]')
 
 // Match relationship filters with `table.column` syntax and resolve underlying
 // column value. If not matched, fallback to generic type.
@@ -837,9 +840,11 @@ export default class PostgrestFilterBuilder<
   ): this {
     const cleanedValues = Array.from(new Set(values))
       .map((s) => {
-        // handle postgrest reserved characters
-        // https://postgrest.org/en/v7.0.0/api.html#reserved-characters
-        if (typeof s === 'string' && PostgrestReservedCharsRegexp.test(s)) return `"${s}"`
+        // Wrap values with PostgREST reserved characters in double quotes, and escape
+        // embedded double quotes and backslashes. Previously an embedded `"` was left
+        // unescaped, producing malformed output such as `in.("a,b"c")` for `a,b"c`.
+        if (typeof s === 'string' && PostgrestReservedCharsRegexp.test(s))
+          return `"${s.replace(/["\\]/g, '\\$&')}"`
         else return `${s}`
       })
       .join(',')
@@ -865,9 +870,11 @@ export default class PostgrestFilterBuilder<
   ): this {
     const cleanedValues = Array.from(new Set(values))
       .map((s) => {
-        // handle postgrest reserved characters
-        // https://postgrest.org/en/v7.0.0/api.html#reserved-characters
-        if (typeof s === 'string' && PostgrestReservedCharsRegexp.test(s)) return `"${s}"`
+        // Wrap values with PostgREST reserved characters in double quotes, and escape
+        // embedded double quotes and backslashes. Previously an embedded `"` was left
+        // unescaped, producing malformed output such as `in.("a,b"c")` for `a,b"c`.
+        if (typeof s === 'string' && PostgrestReservedCharsRegexp.test(s))
+          return `"${s.replace(/["\\]/g, '\\$&')}"`
         else return `${s}`
       })
       .join(',')

--- a/packages/core/postgrest-js/test/filters.test.ts
+++ b/packages/core/postgrest-js/test/filters.test.ts
@@ -890,3 +890,19 @@ test('regexIMatch', async () => {
     }
   `)
 })
+
+test('in()/notIn() escape reserved characters, double quotes, and backslashes', () => {
+  const inBuilder = postgrest
+    .from('users')
+    .select('username')
+    .in('username', ['a,b', 'a"b', 'a,b"c', 'back\\slash']) as any
+  expect(inBuilder.url.searchParams.get('username')).toBe(
+    'in.("a,b","a\\"b","a,b\\"c","back\\\\slash")'
+  )
+
+  const notInBuilder = postgrest
+    .from('users')
+    .select('username')
+    .notIn('username', ['a,b"c']) as any
+  expect(notInBuilder.url.searchParams.get('username')).toBe('not.in.("a,b\\"c")')
+})


### PR DESCRIPTION
## 🔍 Description

`.in()` and `.notIn()` wrap values containing PostgREST reserved characters (`,`, `(`, `)`) in double quotes, but never escape double quotes or backslashes **inside** the value. This produces malformed filters (and a value-injection vector into the query string) whenever a value contains a `"` or `\`.

### What changed?

Both `.in()` and `.notIn()` shared this logic:

```ts
const PostgrestReservedCharsRegexp = new RegExp('[,()]')
// ...
if (typeof s === 'string' && PostgrestReservedCharsRegexp.test(s)) return `"${s}"`
else return `${s}`
```

The fix:
- extends the reserved-chars regexp to also detect `"` and `\`, so values containing them get quoted;
- escapes embedded `"` and `\` inside the quoted string, per PostgREST's [URL grammar](https://docs.postgrest.org/en/stable/references/api/url_grammar.html) (`\"` for a quote, `\\` for a backslash).

```ts
const PostgrestReservedCharsRegexp = new RegExp('[,()"\\\\]')
// ...
if (typeof s === 'string' && PostgrestReservedCharsRegexp.test(s))
  return `"${s.replace(/["\\]/g, '\\$&')}"`
else return `${s}`
```

| Value | Before | After |
|---|---|---|
| `a,b` | `in.("a,b")` | `in.("a,b")` (unchanged) |
| `a"b` | `in.(a"b)` (not quoted) | `in.("a\"b")` |
| `a,b"c` | `in.("a,b"c")` (quote closes early) | `in.("a,b\"c")` |
| `back\slash` | `in.(back\slash)` (not quoted) | `in.("back\\slash")` |

Values without reserved characters are unchanged, so this is backward compatible.

### Why was this change needed?

`.in()` / `.notIn()` are among the filter builders expected to handle escaping for the caller (unlike `.filter()` / `.or()` / `.not()`, which document "sanitize yourself"), so a value should round-trip correctly regardless of its content. Today a value with a comma **and** a quote (e.g. `a,b"c`) serializes to `in.("a,b"c")` — the embedded `"` closes the quoted string early, yielding a malformed filter and letting value content leak into the surrounding query grammar. A value with a quote but no comma (`a"b`) isn't quoted at all.

## 📸 Screenshots/Examples

Added a test in `packages/core/postgrest-js/test/filters.test.ts` that asserts the generated query string for comma, double-quote, quote-and-comma, and backslash values, for both `.in()` and `.notIn()` (no server needed — it inspects the built URL).

## 🔄 Breaking changes

- [x] This PR contains no breaking changes

## 📋 Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/supabase/supabase-js/blob/master/CONTRIBUTING.md)
- [x] My PR title follows the [conventional commit format](https://www.conventionalcommits.org/): `<type>(<scope>): <description>`
- [x] I have run `pnpm nx format` to ensure consistent code formatting
- [x] I have added tests for new functionality (if applicable)
- [ ] I have updated documentation (if applicable)
