### PR TITLE
fix(storage): drop legacy prefix from lifecycles

### DIFF
--- a/packages/core/storage-js/src/lib/types.ts
+++ b/packages/core/storage-js/src/lib/types.ts
@@ -58,17 +58,13 @@ export type LifecycleRuleFilter = Record<string, never>
 /**
  * One lifecycle rule.
  *
- * Today the only action is `noncurrentVersionExpiration`. Include `filter: {}`
- * on each rule. `id` is optional. The server generates one if you omit it.
+ * Today the only action is `noncurrentVersionExpiration`. `filter` is required
+ * and must be `{}`. `id` is optional. The server generates one if you omit it.
  */
 export interface LifecycleRule {
   id?: string
   status: LifecycleRuleStatus
-  filter?: LifecycleRuleFilter
-  /**
-   * Empty-prefix selector from S3 Lifecycle V1. Prefer `filter: {}`.
-   */
-  legacyPrefix?: ''
+  filter: LifecycleRuleFilter
   noncurrentVersionExpiration: NoncurrentVersionExpiration
 }
 

--- a/packages/core/storage-js/src/packages/StorageBucketApi.ts
+++ b/packages/core/storage-js/src/packages/StorageBucketApi.ts
@@ -478,8 +478,8 @@ export default class StorageBucketApi extends BaseApiClient<StorageError> {
    * is overwritten. Send at least one rule. Call {@link deleteBucketLifecycle}
    * to remove the policy.
    *
-   * Each rule currently supports only `noncurrentVersionExpiration`. Set
-   * `filter` to `{}`. Prefix filters, tag filters, and current-object
+   * Each rule currently supports only `noncurrentVersionExpiration`. `filter`
+   * is required and must be `{}`. Prefix filters, tag filters, and current-object
    * expiration are rejected. Rule IDs must be unique. Omit `id` and the
    * server generates one.
    *

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -641,7 +641,6 @@ features:
       - LifecycleRule.id
       - LifecycleRule.status
       - LifecycleRule.filter
-      - LifecycleRule.legacyPrefix
       - LifecycleRule.noncurrentVersionExpiration
       - LifecycleRuleFilter
       - LifecycleRuleStatus


### PR DESCRIPTION
Related to https://github.com/supabase/storage/pull/1338

It was added for better s3 compatibility but since this is a new feature, decided not to introduce legacy prefix at all. Feature isn't released yet so it's safe to drop. 