### PR TITLE
fix(realtime): settle discarded push instead of leaving its promise pending

### DIFF
--- a/packages/core/realtime-js/src/phoenix/channelAdapter.ts
+++ b/packages/core/realtime-js/src/phoenix/channelAdapter.ts
@@ -84,7 +84,7 @@ export default class ChannelAdapter {
 
     if (this.channel.pushBuffer.length > MAX_PUSH_BUFFER_SIZE) {
       const removedPush = this.channel.pushBuffer.shift()!
-      removedPush.cancelTimeout()
+      removedPush.trigger('timeout', {})
       this.socket.log(
         'channel',
         `discarded push due to buffer overflow: ${removedPush.event}`,

--- a/packages/core/realtime-js/test/phoenix/channelAdapter.test.ts
+++ b/packages/core/realtime-js/test/phoenix/channelAdapter.test.ts
@@ -123,3 +123,36 @@ describe('updateJoinPayload', () => {
     })
   })
 })
+
+describe('push buffer overflow', () => {
+  let overflowSetup: TestSetup
+
+  beforeEach(async () => {
+    overflowSetup = setupRealtimeTest({ timeout: defaultTimeout, useFakeTimers: true })
+    overflowSetup.connect()
+    await overflowSetup.socketConnected()
+  })
+
+  afterEach(() => {
+    overflowSetup.cleanup()
+  })
+
+  test('settles the promise of a push discarded by the buffer cap', async () => {
+    const overflowChannel = overflowSetup.client.channel('overflow-topic')
+    overflowChannel.subscribe()
+
+    let firstSettled = false
+    overflowChannel.track({ i: 0 }).then(() => {
+      firstSettled = true
+    })
+
+    for (let i = 1; i <= MAX_PUSH_BUFFER_SIZE; i++) {
+      overflowChannel.track({ i })
+    }
+
+    await vi.advanceTimersByTimeAsync(60000)
+    await Promise.resolve()
+
+    expect(firstSettled).toBe(true)
+  })
+})


### PR DESCRIPTION
## 🔍 Description

### What changed?

When the push buffer is full, `ChannelAdapter.push()` drops the oldest push and calls `removedPush.cancelTimeout()`. That method only clears the timer:

```js
cancelTimeout(){
  clearTimeout(this.timeoutTimer)
  this.timeoutTimer = null
}
```

It fires no receive hook, so nothing tells the caller the push is gone. `RealtimeChannel.send()` resolves only from `receive('ok' | 'error' | 'timeout')`, so the discarded push's promise never settles.

This calls `removedPush.trigger('timeout', {})` instead. That routes through the reply handler registered in `startTimeout()`, which calls `cancelRefEvent()`, `cancelTimeout()` and `matchReceive()` so it does everything the old line did, plus removing the leftover `chan_reply_<ref>` binding and settling the promise.

### Why was this change needed?

`broadcast` pushes escape this: `send()` early-resolves them when `ack` is off. `presence` pushes do not so `await channel.track(...)` and `await channel.untrack(...)` hang forever if that push is the one discarded.

That is reachable in normal use: `track()` called rapidly before the channel has joined (a cursor-position channel, for example) fills the 100-entry buffer, and the earliest calls are silently dropped. The caller gets no error and no timeout — just a promise that never settles.

## 📸 Screenshots/Examples

Added a regression test. It subscribes a channel, leaves it unjoined so pushes buffer, overflows the cap, then advances timers well past the push timeout so every surviving push times out normally. On master:

<img width="827" height="557" alt="pr2-screenshot1" src="https://github.com/user-attachments/assets/bb461a3e-f3de-4966-9154-35ccb8a92c54" />

```
AssertionError: expected false to be true // Object.is equality
```
<img width="812" height="435" alt="pr2-screenshot2" src="https://github.com/user-attachments/assets/c48176d3-b542-4b96-b7f5-ce18888a0d6c" />

The first push's promise is still pending; an in-buffer push under the same conditions settles as expected.

## 🔄 Breaking changes

- [x] This PR contains no breaking changes

## 📋 Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/supabase/supabase-js/blob/master/CONTRIBUTING.md)
- [x] My PR title follows the [conventional commit format](https://www.conventionalcommits.org/): `<type>(<scope>): <description>`
- [x] I have run `pnpm nx format` to ensure consistent code formatting
- [x] I have added tests for new functionality (if applicable)
- [ ] I have updated documentation (if applicable)

## 📝 Additional notes

Full `realtime-js` suite passes locally: 475 passed, 1 skipped.

### One open question

I used `trigger('timeout', {})` so the discarded push resolves as `'timed out'`. That reuses an existing status and adds no API surface, but the push wasn't slow it was dropped by the buffer cap so `'error'` may be the more honest signal. Happy to switch if you'd prefer; either way the promise settles instead of hanging.

### Unrelated, noting rather than changing

The cap check is `pushBuffer.length > MAX_PUSH_BUFFER_SIZE`, so the buffer reaches 101 before trimming. Left alone here to keep this PR to one concern.

Co-authored with Claude; I reproduced the failing test and verified the fix locally.