### PR TITLE
docs(realtime): document relationship of `accessToken()` and heartbeat

### DIFF
--- a/packages/core/realtime-js/src/RealtimeClient.ts
+++ b/packages/core/realtime-js/src/RealtimeClient.ts
@@ -79,6 +79,15 @@ export type RealtimeClientOptions = {
   fetch?: Fetch
   worker?: boolean
   workerUrl?: string
+  /**
+   * Callback returning a fresh token for channel subscription authorization and Realtime RLS.
+   *
+   * Called on connect and on every heartbeat (`heartbeatIntervalMs`, default 25000ms).
+   * The token must stay valid past the next call, or the server closes the channel at
+   * expiry with no automatic resubscribe. So, plan for some call time and overhead,
+   * i.e. if hearbeats happen every 25 seconds and your token is still valid for 27
+   * seconds it's probably safer to refresh right now rather than risk a race condition.
+   */
   accessToken?: () => Promise<string | null>
   disconnectOnEmptyChannelsAfterMs?: number
   /**
@@ -499,6 +508,10 @@ export default class RealtimeClient {
    * When an `accessToken` callback IS configured, the callback is the source of truth:
    * the client remains in callback mode and continues to refresh from it on heartbeat,
    * even after a bootstrap/override `setAuth(token)` call.
+   *
+   * The callback is called on connect and on every heartbeat (`heartbeatIntervalMs`,
+   * default 25000ms). Its token must stay valid past the next call, or the server closes
+   * the channel at expiry with no automatic resubscribe.
    *
    * @param token A JWT string to override the token set on the client.
    *

--- a/packages/core/supabase-js/src/lib/types.ts
+++ b/packages/core/supabase-js/src/lib/types.ts
@@ -259,7 +259,11 @@ export type SupabaseClientOptions<SchemaName> = {
   }
   /**
    * Optional function for using a third-party authentication system with
-   * Supabase. The function should return an access token or ID token (JWT) by
+   * Supabase. Leave unset when using Supabase Auth — session tokens are
+   * refreshed automatically. Only needed when integrating a third-party
+   * provider (e.g. Clerk, Auth0, Firebase).
+   *
+   * The function should return an access token or ID token (JWT) by
    * obtaining it from the third-party auth SDK. Note that this
    * function may be called concurrently and many times. Use memoization and
    * locking techniques if this is not supported by the SDKs.
@@ -267,6 +271,13 @@ export type SupabaseClientOptions<SchemaName> = {
    * When set, the `auth` namespace of the Supabase client cannot be used.
    * Create another client if you wish to use Supabase Auth and third-party
    * authentications concurrently in the same application.
+   *
+   * For Realtime: also called on connect and on every heartbeat
+   * (`realtime.heartbeatIntervalMs`, default 25000ms). The token must stay valid
+   * past the next call, or Realtime closes the channel at expiry with no
+   * automatic resubscribe. So, plan for some call time and overhead,
+   * i.e. if hearbeats happen every 25 seconds and your token is still valid for 27
+   * seconds it's probably safer to refresh right now rather than risk a race condition.
    */
   accessToken?: () => Promise<string | null>
   /**


### PR DESCRIPTION
We had feedback, that the access token would become invalid before reaching another heartbeat to be able to refresh, when using a 3rd party auth provider.

This was resolved by longer token life time, but the interplay of `accessToken()` and when it's called wasn't described in the docs.

I'm not 100% sure if we want to document it in this detail, as it makes it harder for us to change later, but it also feels like this interaction should be documented so users can have better guidance on when to refresh their access tokens to not run into the same issue. I.e. in the sample we got the access token expired at ~148.6s passed and a new heartbeat would have only gone off at ~150s.

## 📋 Checklist

<!-- Ensure all items are checked before submitting -->

- [x] I have read the [Contributing Guidelines](https://github.com/supabase/supabase-js/blob/master/CONTRIBUTING.md)
- [x] My PR title follows the [conventional commit format](https://www.conventionalcommits.org/): `<type>(<scope>): <description>`
- [x] I have run `pnpm nx format` to ensure consistent code formatting
- [ ] I have added tests for new functionality (if applicable)
- [x] I have updated documentation (if applicable)

## 📝 Additional notes

Documentation is to the best of my (AI-assisted) understanding of how that part of the code works.
