### PR TITLE
fix(realtime): clear httpSend timeout after fetch rejection

### DIFF
--- a/packages/core/realtime-js/src/RealtimeChannel.ts
+++ b/packages/core/realtime-js/src/RealtimeChannel.ts
@@ -1172,14 +1172,14 @@ export default class RealtimeChannel {
     const controller = new AbortController()
     const id = setTimeout(() => controller.abort(), timeout)
 
-    const response = await this.socket.fetch(url, {
-      ...options,
-      signal: controller.signal,
-    })
-
-    clearTimeout(id)
-
-    return response
+    try {
+      return await this.socket.fetch(url, {
+        ...options,
+        signal: controller.signal,
+      })
+    } finally {
+      clearTimeout(id)
+    }
   }
 
   /** @internal */

--- a/packages/core/realtime-js/test/RealtimeChannel.messaging.test.ts
+++ b/packages/core/realtime-js/test/RealtimeChannel.messaging.test.ts
@@ -628,6 +628,24 @@ describe('httpSend', () => {
         await expect(channel.httpSend('test', { data: 'test' })).rejects.toThrow('Request timeout')
       })
 
+      test('clears the timeout when fetch rejects', async () => {
+        vi.useFakeTimers()
+        try {
+          const fetchStub = vi.fn().mockRejectedValue(new Error('Network error'))
+          const testSetup = createSocket(hasToken, fetchStub)
+
+          if (hasToken) {
+            await testSetup.client.setAuth()
+          }
+          const channel = testSetup.client.channel('topic')
+
+          await expect(channel.httpSend('test', { data: 'test' })).rejects.toThrow('Network error')
+          expect(vi.getTimerCount()).toBe(0)
+        } finally {
+          vi.useRealTimers()
+        }
+      })
+
       test('handles non-202 status', async () => {
         const mockResponse = createMockResponse(500, 'Internal Server Error', {
           error: 'Server error',


### PR DESCRIPTION
## 🔍 Description

### What changed?

Realtime's fetch timeout is now cleared in a `finally` block, so cleanup runs whether the fetch resolves or rejects. Regression coverage verifies the timer count for `httpSend()` with and without an access token.

### Why was this change necessary?

When the underlying fetch rejected (for example, due to a network failure), `_fetchWithTimeout()` exited before reaching `clearTimeout()`. The live timer retained its `AbortController` until the full request timeout and could keep a short-lived Node.js process open after the request had already failed.

Closes #2681.

## 🎥 Screenshots / Recordings

Not applicable; this is internal timeout cleanup with no UI change.

## 🧪 Testing Instructions

1. Run `corepack pnpm nx test realtime-js --skip-nx-cache`.
2. The new test makes the custom fetch reject immediately under fake timers.
3. Verify the original network error is propagated and no request timer remains scheduled.

Validation performed:

- Focused messaging suite: 48 passed
- Full `realtime-js` test target: 477 passed, 1 skipped
- `corepack pnpm nx build realtime-js --skip-nx-cache`: passed
- Targeted Prettier check: passed
- `git diff --check`: passed

The package-wide lint target currently reports 547 existing errors across the package. The changed lines were checked separately; the new code introduces no additional lint diagnostic.

## 🚨 Breaking Changes

- [x] No breaking changes
- [ ] Contains breaking changes (please describe below)

## ✅ Checklist

- [x] I have read the [Contributing Guide](https://github.com/supabase/supabase-js/blob/master/CONTRIBUTING.md)
- [x] My PR title follows the conventional commit format
- [x] I have run formatting checks
- [x] I have added tests that prove the fix
- [x] No documentation change is required for this internal cleanup

## 📝 Additional Notes

The fetch result and error semantics are unchanged; only timer cleanup moves to an unconditional path.
